### PR TITLE
Fix broken link

### DIFF
--- a/docs/installing-stack.asciidoc
+++ b/docs/installing-stack.asciidoc
@@ -16,7 +16,7 @@ Install the Elastic Stack products you want to use in the following order:
 . Elasticsearch ({ref}/install-elasticsearch.html[install instructions])
 . Kibana ({kibana-ref}/install.html[install])
 . Logstash ({logstash-ref}/installing-logstash.html[install])
-. Beats ({beats-ref}/installing-beats.html[install instructions])
+. Beats ({beats-ref}/getting-started.html[install instructions])
 . Elasticsearch Hadoop ({hadoop-ref}/install.html[install instructions])
 
 Installing in this order ensures that the components each product depends


### PR DESCRIPTION
The content from installing-beats.html is now available in getting-started.html (it's basically just a set of links to the GS guides for all the Beats.