### PR TITLE
Adding text with ES Hadoop Breaking Changes link

### DIFF
--- a/docs/upgrading-stack.asciidoc
+++ b/docs/upgrading-stack.asciidoc
@@ -120,7 +120,7 @@ that you are upgrading.
 |{beatsref}/breaking-changes.html[Breaking Changes from 1.x]
 |{beatsref}/upgrading.html[Upgrading to Beats 5.0]
 |Elasticsearch Hadoop
-|{hadoopref}/breaking-changes.html
+|{hadoopref}/breaking-changes.html[Breaking Changes from 2.x]
 |{hadoopref}/install.html[Upgrading to Elasticsearch Hadoop 5.0]
 |===
 


### PR DESCRIPTION
Sets text for link to "Breaking Changes from 2.x"

I didn't notice this in until I saw it online.

/cc @dedemorton 
