### PR TITLE
[DOCS] Fix callout in Intended Audience

### DIFF
--- a/docs/upgrading-stack.asciidoc
+++ b/docs/upgrading-stack.asciidoc
@@ -29,11 +29,12 @@ each component:
 |2.0 or later
 |Elasticsearch Hadoop
 |2.2 or later
-|Marvel, Shield, Watcher, Graph, Reporting <1>
+|Marvel, Shield, Watcher, Graph, Reporting footnote:[Marvel, Shield, Watcher,
+Graph, and Reporting have all been combined into a new, unified plugin called
+X-Pack. Unlike before, the same X-Pack distribution works for both Elasticsearch
+and Kibana.]
 |2.0 or later
 |===
-1. Marvel, Shield, Watcher, Graph, and Reporting have all been combined into a new, unified plugin called
-X-Pack. Unlike before, the same X-Pack distribution works for both Elasticsearch and Kibana.
 
 NOTE: Kibana 4.2 and Elasticsearch Hadoop 2.2 were the first versions that were compatible with
 Elasticsearch 2.x!


### PR DESCRIPTION
This PR fixes a formatting error in https://www.elastic.co/guide/en/elastic-stack/current/upgrading-elastic-stack.html

In particular, the "Intended Audience" table contains the following:
````
Marvel, Shield, Watcher, Graph, Reporting <1>
````

Per http://www.methods.co.nz/asciidoc/userguide.html#X105, "Callout lists cannot be used within tables", so I've changed it to a footnote in the table.