### PR TITLE
Fix link to Elastic Cloud v5 upgrade topic

### DIFF
--- a/docs/upgrading-stack.asciidoc
+++ b/docs/upgrading-stack.asciidoc
@@ -132,5 +132,5 @@ To avoid downtime on production clusters due to major version upgrades:
 
 . Delete the old cluster to stop incurring additional costs. You are billed extra only for the time that the additional cluster was running. Billing for usage is by the hour.
 
-To learn more about upgrade process on Elastic Cloud, see {cloudref}/_upgrading_to_elasticsearch_5_0.html[
+To learn more about upgrade process on Elastic Cloud, see {cloudref}/_upgrade_to_elasticsearch_5_0.html[
 Upgrading to Elasticsearch {branch}] and {cloudref}/changing-a-cluster.html#changing-a-cluster[Changing a Cluster]. Note that Elastic Cloud does not currently support running snapshot builds (e.g., master builds as this documentation pertains too).


### PR DESCRIPTION
I changed the topic title, which broke this link. This PR should fix the link.