### PR TITLE
[DOCS] Fixes broken links to Cloud docs

### DIFF
--- a/docs/installing-stack.asciidoc
+++ b/docs/installing-stack.asciidoc
@@ -72,4 +72,4 @@ Elastic Cloud is the official hosted Elasticsearch and Kibana offering from Elas
 
 Some Elastic Cloud features can be used only with a specific  link:https://www.elastic.co/cloud/as-a-service/subscriptions[subscription level]. For example, you can install custom plugins, dictionaries, and scripts only if you are a Gold or Platinum customer.
 
-To learn more about Elastic Cloud, see our {cloudref}/getting-started.html[getting started documentation]. Or link:https://www.elastic.co/cloud/as-a-service/signup[sign up for a free trial] and start exploring hosted Elasticsearch within minutes.
+To learn more about Elastic Cloud, see our {cloudref}/ec-getting-started.html[getting started documentation]. Or link:https://www.elastic.co/cloud/as-a-service/signup[sign up for a free trial] and start exploring hosted Elasticsearch within minutes.

--- a/docs/upgrading-stack.asciidoc
+++ b/docs/upgrading-stack.asciidoc
@@ -139,5 +139,5 @@ To avoid downtime on production clusters due to major version upgrades:
 
 . Delete the old cluster to stop incurring additional costs. You are billed extra only for the time that the additional cluster was running. Billing for usage is by the hour.
 
-To learn more about the upgrade process on Elastic Cloud, see {cloudref}/upgrading.html[
-Upgrade Versions] and {cloudref}/cluster-config.html[Configuring Elastic Cloud].
+To learn more about the upgrade process on Elastic Cloud, see {cloudref}/ec-upgrading.html[
+Upgrade Versions] and {cloudref}/ec-deployment-config.html[Configuring Elastic Cloud].


### PR DESCRIPTION
This PR fixes the following broken links in the documentation build:

17:07:17 Bad cross-document links:
17:07:17   html/en/elastic-stack/5.6/installing-elastic-stack.html:
17:07:17    - en/cloud/current/getting-started.html
17:07:17   html/en/elastic-stack/5.6/upgrading-elastic-stack.html:
17:07:17    - en/cloud/current/cluster-config.html
17:07:17    - en/cloud/current/upgrading.html