### PR TITLE
Updates Tip to encourage use of Upgrade Assistant

### DIFF
--- a/docs/upgrading-stack.asciidoc
+++ b/docs/upgrading-stack.asciidoc
@@ -212,8 +212,7 @@ POST /_xpack/migration/upgrade/.security
 You can use your regular administration credentials to upgrade the other
 internal indices using the `_xpack/migration/upgrade` API.
 
-TIP: Once you upgrade the `.kibana` index, you can run Kibana and use the
-X-Pack Reindex Helper UI to upgrade the other indices.
+TIP: Kibana provides an Upgrade Assistant UI to aide in the upgrade process.
 
 [[upgrade-elastic-stack-for-elastic-cloud]]
 === Upgrading on Elastic Cloud


### PR DESCRIPTION
The tip was inaccurate, as the Reindex Helper UI can actually upgrade the `.kibana` index and does not need to take place prior to its use.