### PR TITLE
Tweak link to _upgrade_to_elasticsearch_5_x.html

### DIFF
--- a/docs/upgrading-stack.asciidoc
+++ b/docs/upgrading-stack.asciidoc
@@ -132,5 +132,5 @@ To avoid downtime on production clusters due to major version upgrades:
 
 . Delete the old cluster to stop incurring additional costs. You are billed extra only for the time that the additional cluster was running. Billing for usage is by the hour.
 
-To learn more about upgrade process on Elastic Cloud, see {cloudref}/_upgrade_to_elasticsearch_5_0.html[
+To learn more about upgrade process on Elastic Cloud, see {cloudref}/_upgrade_to_elasticsearch_5_x.html[
 Upgrading to Elasticsearch {branch}] and {cloudref}/changing-a-cluster.html#changing-a-cluster[Changing a Cluster]. Note that Elastic Cloud does not currently support running snapshot builds (e.g., master builds as this documentation pertains too).


### PR DESCRIPTION
Target is _upgrade_to_elasticsearch_5_x.html, not _upgrade_to_elasticsearch_5_0.html.

(Fix first, ask for forgiveness later.)