### PR TITLE
Documents built-in `beats_admin` role

### DIFF
--- a/docs/en/stack/security/authorization/built-in-roles.asciidoc
+++ b/docs/en/stack/security/authorization/built-in-roles.asciidoc
@@ -51,7 +51,8 @@ NOTE: This role does not provide access to the logstash indices and is not
 suitable for use within a Logstash pipeline.
 
 [[built-in-roles-beats-admin]] `beats_admin` ::
-Grants access to the `.management-beats` index for managing configurations.
+Grants access to the `.management-beats` index, which contains configuration
+information for the Beats.
 
 [[built-in-roles-beats-system]] `beats_system` ::
 Grants access necessary for the Beats system user to send system-level data

--- a/docs/en/stack/security/authorization/built-in-roles.asciidoc
+++ b/docs/en/stack/security/authorization/built-in-roles.asciidoc
@@ -50,6 +50,9 @@ change between releases.
 NOTE: This role does not provide access to the logstash indices and is not
 suitable for use within a Logstash pipeline.
 
+[[built-in-roles-beats-admin]] `beats_admin` ::
+Grants access to the `.management-beats` index for managing configurations.
+
 [[built-in-roles-beats-system]] `beats_system` ::
 Grants access necessary for the Beats system user to send system-level data
 (such as monitoring) to {es}.


### PR DESCRIPTION
This role is require for Beats central management and was added to X-Pack Elasticsearch as part of https://github.com/elastic/elasticsearch/pull/30520.