### PR TITLE
[DOCS] Removed links to X-Pack installation

### DIFF
--- a/docs/installing-stack.asciidoc
+++ b/docs/installing-stack.asciidoc
@@ -4,7 +4,7 @@
 When installing the Elastic Stack, you must use the same version
 across the entire stack. For example, if you are using Elasticsearch
 {version}, you install Beats {version}, Elasticsearch Hadoop {version},
-Kibana {version}, Logstash {version}, and {xpack} {version}.
+Kibana {version}, and Logstash {version}.
 
 If you're upgrading an existing installation, see <<upgrading-elastic-stack, Upgrading the Elastic Stack>> for information about how to ensure compatibility with {version}.
 
@@ -14,11 +14,8 @@ If you're upgrading an existing installation, see <<upgrading-elastic-stack, Upg
 Install the Elastic Stack products you want to use in the following order:
 
 . Elasticsearch ({ref}/install-elasticsearch.html[install instructions])
-. {xpack} for Elasticsearch ({ref}/installing-xpack-es.html[install instructions])
 . Kibana ({kibana-ref}/install.html[install])
-. {xpack} for Kibana ({kibana-ref}/installing-xpack-kb.html[install instructions])
 . Logstash ({logstash-ref}/installing-logstash.html[install])
-. {xpack} for Logstash ({logstash-ref}/installing-xpack-log.html[install instructions])
 . Beats ({beats-ref}/installing-beats.html[install instructions])
 . Elasticsearch Hadoop ({hadoop-ref}/install.html[install instructions])
 


### PR DESCRIPTION
This PR removes text related to "installing X-Pack", since this is no longer required. 