### PR TITLE
[DOCS] Adds link for ML getting started scripts

### DIFF
--- a/docs/en/stack/ml/getting-started-multi.asciidoc
+++ b/docs/en/stack/ml/getting-started-multi.asciidoc
@@ -123,7 +123,8 @@ When the job is created, you can choose to view the results, continue the job in
 real-time, and create a watch. In this tutorial, we will proceed to view the
 results.
 
-TIP: The `create_multi_metric.sh` script creates a similar job and {dfeed} by
+TIP: The `create_multi_metric.sh` script, which is included with the   
+<<ml-gs-sampledata,sample data>>, creates a similar job and {dfeed} by
 using the {ml} APIs. Before you run it, you must edit the USERNAME and PASSWORD 
 variables with your actual user ID and password. If {security} is not enabled, 
 use the `create_multi_metric_noauth.sh` script instead. For API reference 

--- a/docs/en/stack/ml/getting-started-single.asciidoc
+++ b/docs/en/stack/ml/getting-started-single.asciidoc
@@ -128,7 +128,8 @@ When the job is created, you can choose to view the results, continue the job
 in real-time, and create a watch. In this tutorial, we will look at how to
 manage jobs and {dfeeds} before we view the results.
 
-TIP: The `create_single_metric.sh` script creates a similar job and {dfeed} by
+TIP: The `create_single_metric.sh` script, which is included with the   
+<<ml-gs-sampledata,sample data>>, creates a similar job and {dfeed} by
 using the {ml} APIs. Before you run it, you must edit the USERNAME and PASSWORD 
 variables with your actual user ID and password. If {security} is not enabled, 
 use the `create_single_metric_noauth.sh` script instead. For API reference 


### PR DESCRIPTION
This PR addresses some confusion about where to obtain the create_single_metric.sh, create_single_metric_noauth.sh, create_multi_metric.sh, and create_multi_metric_noauth.sh scripts. It adds links to the page where we describe how to download and extract the server_metrics.tar.gz (which contains these scripts). 