### PR TITLE
[DOCS] Updates link to role mapping API

### DIFF
--- a/docs/en/stack/security/authentication/ldap-realm.asciidoc
+++ b/docs/en/stack/security/authentication/ldap-realm.asciidoc
@@ -52,7 +52,7 @@ systems in the organization.
 
 The `ldap` realm enables you to map LDAP users to to roles via their LDAP
 groups, or other metadata. This role mapping can be configured via the
-{ref}/security-api-role-mapping.html[role-mapping API], or by using a file stored
+{ref}/security-api-put-role-mapping.html[add role mapping API] or by using a file stored
 on each node. When a user authenticates with LDAP, the privileges
 for that user are the union of all privileges defined by the roles to which
 the user is mapped. For more information, see 


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/32797

This PR fixes a broken link to the role mapping APIs.