### PR TITLE
Add .\metricbeat.exe when executing from the CWD

### DIFF
--- a/docs/en/stack/getting-started/get-started-stack.asciidoc
+++ b/docs/en/stack/getting-started/get-started-stack.asciidoc
@@ -453,7 +453,7 @@ sudo metricbeat modules enable system
 +
 [source,yaml]
 ----
-PS C:\Program Files\Metricbeat> metricbeat.exe modules enable system
+PS C:\Program Files\Metricbeat> .\metricbeat.exe modules enable system
 ----
 
 . Set up the initial environment:


### PR DESCRIPTION
Cherry-picks #63  into the 6.3 branch.