### PR TITLE
[DOCS] Creates field and document level security overview

### DIFF
--- a/docs/en/stack/security/authorization/document-level-security.asciidoc
+++ b/docs/en/stack/security/authorization/document-level-security.asciidoc
@@ -1,0 +1,60 @@
+[role="xpack"]
+[[document-level-security]]
+=== Document level security
+
+Document level security restricts the documents that users have read access to.
+In particular, it restricts which documents can be accessed from document-based 
+read APIs. 
+
+To enable document level security, you use a query to specify the documents that 
+each role can access. The document query is associated with a particular index 
+or index pattern and operates in conjunction with the privileges specified for 
+the indices.
+
+The following role definition grants read access only to documents that
+belong to the `click` category within all the `events-*` indices:
+
+[source,js]
+--------------------------------------------------
+POST /_xpack/security/role/click_role
+{
+  "indices": [
+    {
+      "names": [ "events-*" ],
+      "privileges": [ "read" ],
+      "query": "{\"match\": {\"category\": \"click\"}}"
+    }
+  ]
+}
+--------------------------------------------------
+// CONSOLE
+
+NOTE: Omitting the `query` entry entirely disables document level security for
+      the respective indices permission entry.
+
+The specified `query` expects the same format as if it was defined in the
+search request and supports the full {es} {ref}/query-dsl.html[Query DSL].
+
+For example, the following role grants read access only to the documents whose
+`department_id` equals `12`:
+
+[source,js]
+--------------------------------------------------
+POST /_xpack/security/role/dept_role
+{
+  "indices" : [
+    {
+      "names" : [ "*" ],
+      "privileges" : [ "read" ],
+      "query" : {
+        "term" : { "department_id" : 12 }
+      }
+    }
+  ]
+}
+--------------------------------------------------
+// CONSOLE
+
+NOTE: `query` also accepts queries written as string values.
+
+For more information, see <<field-and-document-access-control>>.

--- a/docs/en/stack/security/authorization/field-level-security.asciidoc
+++ b/docs/en/stack/security/authorization/field-level-security.asciidoc
@@ -1,0 +1,227 @@
+[role="xpack"]
+[[field-level-security]]
+=== Field level security
+
+Field level security restricts the fields that users have read access to.
+In particular, it restricts which fields can be accessed from document-based 
+read APIs. 
+
+To enable field level security, specify the fields that each role can access
+as part of the indices permissions in a role definition. Field level security is
+thus bound to a well-defined set of indices (and potentially a set of
+<<document-level-security, documents>>).
+
+The following role definition grants read access only to the `category`,
+`@timestamp`, and `message` fields in all the `events-*` indices.
+
+[source,js]
+--------------------------------------------------
+POST /_xpack/security/role/test_role1
+{
+  "indices": [
+    {
+      "names": [ "events-*" ],
+      "privileges": [ "read" ],
+      "field_security" : {
+        "grant" : [ "category", "@timestamp", "message" ]
+      }
+    }
+  ]
+}
+--------------------------------------------------
+// CONSOLE
+
+Access to the following meta fields is always allowed: `_id`,
+`_type`, `_parent`, `_routing`, `_timestamp`, `_ttl`, `_size` and `_index`. If
+you specify an empty list of fields, only these meta fields are accessible.
+
+NOTE: Omitting the fields entry entirely disables field level security.
+
+You can also specify field expressions. For example, the following
+example grants read access to all fields that start with an `event_` prefix:
+
+[source,js]
+--------------------------------------------------
+POST /_xpack/security/role/test_role2
+{
+  "indices" : [
+    {
+      "names" : [ "*" ],
+      "privileges" : [ "read" ],
+      "field_security" : {
+        "grant" : [ "event_*" ]
+      }
+    }
+  ]
+}
+--------------------------------------------------
+// CONSOLE
+
+Use the dot notations to refer to nested fields in more complex documents. For
+example, assuming the following document:
+
+[source,js]
+--------------------------------------------------
+{
+  "customer": {
+    "handle": "Jim",
+    "email": "jim@mycompany.com",
+    "phone": "555-555-5555"
+  }
+}
+--------------------------------------------------
+// NOTCONSOLE
+
+The following role definition enables only read access to the customer `handle`
+field:
+
+[source,js]
+--------------------------------------------------
+POST /_xpack/security/role/test_role3
+{
+  "indices" : [
+    {
+      "names" : [ "*" ],
+      "privileges" : [ "read" ],
+      "field_security" : {
+        "grant" : [ "customer.handle" ]
+      }
+    }
+  ]
+}
+--------------------------------------------------
+// CONSOLE
+
+This is where wildcard support shines. For example, use `customer.*` to enable
+only read access to the `customer` data:
+
+[source,js]
+--------------------------------------------------
+POST /_xpack/security/role/test_role4
+{
+  "indices" : [
+    {
+      "names" : [ "*" ],
+      "privileges" : [ "read" ],
+      "field_security" : {
+        "grant" : [ "customer.*" ]
+      }
+    }
+  ]
+}
+--------------------------------------------------
+// CONSOLE 
+
+You can deny permission to access fields with the following syntax:
+
+[source,js]
+--------------------------------------------------
+POST /_xpack/security/role/test_role5
+{
+  "indices" : [
+    {
+      "names" : [ "*" ],
+      "privileges" : [ "read" ],
+      "field_security" : {
+        "grant" : [ "*"],
+        "except": [ "customer.handle" ]
+      }
+    }
+  ]
+}
+--------------------------------------------------
+// CONSOLE
+
+The following rules apply:
+
+* The absence of `field_security` in a role is equivalent to * access.
+* If permission has been granted explicitly to some fields, you can specify
+denied fields. The denied fields must be a subset of the fields to which
+permissions were granted.
+* Defining denied and granted fields implies access to all granted fields except
+those which match the pattern in the denied fields.
+
+For example:
+
+[source,js]
+--------------------------------------------------
+POST /_xpack/security/role/test_role6
+{
+  "indices" : [
+    {
+      "names" : [ "*" ],
+      "privileges" : [ "read" ],
+      "field_security" : {
+        "except": [ "customer.handle" ],
+        "grant" : [ "customer.*" ]
+      }
+    }
+  ]
+}
+--------------------------------------------------
+// CONSOLE
+
+In the above example, users can read all fields with the prefix "customer."
+except for "customer.handle".
+
+An empty array for `grant` (for example, `"grant" : []`) means that access has
+not been granted to any fields.
+
+When a user has several roles that specify field level permissions, the
+resulting field level permissions per index are the union of the individual role
+permissions. For example, if these two roles are merged:
+
+[source,js]
+--------------------------------------------------
+POST /_xpack/security/role/test_role7
+{
+  "indices" : [
+    {
+      "names" : [ "*" ],
+      "privileges" : [ "read" ],
+      "field_security" : {
+        "grant": [ "a.*" ],
+        "except" : [ "a.b*" ]
+      }
+    }
+  ]
+}
+
+POST /_xpack/security/role/test_role8
+{
+  "indices" : [
+    {
+      "names" : [ "*" ],
+      "privileges" : [ "read" ],
+      "field_security" : {
+        "grant": [ "a.b*" ],
+        "except" : [ "a.b.c*" ]
+      }
+    }
+  ]
+}
+--------------------------------------------------
+// CONSOLE
+
+The resulting permission is equal to:
+
+[source,js]
+--------------------------------------------------
+{
+  // role 1 + role 2
+  ...
+  "indices" : [
+    {
+      "names" : [ "*" ],
+      "privileges" : [ "read" ],
+      "field_security" : {
+        "grant": [ "a.*" ],
+        "except" : [ "a.b.c*" ]
+      }
+    }
+  ]
+}
+--------------------------------------------------
+// NOTCONSOLE
+
+For more information, see <<field-and-document-access-control>>.

--- a/docs/en/stack/security/authorization/index.asciidoc
+++ b/docs/en/stack/security/authorization/index.asciidoc
@@ -11,6 +11,12 @@ include::{xes-repo-dir}/security/authorization/managing-roles.asciidoc[]
 :edit_url: https://github.com/elastic/stack-docs/edit/{branch}/docs/en/stack/security/authorization/privileges.asciidoc
 include::privileges.asciidoc[]
 
+:edit_url: https://github.com/elastic/stack-docs/edit/{branch}/docs/en/stack/security/authorization/document-level-security.asciidoc
+include::document-level-security.asciidoc[]
+
+:edit_url: https://github.com/elastic/stack-docs/edit/{branch}/docs/en/stack/security/authorization/field-level-security.asciidoc
+include::field-level-security.asciidoc[]
+
 :edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/authorization/alias-privileges.asciidoc
 include::{xes-repo-dir}/security/authorization/alias-privileges.asciidoc[]
 


### PR DESCRIPTION
This PR splits off separate overview pages for field-level security and document-level security and moves them higher in the table of contents. 

It also adds code snippet testing for the examples. 

This content had previously been rather buried in this long page:
https://www.elastic.co/guide/en/elastic-stack-overview/master/field-and-document-access-control.html#field-level-security

https://www.elastic.co/guide/en/elastic-stack-overview/master/field-and-document-access-control.html#document-level-security