### PR TITLE
Corrected upgrade steps in the interactive guide & stack upgrade doc.

### DIFF
--- a/docs/60_upgrade_guide.html
+++ b/docs/60_upgrade_guide.html
@@ -584,6 +584,7 @@ var saveAs=saveAs||navigator.msSaveBlob&&navigator.msSaveBlob.bind(navigator)||f
 
 
 
+
 </style><script role="script" id="twine-user-script" type="text/twine-javascript">postrender['radiobutton-reveal'] = function (content) {
 	var reveal = content.querySelector('#reveal');
 
@@ -603,6 +604,7 @@ var saveAs=saveAs||navigator.msSaveBlob&&navigator.msSaveBlob.bind(navigator)||f
 			});
 	}
 };
+
 
 
 
@@ -829,14 +831,12 @@ Do you have TLS enabled?
 &lt;span class=&quot;pseudo-link&quot;&gt;Stop sending data to your cluster.&lt;/span&gt;
 [[Shut down your cluster and install Elasticsearch 6.3 on all nodes.|https://www.elastic.co/guide/en/elasticsearch/reference/6.3/restart-upgrade.html]]
 &lt;&lt;if $xpack&gt;&gt;\
-&lt;span class=&quot;pseudo-link&quot;&gt;Use bin/elasticsearch-plugin remove to uninstall the old X-Pack plugin before restarting Elasticsearch.&lt;/span&gt;
-&lt;span class=&quot;list-indent&quot;&gt;X-Pack is installed automatically with the default Elasticsearch 6.3 distribution.&lt;/span&gt;
+&lt;span class=&quot;pseudo-link&quot;&gt;Remove the X-Pack plugin before restarting Elasticsearch.&lt;/span&gt;
+&lt;span class=&quot;list-indent&quot;&gt;Run bin/elasticsearch-plugin remove x-pack.&lt;/span&gt;\
 &lt;&lt;endif&gt;&gt;\
 &lt;&lt;if $xpack_monitoring&gt;&gt;\
-&lt;span class=&quot;pseudo-link&quot;&gt;Explicitly enable data collection to use monitoring.&lt;/span&gt;
-&lt;span class=&quot;list-indent&quot;&gt;Set xpack.monitoring.collection.enabled to true with the _cluster/settings API.&lt;/span&gt;
-&lt;&lt;endif&gt;&gt;\
-&lt;span class=&quot;list-indent&quot;&gt;X-Pack is installed automatically with the default Elasticsearch 6.3 distribution.&lt;/span&gt;
+&lt;span class=&quot;pseudo-link&quot;&gt;Explicitly enable data collection to use monitoring.&lt;/span&gt;\
+&lt;span class=&quot;list-indent&quot;&gt;Set xpack.monitoring.collection.enabled to true with the _cluster/settings API.&lt;/span&gt;\
 &lt;&lt;endif&gt;&gt;\
 &lt;&lt;include enable-tls&gt;&gt;\
 &lt;span class=&quot;pseudo-link&quot;&gt;Restart your Elasticsearch cluster&lt;/span&gt;.

--- a/docs/60_upgrade_guide.html
+++ b/docs/60_upgrade_guide.html
@@ -928,9 +928,6 @@ Do you have TLS enabled?
 &lt;&lt;if $logstash&gt;&gt;\
 [[Upgrade Logstash to 6.3.|https://www.elastic.co/guide/en/logstash/5.6/upgrading-logstash.html]]
 &lt;span class=&quot;list-indent&quot;&gt;You can run Logstash 5.6 with Elasticsearch 6.3 until it&#x27;s convenient to upgrade.&lt;/span&gt;\
-&lt;&lt;if $xpack&gt;&gt;\
-[[Install X-Pack into Logstash.|https://www.elastic.co/guide/en/logstash/5.6/installing-xpack-log.html]]
-&lt;&lt;endif&gt;&gt;\
 &lt;&lt;endif&gt;&gt;\
 &lt;&lt;if $beats&gt;&gt;\
 [[Upgrade each beat to 6.3.|https://www.elastic.co/guide/en/beats/libbeat/6.3/upgrading-5-to-6.html#upgrading-to-5.6]]

--- a/docs/60_upgrade_guide.html
+++ b/docs/60_upgrade_guide.html
@@ -4,19 +4,6 @@
 <meta charset="UTF-8" />
 <title>Elastic Stack 6.3 Upgrade Guide</title>
 <meta name="viewport" content="width=device-width,initial-scale=1" />
-<style>
-  #init-screen {
-    background-color: #ffffff !important;
-  }
-
-  html[data-init=loading] #init-loading {
-    border-top-color: lightgray !important;
-    border-bottom-color: lightgray !important;
-    width: 20px !important;
-    border-width: 10px !important;
-    height: 20px !important;
-  }
-</style>
 <!--
 
 SugarCube (v2.18.0): A free (gratis and libre) story format.
@@ -75,7 +62,7 @@ void 0!==c?null===c?void r.removeAttr(a,b):e&&"set"in e&&void 0!==(d=e.set(a,c,b
 /*
  * jQuery throttle / debounce - v1.1 - 3/7/2010
  * http://benalman.com/projects/jquery-throttle-debounce-plugin/
- *
+ * 
  * Copyright (c) 2010 "Cowboy" Ben Alman
  * Dual licensed under the MIT and GPL licenses.
  * http://benalman.com/about/license/
@@ -115,21 +102,6 @@ var saveAs=saveAs||navigator.msSaveBlob&&navigator.msSaveBlob.bind(navigator)||f
 		<div id="init-lacking">Your browser lacks required capabilities. Please upgrade it or switch to another to continue.</div>
 		<div id="init-loading"><div>Loading&hellip;</div></div>
 	</div>
-  <script type="text/javascript">
-    function updateIframeHeight() {
-      // Wait a slight delay because user input could cause the UI to change, so we need to wait
-      // for the UI to re-render before calculating the height.
-      window.setTimeout(function () {
-        var height = document.body.offsetHeight;
-        window.top.postMessage(height, '*');
-      }, 150);
-    }
-
-    // Tell the container that the Iframe height needs to be updated.
-    window.addEventListener('click', updateIframeHeight);
-    window.addEventListener('keypress', updateIframeHeight);
-    document.addEventListener('DOMContentLoaded', updateIframeHeight);
-  </script>
 	<div id="store-area" hidden><tw-storydata name="Elastic Stack 6.3 Upgrade Guide" startnode="1" creator="Twine" creator-version="2.1.3" ifid="749DFD70-0EC2-4CB9-9963-4ACB86A52F3D" format="SugarCube" format-version="2.18.0" options="" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">/* ==================== CHROME ==================================== */
 
   #upgradeStackWizard {
@@ -583,6 +555,7 @@ var saveAs=saveAs||navigator.msSaveBlob&&navigator.msSaveBlob.bind(navigator)||f
 
 
 
+
 </style><script role="script" id="twine-user-script" type="text/twine-javascript">postrender['radiobutton-reveal'] = function (content) {
 	var reveal = content.querySelector('#reveal');
 
@@ -602,6 +575,7 @@ var saveAs=saveAs||navigator.msSaveBlob&&navigator.msSaveBlob.bind(navigator)||f
 			});
 	}
 };
+
 
 
 
@@ -820,13 +794,22 @@ Do you have TLS enabled?
 &lt;&lt;endif&gt;&gt;\
 &lt;span class=&quot;pseudo-link&quot;&gt;Restart the node.&lt;/span&gt;
 &lt;/span&gt;\
-&lt;&lt;include components-56&gt;&gt;\</tw-passagedata><tw-passagedata pid="10" name="fcr-upgrade-60" tags="" position="1401,647">!!!Perform a Full Cluster Restart Upgrade to 6.3
+&lt;&lt;include components-56&gt;&gt;\</tw-passagedata><tw-passagedata pid="10" name="fcr-upgrade-60" tags="" position="1400,647">!!!Perform a Full Cluster Restart Upgrade to 6.3
 &lt;&lt;if $xpack_ml&gt;&gt;\
 [[Stop any running Machine Learning jobs.|https://www.elastic.co/guide/en/x-pack/current/stopping-ml.html]]
 &lt;&lt;endif&gt;&gt;\
 &lt;span class=&quot;pseudo-link&quot;&gt;Stop sending data to your cluster.&lt;/span&gt;
 [[Shut down your cluster and install Elasticsearch 6.3 on all nodes.|https://www.elastic.co/guide/en/elasticsearch/reference/6.3/restart-upgrade.html]]
+&lt;&lt;if $xpack&gt;&gt;\
+&lt;span class=&quot;pseudo-link&quot;&gt;Use bin/elasticsearch-plugin remove to uninstall the old X-Pack plugin before restarting Elasticsearch.&lt;/span&gt;
 &lt;span class=&quot;list-indent&quot;&gt;X-Pack is installed automatically with the default Elasticsearch 6.3 distribution.&lt;/span&gt;
+&lt;&lt;endif&gt;&gt;\
+&lt;&lt;if $xpack_monitoring&gt;&gt;\
+&lt;span class=&quot;pseudo-link&quot;&gt;Explicitly enable data collection to use monitoring.&lt;/span&gt;
+&lt;span class=&quot;list-indent&quot;&gt;Set xpack.monitoring.collection.enabled to true with the _cluster/settings API.&lt;/span&gt;
+&lt;&lt;endif&gt;&gt;\
+&lt;span class=&quot;list-indent&quot;&gt;X-Pack is installed automatically with the default Elasticsearch 6.3 distribution.&lt;/span&gt;
+&lt;&lt;endif&gt;&gt;\
 &lt;&lt;include enable-tls&gt;&gt;\
 &lt;span class=&quot;pseudo-link&quot;&gt;Restart your Elasticsearch cluster&lt;/span&gt;.
 &lt;&lt;include components-60&gt;&gt;</tw-passagedata><tw-passagedata pid="11" name="components-56" tags="" position="1533,221">&lt;&lt;if $kibana&gt;&gt;\
@@ -848,7 +831,7 @@ Do you have TLS enabled?
 &lt;&lt;endif&gt;&gt;\
 &lt;&lt;if $hadoop &amp;&amp; $upgrade_56 == &quot;rolling&quot;&gt;&gt;\
 [[Upgrade Elasticsearch for Hadoop to 5.6.|https://www.elastic.co/guide/en/elasticsearch/hadoop/5.6/install.html]]\
-&lt;&lt;endif&gt;&gt;\</tw-passagedata><tw-passagedata pid="12" name="rolling-upgrade-60" tags="" position="1400,476">!!!Upgrade to 6.3
+&lt;&lt;endif&gt;&gt;\</tw-passagedata><tw-passagedata pid="12" name="rolling-upgrade-60" tags="" position="1401,476">!!!Upgrade to 6.3
 &lt;&lt;if $xpack_ml&gt;&gt;\
 [[Stop any running Machine Learning jobs.|https://www.elastic.co/guide/en/elastic-stack-overview/6.3/stopping-ml.html]]
 &lt;&lt;endif&gt;&gt;\
@@ -858,6 +841,14 @@ Do you have TLS enabled?
 &lt;&lt;endif&gt;&gt;\
 [[Upgrade Elasticsearch to 6.3.|https://www.elastic.co/guide/en/elasticsearch/reference/6.3/rolling-upgrades.html]]
 &lt;span class=&quot;list-indent&quot;&gt;You can perform a rolling upgrade to Elasticsearch 6.3.&lt;/span&gt;\
+&lt;&lt;if $xpack&gt;&gt;\
+&lt;span class=&quot;pseudo-link&quot;&gt;Remove the X-Pack plugin before restarting Elasticsearch.&lt;/span&gt;
+&lt;span class=&quot;list-indent&quot;&gt;Run bin/elasticsearch-plugin remove x-pack.&lt;/span&gt;\
+&lt;&lt;endif&gt;&gt;\
+&lt;&lt;if $xpack_monitoring&gt;&gt;\
+&lt;span class=&quot;pseudo-link&quot;&gt;Explicitly enable data collection to use monitoring.&lt;/span&gt;\
+&lt;span class=&quot;list-indent&quot;&gt;Set xpack.monitoring.collection.enabled to true with the _cluster/settings API.&lt;/span&gt;\
+&lt;&lt;endif&gt;&gt;\
 &lt;&lt;if $upgrade_63 == &quot;rolling&quot;&gt;&gt;\
 &lt;&lt;include &quot;components-63&quot;&gt;&gt;\
 &lt;&lt;else&gt;&gt;\

--- a/docs/60_upgrade_guide.html
+++ b/docs/60_upgrade_guide.html
@@ -4,6 +4,19 @@
 <meta charset="UTF-8" />
 <title>Elastic Stack 6.3 Upgrade Guide</title>
 <meta name="viewport" content="width=device-width,initial-scale=1" />
+<style>
+  #init-screen {
+    background-color: #ffffff !important;
+  }
+
+  html[data-init=loading] #init-loading {
+    border-top-color: lightgray !important;
+    border-bottom-color: lightgray !important;
+    width: 20px !important;
+    border-width: 10px !important;
+    height: 20px !important;
+  }
+</style>
 <!--
 
 SugarCube (v2.18.0): A free (gratis and libre) story format.
@@ -62,7 +75,7 @@ void 0!==c?null===c?void r.removeAttr(a,b):e&&"set"in e&&void 0!==(d=e.set(a,c,b
 /*
  * jQuery throttle / debounce - v1.1 - 3/7/2010
  * http://benalman.com/projects/jquery-throttle-debounce-plugin/
- * 
+ *
  * Copyright (c) 2010 "Cowboy" Ben Alman
  * Dual licensed under the MIT and GPL licenses.
  * http://benalman.com/about/license/
@@ -102,6 +115,21 @@ var saveAs=saveAs||navigator.msSaveBlob&&navigator.msSaveBlob.bind(navigator)||f
 		<div id="init-lacking">Your browser lacks required capabilities. Please upgrade it or switch to another to continue.</div>
 		<div id="init-loading"><div>Loading&hellip;</div></div>
 	</div>
+  <script type="text/javascript">
+    function updateIframeHeight() {
+      // Wait a slight delay because user input could cause the UI to change, so we need to wait
+      // for the UI to re-render before calculating the height.
+      window.setTimeout(function () {
+        var height = document.body.offsetHeight;
+        window.top.postMessage(height, '*');
+      }, 150);
+    }
+
+    // Tell the container that the Iframe height needs to be updated.
+    window.addEventListener('click', updateIframeHeight);
+    window.addEventListener('keypress', updateIframeHeight);
+    document.addEventListener('DOMContentLoaded', updateIframeHeight);
+  </script>
 	<div id="store-area" hidden><tw-storydata name="Elastic Stack 6.3 Upgrade Guide" startnode="1" creator="Twine" creator-version="2.1.3" ifid="749DFD70-0EC2-4CB9-9963-4ACB86A52F3D" format="SugarCube" format-version="2.18.0" options="" hidden><style role="stylesheet" id="twine-user-stylesheet" type="text/twine-css">/* ==================== CHROME ==================================== */
 
   #upgradeStackWizard {

--- a/docs/upgrading-stack.asciidoc
+++ b/docs/upgrading-stack.asciidoc
@@ -119,9 +119,12 @@ or 6.0-6.2. {xpack} Basic features are operational once the cluster is fully
 upgraded. If you are already using {xpack}, your settings are preserved when
 you upgrade.
 
-If you are using {xpack} for the first time, you must explicitly enable data
-collection after the upgrade to use monitoring. Set
-`xpack.monitoring.collection.enabled` to `true` with the `_cluster/settings`
+IMPORTANT: If you use {xpack} you must explicitly remove the old {xpack} plugin
+before restarting: `bin/elasticsearch-plugin remove x-pack`. The node will fail
+to start if the {xpack} plugin is present.
+
+You must explicitly enable data collection after the upgrade to use monitoring.
+Set `xpack.monitoring.collection.enabled` to `true` with the `_cluster/settings`
 API:
 
 [source,json]


### PR DESCRIPTION
- Removed ref to installing X-Pack in Logstash in the interactive guide.
- Added step for removing old X-Pack plugin in the interactive guide & docs.
- Added step for enabling data collection for monitoring to the interactive guide & made it clear that you always need to enable data collection after upgrade.