### PR TITLE
Encourage upgrading to 5.6 prior to migrating internal indices

### DIFF
--- a/docs/upgrading-stack.asciidoc
+++ b/docs/upgrading-stack.asciidoc
@@ -180,8 +180,8 @@ index as alias for the new index and delete the 2.x index.
 The format used for the internal indices used by Kibana and {xpack} has
 changed in {major-version}. Before you can run Kibana and {xpack} in {version},
 these indices must be upgraded to the new format. If you are upgrading from a
-version prior to 5.6, you must upgrade them after after installing
-Elasticsearch {version}.
+version prior to 5.6, you will want to upgrade them after after installing
+Elastic 5.6.
 
 To get a list of the indices that need to be upgraded, install {xpack} and use
 the {ref}/migration-api-assistance.html[`_xpack/migration/assistance` API]:


### PR DESCRIPTION
Per the discussion on https://github.com/elastic/x-pack-kibana/issues/2496, the docs are coming across on https://www.elastic.co/guide/en/elastic-stack/6.0/upgrading-elastic-stack.html#upgrade-internal-indices as the following:

> If you are upgrading from a version prior to 5.6, you must upgrade them after after installing Elasticsearch 6.0.0-beta2.

This is incorrect, in that you should not upgrade to Elasticsearch 6.0 prior to migrating the internal indices.