### PR TITLE
[DOCS] Update ML tutorial for when security is not enabled

### DIFF
--- a/docs/en/stack/ml/getting-started-data.asciidoc
+++ b/docs/en/stack/ml/getting-started-data.asciidoc
@@ -96,11 +96,14 @@ for the fields. Mappings divide the documents in the index into logical groups
 and specify a field's characteristics, such as the field's searchability or
 whether or not it's _tokenized_, or broken up into separate words.
 
-The sample data includes an `upload_server-metrics.sh` script, which you can use
+The sample data includes an `upload_server_metrics.sh` script, which you can use
 to create the mappings and load the data set. You can download it by clicking
-here: https://download.elastic.co/demos/machine_learning/gettingstarted/upload_server-metrics.sh[upload_server-metrics.sh]
+here: https://download.elastic.co/demos/machine_learning/gettingstarted/upload_server_metrics.sh[upload_server_metrics.sh]
 Before you run it, however, you must edit the USERNAME and PASSWORD variables
 with your actual user ID and password.
+If you do not have {security} enabled, use the 
+https://download.elastic.co/demos/machine_learning/gettingstarted/upload_server_metrics_noauth.sh[upload_server_metrics_noauth.sh] 
+script instead. 
 
 The script runs a command similar to the following example, which sets up a
 mapping for the data set:
@@ -144,11 +147,12 @@ http://localhost:9200/server-metrics -d '{
 ----------------------------------
 // NOTCONSOLE
 
-NOTE: If you run this command, you must replace `x-pack-test-password` with your
-actual password.
+NOTE: If you run this command (or similar commands in subsequent examples), you 
+must replace `x-pack-test-password` with your actual password. If {security} is 
+not enabled, you can omit the `-u` parameter. 
 
 You can then use the {es} `bulk` API to load the data set. The
-`upload_server-metrics.sh` script runs commands similar to the following
+`upload_server_metrics.sh` script runs commands similar to the following
 example, which loads the four JSON files:
 
 [source,sh]

--- a/docs/en/stack/ml/getting-started-data.asciidoc
+++ b/docs/en/stack/ml/getting-started-data.asciidoc
@@ -196,7 +196,7 @@ green  open   server-metrics ... 1 0 905940  ...
 
 Next, you must define an index pattern for this data set:
 
-. Open {kib} in your web browser and log in. If you are running {kib}
+. Open {kib} in your web browser. If you are running {kib}
 locally, go to `http://localhost:5601/`.
 
 . Click the **Management** tab, then **{kib}** > **Index Patterns**.

--- a/docs/en/stack/ml/getting-started-data.asciidoc
+++ b/docs/en/stack/ml/getting-started-data.asciidoc
@@ -96,64 +96,59 @@ for the fields. Mappings divide the documents in the index into logical groups
 and specify a field's characteristics, such as the field's searchability or
 whether or not it's _tokenized_, or broken up into separate words.
 
-The sample data includes an `upload_server_metrics.sh` script, which you can use
-to create the mappings and load the data set. You can download it by clicking
-here: https://download.elastic.co/demos/machine_learning/gettingstarted/upload_server_metrics.sh[upload_server_metrics.sh]
+You can use scripts to create the mappings and load the data set. Download  https://download.elastic.co/demos/machine_learning/gettingstarted/upload_server_metrics.sh[upload_server_metrics.sh] to the directory where you extracted the sample data. 
 Before you run it, however, you must edit the USERNAME and PASSWORD variables
-with your actual user ID and password.
-If you do not have {security} enabled, use the 
+with your actual user ID and password. If {security} is not enabled, use the 
 https://download.elastic.co/demos/machine_learning/gettingstarted/upload_server_metrics_noauth.sh[upload_server_metrics_noauth.sh] 
 script instead. 
 
-The script runs a command similar to the following example, which sets up a
-mapping for the data set:
+The script runs a `curl` command that makes the following create index API 
+request:
 
 [source,sh]
 ----------------------------------
-curl -u elastic:x-pack-test-password -X PUT -H 'Content-Type: application/json'
-http://localhost:9200/server-metrics -d '{
-   "settings":{
-      "number_of_shards":1,
-      "number_of_replicas":0
-   },
-   "mappings":{
-      "metric":{
-         "properties":{
-            "@timestamp":{
-               "type":"date"
-            },
-            "accept":{
-               "type":"long"
-            },
-            "deny":{
-               "type":"long"
-            },
-            "host":{
-               "type":"keyword"
-            },
-            "response":{
-               "type":"float"
-            },
-            "service":{
-               "type":"keyword"
-            },
-            "total":{
-               "type":"long"
-            }
-         }
+PUT server-metrics
+{
+  "settings": {
+    "number_of_shards":1,
+    "number_of_replicas":0
+  },
+  "mappings": {  
+    "metric": {  
+      "properties":{  
+        "@timestamp": {  
+          "type":"date"
+        },
+        "accept": {  
+          "type":"long"
+        },
+        "deny": {  
+          "type":"long"
+        },
+        "host": {  
+          "type":"keyword"
+        },
+        "response": {  
+          "type":"float"
+        },
+        "service": { 
+          "type":"keyword"
+        },
+        "total": {  
+          "type":"long"
+        }
       }
-   }
-}'
+    }
+  }  
+}
 ----------------------------------
-// NOTCONSOLE
+// CONSOLE
 
-NOTE: If you run this command (or similar commands in subsequent examples), you 
-must replace `x-pack-test-password` with your actual password. If {security} is 
-not enabled, you can omit the `-u` parameter. 
+To learn more about mappings and data types, see {ref}/mapping.html[Mapping].
 
-You can then use the {es} `bulk` API to load the data set. The
-`upload_server_metrics.sh` script runs commands similar to the following
-example, which loads the four JSON files:
+You can then use the bulk API to load the sample data set. The 
+`upload_server_metrics.sh` script runs commands similar to the following example, 
+which loads the four JSON files:
 
 [source,sh]
 ----------------------------------
@@ -171,19 +166,21 @@ http://localhost:9200/server-metrics/_bulk --data-binary "@server-metrics_4.json
 ----------------------------------
 // NOTCONSOLE
 
-TIP: This will upload 200MB of data. This is split into 4 files as there is a
-maximum 100MB limit when using the `_bulk` API.
+NOTE: If you want to try running these commands, you must specify a valid user 
+ID and password in the `-u` parameter. If {security} is not enabled, you can 
+omit the `-u` parameter.
 
-These commands might take some time to run, depending on the computing resources
-available.
+These commands upload 200MB of data and might take some time to run, depending 
+on the computing resources available.
 
-You can verify that the data was loaded successfully with the following command:
+You can verify that the data was loaded successfully by running the cat indices 
+API:
 
 [source,sh]
 ----------------------------------
-curl 'http://localhost:9200/_cat/indices?v' -u elastic:x-pack-test-password
+GET _cat/indices?v
 ----------------------------------
-// NOTCONSOLE
+// CONSOLE
 
 You should see output similar to the following:
 

--- a/docs/en/stack/ml/getting-started-multi.asciidoc
+++ b/docs/en/stack/ml/getting-started-multi.asciidoc
@@ -30,7 +30,7 @@ services have unusual patterns.
 
 To create a multi-metric job in {kib}:
 
-. Open {kib} in your web browser and log in. If you are running {kib} locally,
+. Open {kib} in your web browser. If you are running {kib} locally,
 go to `http://localhost:5601/`.
 
 . Click **Machine Learning** in the side navigation, then click **Create new job**.
@@ -102,9 +102,6 @@ do not need more than three. If you pick many influencers, the results can be
 overwhelming and there is a small overhead to the analysis.
 
 ========================
-//TBD: Is this something you can determine later from looking at results and
-//update your job with if necessary? Is it all post-processing or does it affect
-//the ongoing modeling?
 --
 
 . Click **Use full server-metrics* data**. Two graphs are generated for each
@@ -128,8 +125,10 @@ results.
 
 TIP: The `create_multi_metic.sh` script creates a similar job and {dfeed} by
 using the {ml} APIs. You can download that script by clicking
-here: https://download.elastic.co/demos/machine_learning/gettingstarted/create_multi_metric.sh[create_multi_metric.sh]
-For API reference information, see {ref}/ml-apis.html[Machine Learning APIs].
+here: https://download.elastic.co/demos/machine_learning/gettingstarted/create_multi_metric.sh[create_multi_metric.sh] Before you run it, you must edit the USERNAME and PASSWORD variables
+with your actual user ID and password. If you do not have {security} enabled, use the 
+https://download.elastic.co/demos/machine_learning/gettingstarted/create_multi_metric_noauth.sh[create_multi_metric_noauth.sh] 
+script instead. For API reference information, see {ref}/ml-apis.html[Machine Learning APIs].
 
 [[ml-gs-job2-analyze]]
 === Exploring Multi-metric Job Results

--- a/docs/en/stack/ml/getting-started-multi.asciidoc
+++ b/docs/en/stack/ml/getting-started-multi.asciidoc
@@ -123,10 +123,10 @@ When the job is created, you can choose to view the results, continue the job in
 real-time, and create a watch. In this tutorial, we will proceed to view the
 results.
 
-TIP: The `create_multi_metic.sh` script creates a similar job and {dfeed} by
+TIP: The `create_multi_metric.sh` script creates a similar job and {dfeed} by
 using the {ml} APIs. You can download that script by clicking
 here: https://download.elastic.co/demos/machine_learning/gettingstarted/create_multi_metric.sh[create_multi_metric.sh] Before you run it, you must edit the USERNAME and PASSWORD variables
-with your actual user ID and password. If you do not have {security} enabled, use the 
+with your actual user ID and password. If {security} is not enabled, use the 
 https://download.elastic.co/demos/machine_learning/gettingstarted/create_multi_metric_noauth.sh[create_multi_metric_noauth.sh] 
 script instead. For API reference information, see {ref}/ml-apis.html[Machine Learning APIs].
 

--- a/docs/en/stack/ml/getting-started-single.asciidoc
+++ b/docs/en/stack/ml/getting-started-single.asciidoc
@@ -128,10 +128,10 @@ When the job is created, you can choose to view the results, continue the job
 in real-time, and create a watch. In this tutorial, we will look at how to
 manage jobs and {dfeeds} before we view the results.
 
-TIP: The `create_single_metic.sh` script creates a similar job and {dfeed} by
+TIP: The `create_single_metric.sh` script creates a similar job and {dfeed} by
 using the {ml} APIs. You can download that script by clicking
 here: https://download.elastic.co/demos/machine_learning/gettingstarted/create_single_metric.sh[create_single_metric.sh] Before you run it, you must edit the USERNAME and PASSWORD variables
-with your actual user ID and password. If you do not have {security} enabled, use the 
+with your actual user ID and password. If {security} is not enabled, use the 
 https://download.elastic.co/demos/machine_learning/gettingstarted/create_single_metric_noauth.sh[create_single_metric_noauth.sh] 
 script instead. For API reference information, see {ref}/ml-apis.html[Machine Learning APIs].
 

--- a/docs/en/stack/ml/getting-started-single.asciidoc
+++ b/docs/en/stack/ml/getting-started-single.asciidoc
@@ -20,7 +20,7 @@ functions) and the fields that will be analyzed.
 
 To create a single metric job in {kib}:
 
-. Open {kib} in your web browser and log in. If you are running {kib} locally,
+. Open {kib} in your web browser. If you are running {kib} locally,
 go to `http://localhost:5601/`.
 
 . Click **Machine Learning** in the side navigation.
@@ -130,8 +130,10 @@ manage jobs and {dfeeds} before we view the results.
 
 TIP: The `create_single_metic.sh` script creates a similar job and {dfeed} by
 using the {ml} APIs. You can download that script by clicking
-here: https://download.elastic.co/demos/machine_learning/gettingstarted/create_single_metric.sh[create_single_metric.sh]
-For API reference information, see {ref}/ml-apis.html[Machine Learning APIs].
+here: https://download.elastic.co/demos/machine_learning/gettingstarted/create_single_metric.sh[create_single_metric.sh] Before you run it, you must edit the USERNAME and PASSWORD variables
+with your actual user ID and password. If you do not have {security} enabled, use the 
+https://download.elastic.co/demos/machine_learning/gettingstarted/create_single_metric_noauth.sh[create_single_metric_noauth.sh] 
+script instead. For API reference information, see {ref}/ml-apis.html[Machine Learning APIs].
 
 [[ml-gs-job1-manage]]
 === Managing Jobs

--- a/docs/en/stack/ml/getting-started-wizards.asciidoc
+++ b/docs/en/stack/ml/getting-started-wizards.asciidoc
@@ -26,7 +26,7 @@ jobs.
 
 To see the job creation wizards:
 
-. Open {kib} in your web browser and log in. If you are running {kib} locally,
+. Open {kib} in your web browser. If you are running {kib} locally,
 go to `http://localhost:5601/`.
 
 . Click **Machine Learning** in the side navigation.


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/issues/31541

This PR updates the machine learning tutorial to use alternative scripts (https://github.com/elastic/machine-learning-utils/pull/61) when security is not enabled. It also removes unnecessary comments about logging into Kibana. 
