### PR TITLE
[DOCS] Clarified license management

### DIFF
--- a/docs/en/stack/license.asciidoc
+++ b/docs/en/stack/license.asciidoc
@@ -3,33 +3,23 @@
 
 [partintro]
 --
-If a license is not already registered for the cluster, when you install a 
-product that contains {xpack} and you start the cluster, it generates a basic license.
+When you install the default distribution of the {stack}, you receive a basic 
+license. For the full list of free features that are included in the basic 
+license, see: https://www.elastic.co/subscriptions
 
-If you want to try all of the {xpack} features, you can start a 30-day
-trial. At the end of the trial period, you can
-https://www.elastic.co/subscriptions/[purchase a subscription]
-to keep using the full functionality of the {xpack} components.
+If you want to try the platinum features, you can start a 30-day trial. Go to the 
+{kibana-ref}/managing-licenses.html[License Management] page in {kib} or use the 
+{ref}/start-trial.html[start trial API].
 
-IMPORTANT:  When your license expires, {xpack} operates in a degraded mode. For
-more information, see  <<license-expiration, License Expiration>>.
+NOTE: You can initiate a trial license only if your cluster has not already 
+activated a trial license for the current major product version. For example, if 
+you have already activated a trial for v6.0, you cannot start a new trial until 
+v7.0. To check your trial status, use the 
+{ref}/get-trial-status.html[get trial status API].
 
-[float]
-[[generated-license]]
-== Generating a Trial License
-
-You can initiate a trial license only if your cluster has not already activated
-a trial license for the current major {xpack} version. For example, if you have
-already activated a trial for v6.0, you cannot start a new trial until v7.0.
-
-You can view the status of your license and activate a trial license through the
-https://www.elastic.co/guide/en/kibana/master/management.html[Kibana Management] UI.
-
-You can also use the license APIs directly. To see if you can activate a
-trial license for your cluster, use the {ref}/get-trial-status.html[get trial
-status API]. To start a trial, use the {ref}/start-trial.html[start trial API].
-
-For more information, see {ref}/license-settings.html[{xpack} License Settings].
+At the end of the trial period, the platinum features operate in a 
+<<license-expiration,degraded mode>>. You can revert to a basic license, extend 
+the trial, or https://www.elastic.co/subscriptions/[purchase a subscription].
 
 [float]
 [[installing-license]]
@@ -37,14 +27,7 @@ For more information, see {ref}/license-settings.html[{xpack} License Settings].
 
 You can update your license at runtime without shutting down your nodes. License
 updates take effect immediately. The license is provided as a _JSON_ file that
-you install with the {ref}/update-license.html[update license API].
-
-[float]
-[[listing-licenses]]
-== Viewing the Installed License
-
-You can use the {ref}/get-license.html[get license API] to retrieve the
-currently installed license.
+you install in {kib} or by using the {ref}/update-license.html[update license API].
 
 --
 


### PR DESCRIPTION
This PR updates the License Management page in the Stack Overview (https://www.elastic.co/guide/en/elastic-stack-overview/master/license-management.html).

In general, we should keep the licensing details to a minimum in the docs and instead refer to the elastic.co/subscriptions page.

Related to https://github.com/elastic/kibana/pull/20316 and https://github.com/elastic/elasticsearch/pull/31667