### PR TITLE
[DOCS] Added datafeed tip to upgrade docs

### DIFF
--- a/docs/upgrading-stack.asciidoc
+++ b/docs/upgrading-stack.asciidoc
@@ -12,7 +12,7 @@ are using. Want a list that's tailored to your stack? Try out our
 {upgrade_guide}[Interactive Upgrade Guide].
 ****
 
-We recommend upgrading to 5.6 before upgrading to {version}. {xpack} 5.6
+We recommend upgrading to the most recent 5.6 before upgrading to {version}. {xpack} 5.6
 provides a free Upgrade Assistant that identifies issues you need to address
 before upgrading and simplifies migrating indices that need to be reindexed
 before you upgrade. The Upgrade Assistant is enabled with both Trial and
@@ -51,12 +51,20 @@ and make the necessary changes so your code is compatible with {version}:
 ** {logstash-ref}/breaking-changes.html[Logstash {version} breaking changes]
 ** {xpack-ref}/xpack-breaking-changes.html[{xpack} {version} breaking changes]
 
-IMPORTANT: If you're upgrading from 2.x, make sure you
-check the breaking changes from 2.x to 5.x, as well as from 5.x to 6.x!
+[IMPORTANT]
+===============================
+
+* If you're upgrading from 2.x, make sure you check the breaking changes from
+2.x to 5.x, as well as from 5.x to 6.x!
+* If you are using {ml} {dfeeds} that contain discontinued search or query
+domain specific language (DSL), the upgrade will fail. In 5.6.5 and later, the
+Upgrade Assistant provides information about which {dfeeds} need to be updated.
+
+===============================
 --
 
 . {ref}/docs-reindex.html[Reindex] or delete all 2.x indices. We recommend
-upgrading to 5.6 and using the {xpack} Reindex Helper to reindex 2.x indices.
+upgrading to the most recent 5.6 and using the {xpack} Reindex Helper to reindex 2.x indices.
 
 . If Kibana and {xpack} are part of your stack, upgrade the internal Kibana
 and {xpack} indices. We recommend using the {xpack} 5.6 Reindex Helper to
@@ -119,7 +127,7 @@ trial license and the free https://register.elastic.co/[Basic license].
 
 To upgrade to {version} from 5.6:
 
-. {ref}/setup-upgrade.html[Upgrade Elasticsearch] to 5.6 and
+. {ref}/setup-upgrade.html[Upgrade Elasticsearch] to the most recent 5.6 and
 install {xpack} on all nodes in your cluster. If you are upgrading from an
 earlier 5.x release, you can perform a rolling upgrade. To upgrade from older
 versions you must perform a full cluster restart.
@@ -141,7 +149,7 @@ in `elasticsearch.yml`:
 xpack.security.enabled: false
 ----------------------------------------------------------
 
-. Upgrade Kibana to 5.6 and install {xpack}.
+. Upgrade Kibana to the most recent 5.6 and install {xpack}.
 
 . If you disabled {xpack} security in `elasticsearch.yml`, also disable
 Security in `kibana.yml`:


### PR DESCRIPTION
This PR is related to https://github.com/elastic/support-support-help/issues/313#issuecomment-345756967. It adds a warning about the impact of discontinued queries on the machine learning datafeeds. 

It also adds some text to clarify that users should install the latest version of 5.6, not just any old 5.6, since some items like this weren't added to the upgrade assistant until recently. 