### PR TITLE
Update stack upgrade docs re upgrade assistant

### DIFF
--- a/docs/upgrading-stack.asciidoc
+++ b/docs/upgrading-stack.asciidoc
@@ -42,8 +42,10 @@ IMPORTANT: If you're upgrading from 2.x, make sure you
 check the breaking changes from 2.x to 5.x, as well as from 5.x to 6.x!
 --
 
-. {ref}/docs-reindex.html[Reindex] or delete all 2.x indices. We recommend
-upgrading to 5.6 and using the {xpack} Reindex Helper to reindex 2.x indices.
+. We recommend upgrading to 5.6 and using the
+{xpack-ref}/xpack-upgrade-assistant.html[Upgrade Assistant]'s Reindex Helper to
+reindex 2.x indices. Alternatively, you can manually {ref}/docs-reindex.html[reindex]
+or delete all 2.x indices.
 
 . If Kibana and {xpack} are part of your stack, upgrade the internal Kibana
 and {xpack} indices. We recommend using the {xpack} 5.6 Reindex Helper to
@@ -54,7 +56,7 @@ internal indices after you install Elasticsearch {version}.
 
 . If you use {xpack} to secure your cluster:
 .. Make sure TLS is enabled to encrypt communications between nodes. TLS must
-be enabled to upgrade to {version}. For more information, see 
+be enabled to upgrade to {version}. For more information, see
 {xpack-ref}/encrypting-communications.html[Encrypting Communications].
 +
 NOTE: Enabling TLS requires a full cluster restart. Nodes that have TLS
@@ -183,8 +185,18 @@ these indices must be upgraded to the new format. If you are upgrading from a
 version prior to 5.6, you must upgrade them after after installing
 Elasticsearch {version}.
 
-To get a list of the indices that need to be upgraded, install {xpack} and use
-the {ref}/migration-api-assistance.html[`_xpack/migration/assistance` API]:
+Starting in 5.6, X-Pack Kibana provides an
+{xpack-ref}/xpack-upgrade-assistant.html[Upgrade Assistant UI] to aid in the
+upgrade process. Use this utility to upgrade the internal Kibana and X-Pack
+indices.
+
+If you would prefer to perform the upgrade of internal indices manually,
+keep reading.
+
+===== Manually upgrading X-Pack indices for {major-version}
+
+To get a list of the X-Pack indices that need to be upgraded, install {xpack}
+and use the {ref}/migration-api-assistance.html[`_xpack/migration/assistance` API]:
 
 [source,json]
 ----------------------------------------------------------
@@ -212,8 +224,9 @@ POST /_xpack/migration/upgrade/.security
 You can use your regular administration credentials to upgrade the other
 internal indices using the `_xpack/migration/upgrade` API.
 
-TIP: Once you upgrade the `.kibana` index, you can run Kibana and use the
-X-Pack Reindex Helper UI to upgrade the other indices.
+===== Manually upgrading Kibana indices for {major-version}
+
+To upgrade your Kibana indices, follow {kibana-ref}/migrating-6.0-index.html[this guide].
 
 [[upgrade-elastic-stack-for-elastic-cloud]]
 === Upgrading on Elastic Cloud
@@ -246,3 +259,4 @@ Upgrade Versions] and {cloudref}/cluster-config.html[Configuring Elastic Cloud].
 
 NOTE: Elastic Cloud only supports upgrades to released versions. Preview
 releases and master snapshots are not supported.
+


### PR DESCRIPTION
Targetting 6.0
This will be forward ported to everything 6.0+. Actually does this need to appear in the 5.6 docs?

The changes here reflect my thoughts on some aspects of the docs that are still misleading.