### PR TITLE
[DOCS] Fixes edit links

### DIFF
--- a/x-pack/docs/en/index.asciidoc
+++ b/x-pack/docs/en/index.asciidoc
@@ -27,14 +27,19 @@ include::xpack-apis.asciidoc[]
 
 include::xpack-features.asciidoc[]
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/index.asciidoc
 include::{xes-repo-dir}/security/index.asciidoc[]
 
+:edit_url:
 include::monitoring/index.asciidoc[]
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/index.asciidoc
 include::{xes-repo-dir}/watcher/index.asciidoc[]
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/ml/index.asciidoc
 include::{xes-repo-dir}/ml/index.asciidoc[]
 
+:edit_url:
 include::xpack-troubleshooting.asciidoc[]
 
 include::xpack-limitations.asciidoc[]

--- a/x-pack/docs/en/xpack-limitations.asciidoc
+++ b/x-pack/docs/en/xpack-limitations.asciidoc
@@ -20,8 +20,11 @@ https://www.elastic.co/blog/elastic-stack-6-0-0-alpha1-released[Elastic Stack 6.
 * <<ml-limitations, X-Pack machine learning>>
 
 --
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/limitations.asciidoc
 include::{xes-repo-dir}/security/limitations.asciidoc[]
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/limitations.asciidoc
 include::{xes-repo-dir}/watcher/limitations.asciidoc[]
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/ml/limitations.asciidoc
 include::{xes-repo-dir}/ml/limitations.asciidoc[]

--- a/x-pack/docs/en/xpack-troubleshooting.asciidoc
+++ b/x-pack/docs/en/xpack-troubleshooting.asciidoc
@@ -39,10 +39,13 @@ build information and indicates which {xpack} features are enabled:
 GET /_xpack
 --------------------------------------------------
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/
 include::{xes-repo-dir}/security/troubleshooting.asciidoc[]
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/
 include::{xes-repo-dir}/watcher/troubleshooting.asciidoc[]
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/monitoring/
 include::{xkb-repo-dir}/monitoring/monitoring-troubleshooting.asciidoc[]
 
 include::{xes-repo-dir}/ml/troubleshooting.asciidoc[]


### PR DESCRIPTION
This PR fixes the "edit" links, which were failing to locate the files in the elasticsearch and kibana repos. 