### PR TITLE
[DOCS] Moves monitor troubleshooting content kibana repo

### DIFF
--- a/docs/en/stack/monitoring/troubleshooting.asciidoc
+++ b/docs/en/stack/monitoring/troubleshooting.asciidoc
@@ -1,0 +1,8 @@
+[[monitoring-troubleshooting]]
+== {monitoring} Troubleshooting
+++++
+<titleabbrev>{monitoring}</titleabbrev>
+++++
+
+See
+{logstash-ref}/monitoring-troubleshooting.html[Troubleshooting {monitoring} in Logstash].

--- a/docs/en/stack/troubleshooting.asciidoc
+++ b/docs/en/stack/troubleshooting.asciidoc
@@ -45,8 +45,8 @@ include::{xes-repo-dir}/security/troubleshooting.asciidoc[]
 :edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/troubleshooting.asciidoc
 include::{xes-repo-dir}/watcher/troubleshooting.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/monitoring/monitoring-troubleshooting.asciidoc
-include::{kib-repo-dir}/monitoring/monitoring-troubleshooting.asciidoc[]
+:edit_url: https://github.com/elastic/stack-docs/edit/{branch}/docs/en/stack/monitoring/troubleshooting.asciidoc
+include::monitoring/troubleshooting.asciidoc[]
 
 :edit_url: https://github.com/elastic/stack-docs/edit/{branch}/docs/en/stack/ml/troubleshooting.asciidoc
 include::ml/troubleshooting.asciidoc[]


### PR DESCRIPTION
This PR copies the content of https://github.com/elastic/kibana/blob/master/docs/monitoring/monitoring-troubleshooting.asciidoc to this repo for use in the Stack Overview.

