### PR TITLE
[DOCS] Updates location of ML pages

### DIFF
--- a/docs/en/stack/index.asciidoc
+++ b/docs/en/stack/index.asciidoc
@@ -13,6 +13,7 @@
 
 :kib-repo-dir:      {docdir}/../../../../kibana/docs
 :xes-repo-dir:      {docdir}/../../../../elasticsearch/x-pack/docs/en
+:es-repo-dir:       {docdir}/../../../../elasticsearch/docs/reference
 
 include::{asciidoc-dir}/../../shared/versions.asciidoc[]
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]

--- a/docs/en/stack/ml/api-quickref.asciidoc
+++ b/docs/en/stack/ml/api-quickref.asciidoc
@@ -1,0 +1,102 @@
+[role="xpack"]
+[[ml-api-quickref]]
+== API quick reference
+
+All {ml} endpoints have the following base:
+
+[source,js]
+----
+/_xpack/ml/
+----
+// NOTCONSOLE
+
+The main {ml} resources can be accessed with a variety of endpoints:
+
+* <<ml-api-jobs,+/anomaly_detectors/+>>: Create and manage {ml} jobs
+* <<ml-api-datafeeds,+/datafeeds/+>>: Select data from {es} to be analyzed
+* <<ml-api-results,+/results/+>>: Access the results of a {ml} job
+* <<ml-api-snapshots,+/model_snapshots/+>>: Manage model snapshots
+//* <<ml-api-validate,+/validate/+>>: Validate subsections of job configurations
+
+[float]
+[[ml-api-jobs]]
+=== /anomaly_detectors/
+
+* {ref}/ml-put-job.html[PUT /anomaly_detectors/<job_id+++>+++]: Create a job
+* {ref}/ml-open-job.html[POST /anomaly_detectors/<job_id>/_open]: Open a job
+* {ref}/ml-post-data.html[POST /anomaly_detectors/<job_id>/_data]: Send data to a job
+* {ref}/ml-get-job.html[GET /anomaly_detectors]: List jobs
+* {ref}/ml-get-job.html[GET /anomaly_detectors/<job_id+++>+++]: Get job details
+* {ref}/ml-get-job-stats.html[GET /anomaly_detectors/<job_id>/_stats]: Get job statistics
+* {ref}/ml-update-job.html[POST /anomaly_detectors/<job_id>/_update]: Update certain properties of the job configuration
+* {ref}/ml-flush-job.html[POST anomaly_detectors/<job_id>/_flush]: Force a job to analyze buffered data
+* {ref}/ml-forecast.html[POST anomaly_detectors/<job_id>/_forecast]: Forecast future job behavior
+* {ref}/ml-close-job.html[POST /anomaly_detectors/<job_id>/_close]: Close a job
+* {ref}/ml-delete-job.html[DELETE /anomaly_detectors/<job_id+++>+++]: Delete a job
+
+[float]
+[[ml-api-calendars]]
+=== /calendars/
+
+* {ref}/ml-put-calendar.html[PUT /calendars/<calendar_id+++>+++]: Create a calendar
+* {ref}/ml-post-calendar-event.html[POST /calendars/<calendar_id+++>+++/events]: Add a scheduled event to a calendar
+* {ref}/ml-put-calendar-job.html[PUT /calendars/<calendar_id+++>+++/jobs/<job_id+++>+++]: Associate a job with a calendar
+* {ref}/ml-get-calendar.html[GET /calendars/<calendar_id+++>+++]: Get calendar details
+* {ref}/ml-get-calendar-event.html[GET /calendars/<calendar_id+++>+++/events]: Get scheduled event details
+* {ref}/ml-delete-calendar-event.html[DELETE /calendars/<calendar_id+++>+++/events/<event_id+++>+++]: Remove a scheduled event from a calendar
+* {ref}/ml-delete-calendar-job.html[DELETE /calendars/<calendar_id+++>+++/jobs/<job_id+++>+++]: Disassociate a job from a calendar
+* {ref}/ml-delete-calendar.html[DELETE /calendars/<calendar_id+++>+++]: Delete a calendar
+
+[float]
+[[ml-api-filters]]
+=== /filters/
+
+* {ref}/ml-put-filter.html[PUT /filters/<filter_id+++>+++]: Create a filter
+* {ref}/ml-update-filter.html[POST /filters/<filter_id+++>+++/_update]: Update a filter
+* {ref}/ml-get-filter.html[GET /filters/<filter_id+++>+++]: List filters
+* {ref}/ml-delete-filter.html[DELETE /filter/<filter_id+++>+++]: Delete a filter
+
+[float]
+[[ml-api-datafeeds]]
+=== /datafeeds/
+
+* {ref}/ml-put-datafeed.html[PUT /datafeeds/<datafeed_id+++>+++]: Create a {dfeed}
+* {ref}/ml-start-datafeed.html[POST /datafeeds/<datafeed_id>/_start]: Start a {dfeed}
+* {ref}/ml-get-datafeed.html[GET /datafeeds]: List {dfeeds}
+* {ref}/ml-get-datafeed.html[GET /datafeeds/<datafeed_id+++>+++]: Get {dfeed} details
+* {ref}/ml-get-datafeed-stats.html[GET /datafeeds/<datafeed_id>/_stats]: Get statistical information for {dfeeds}
+* {ref}/ml-preview-datafeed.html[GET /datafeeds/<datafeed_id>/_preview]: Get a preview of a {dfeed}
+* {ref}/ml-update-datafeed.html[POST /datafeeds/<datafeedid>/_update]: Update certain settings for a {dfeed}
+* {ref}/ml-stop-datafeed.html[POST /datafeeds/<datafeed_id>/_stop]: Stop a {dfeed}
+* {ref}/ml-delete-datafeed.html[DELETE /datafeeds/<datafeed_id+++>+++]: Delete {dfeed}
+
+[float]
+[[ml-api-results]]
+=== /results/
+
+* {ref}/ml-get-bucket.html[GET /results/buckets]: List the buckets in the results
+* {ref}/ml-get-bucket.html[GET /results/buckets/<bucket_id+++>+++]: Get bucket details
+* {ref}/ml-get-overall-buckets.html[GET /results/overall_buckets]: Get overall bucket results for multiple jobs
+* {ref}/ml-get-category.html[GET /results/categories]: List the categories in the results
+* {ref}/ml-get-category.html[GET /results/categories/<category_id+++>+++]: Get category details
+* {ref}/ml-get-influencer.html[GET /results/influencers]: Get influencer details
+* {ref}/ml-get-record.html[GET /results/records]: Get records from the results
+
+[float]
+[[ml-api-snapshots]]
+=== /model_snapshots/
+
+* {ref}/ml-get-snapshot.html[GET /model_snapshots]: List model snapshots
+* {ref}/ml-get-snapshot.html[GET /model_snapshots/<snapshot_id+++>+++]: Get model snapshot details
+* {ref}/ml-revert-snapshot.html[POST /model_snapshots/<snapshot_id>/_revert]: Revert a model snapshot
+* {ref}/ml-update-snapshot.html[POST /model_snapshots/<snapshot_id>/_update]: Update certain settings for a model snapshot
+* {ref}/ml-delete-snapshot.html[DELETE /model_snapshots/<snapshot_id+++>+++]: Delete a model snapshot
+
+////
+[float]
+[[ml-api-validate]]
+=== /validate/
+
+* {ref}/ml-valid-detector.html[POST /anomaly_detectors/_validate/detector]: Validate a detector
+* {ref}/ml-valid-job.html[POST /anomaly_detectors/_validate]: Validate a job
+////

--- a/docs/en/stack/ml/index.asciidoc
+++ b/docs/en/stack/ml/index.asciidoc
@@ -24,14 +24,14 @@ include::overview.asciidoc[]
 :edit_url: https://github.com/elastic/stack-docs/edit/{branch}/docs/en/stack/ml/getting-started.asciidoc
 include::getting-started.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/ml/configuring.asciidoc
-include::{xes-repo-dir}/ml/configuring.asciidoc[]
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/docs/reference/ml/configuring.asciidoc
+include::{es-repo-dir}/ml/configuring.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/ml/stopping-ml.asciidoc
-include::{xes-repo-dir}/ml/stopping-ml.asciidoc[]
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/docs/reference/ml/stopping-ml.asciidoc
+include::{es-repo-dir}/ml/stopping-ml.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/ml/api-quickref.asciidoc
-include::{xes-repo-dir}/ml/api-quickref.asciidoc[]
+:edit_url: https://github.com/elastic/stack-docs/edit/{branch}/docs/en/stack/ml/api-quickref.asciidoc
+include::api-quickref.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/ml/functions.asciidoc
-include::{xes-repo-dir}/ml/functions.asciidoc[]
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/docs/reference/ml/functions.asciidoc
+include::{es-repo-dir}/ml/functions.asciidoc[]


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/issues/30665 and https://github.com/elastic/elasticsearch/pull/33248

This PR updates the Stack Overview to use appropriate links to the new location of the machine learning content in the elasticsearch repo. 