### PR TITLE
[DOCS] Fixes code snippet testing in stack-docs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,3 +29,9 @@ apply plugin: 'elasticsearch.docs-test'
 integTestCluster {
   distribution = 'zip'
 }
+
+/* List of files that have snippets that probably should be converted to
+ * `// CONSOLE` and `// TESTRESPONSE` but have yet to be converted. */
+buildRestTests.expectedUnconvertedCandidates = [
+        'docs/en/stack/getting-started/get-started-stack.asciidoc',
+]

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,7 @@
+import org.elasticsearch.gradle.test.NodeInfo
+
+import java.nio.charset.StandardCharsets
+
 /*
  * Licensed to Elasticsearch under one or more contributor
  * license agreements. See the NOTICE file distributed with
@@ -20,18 +24,81 @@
 plugins {
   id 'eclipse'
   id 'idea'
-  // TODO set version to 6.3.0 and the tests should pass!
-  id 'elasticsearch.docs-test' version '6.2.4' apply false
+  id 'elasticsearch.docs-test' version '6.4.0' apply false
 }
 
 apply plugin: 'elasticsearch.docs-test'
-
-integTestCluster {
-  distribution = 'zip'
-}
 
 /* List of files that have snippets that probably should be converted to
  * `// CONSOLE` and `// TESTRESPONSE` but have yet to be converted. */
 buildRestTests.expectedUnconvertedCandidates = [
         'docs/en/stack/getting-started/get-started-stack.asciidoc',
 ]
+
+dependencies {
+    testCompile project(path: xpackModule('core'), configuration: 'default')
+    testCompile project(path: xpackModule('core'), configuration: 'testArtifacts')
+    testCompile project(path: xpackProject('plugin').path, configuration: 'testArtifacts')
+}
+
+Closure waitWithAuth = { NodeInfo node, AntBuilder ant ->
+    File tmpFile = new File(node.cwd, 'wait.success')
+    // wait up to twenty seconds
+    final long stopTime = System.currentTimeMillis() + 20000L;
+    Exception lastException = null;
+    while (System.currentTimeMillis() < stopTime) {
+        lastException = null;
+        // we use custom wait logic here as the elastic user is not available immediately and ant.get will fail when a 401 is returned
+        HttpURLConnection httpURLConnection = null;
+        try {
+            httpURLConnection = (HttpURLConnection) new URL("http://${node.httpUri()}/_cluster/health").openConnection();
+            httpURLConnection.setRequestProperty("Authorization", "Basic " +
+                    Base64.getEncoder().encodeToString("test_admin:x-pack-test-password".getBytes(StandardCharsets.UTF_8)));
+            httpURLConnection.setRequestMethod("GET");
+            httpURLConnection.setConnectTimeout(1000);
+            httpURLConnection.setReadTimeout(30000);
+            httpURLConnection.connect();
+            if (httpURLConnection.getResponseCode() == 200) {
+                tmpFile.withWriter StandardCharsets.UTF_8.name(), {
+                    it.write(httpURLConnection.getInputStream().getText(StandardCharsets.UTF_8.name()))
+                }
+                break;
+            }
+        } catch (Exception e) {
+            logger.debug("failed to call cluster health", e)
+            lastException = e
+        } finally {
+            if (httpURLConnection != null) {
+                httpURLConnection.disconnect();
+            }
+        }
+
+        // did not start, so wait a bit before trying again
+        Thread.sleep(500L);
+    }
+    if (tmpFile.exists() == false && lastException != null) {
+        logger.error("final attempt of calling cluster health failed", lastException)
+    }
+    return tmpFile.exists()
+}
+
+integTestCluster {
+  distribution = 'zip'
+  setting 'xpack.security.enabled', 'true'
+  setting 'xpack.security.authc.token.enabled', 'true'
+  // Disable monitoring exporters for the docs tests
+  setting 'xpack.monitoring.exporters._local.type', 'local'
+  setting 'xpack.monitoring.exporters._local.enabled', 'false'
+  setting 'xpack.license.self_generated.type', 'trial'
+  setupCommand 'setupTestAdmin',
+        'bin/elasticsearch-users', 'useradd', 'test_admin', '-p', 'x-pack-test-password', '-r', 'superuser'
+  waitCondition = waitWithAuth
+}
+
+buildRestTests.docs = fileTree(projectDir) {
+    // No snippets in here!
+    exclude 'build.gradle'
+    // That is where the snippets go, not where they come from!
+    exclude 'build'
+    // These file simply doesn't pass yet. We should figure out how to fix them.
+}

--- a/docs/en/stack/getting-started/get-started-stack.asciidoc
+++ b/docs/en/stack/getting-started/get-started-stack.asciidoc
@@ -771,7 +771,7 @@ The system metrics collected by {metricbeat} include a field called `cmdline`
 that contains the full command-line arguments used to start system processes.
 For example:
 
-[source,json]
+[source,js]
 ----
 "cmdline": "/Applications/Firefox.app/Contents/MacOS/plugin-container.app/Contents/MacOS/plugin-container -childID 3
 -isForBrowser -boolPrefs 36:1|299:0| -stringPrefs 285:38;{b77ae304-9f53-a248-8bd4-a243dbf2cab1}| -schedulerPrefs

--- a/docs/upgrading-stack.asciidoc
+++ b/docs/upgrading-stack.asciidoc
@@ -129,7 +129,7 @@ You must explicitly enable data collection after the upgrade to use monitoring.
 Set `xpack.monitoring.collection.enabled` to `true` with the `_cluster/settings`
 API:
 
-[source,json]
+[source,js]
 ----------------------------------------------------------
 PUT /_cluster/settings
 {
@@ -143,7 +143,7 @@ PUT /_cluster/settings
 To take all of the {xpack} features for a spin, you can start a 30-day trial
 from Kibana, or with the Start Trial API:
 
-[source,json]
+[source,js]
 ----------------------------------------------------------
 POST _xpack/license/start_trial
 ----------------------------------------------------------
@@ -171,7 +171,7 @@ If your trial license to use {xpack} expires,
 https://register.elastic.co/[register for a free Basic license]. To apply the
 license, upload the license file with the `license` API:
 +
-[source,json]
+[source,sh]
 ----------------------------------------------------------
 license -d @license.json
 ----------------------------------------------------------
@@ -244,7 +244,7 @@ Elasticsearch {version}.
 To get a list of the indices that need to be upgraded, install {xpack} and use
 the {ref}/migration-api-assistance.html[`_xpack/migration/assistance` API]:
 
-[source,json]
+[source,js]
 ----------------------------------------------------------
 GET /_xpack/migration/assistance
 ----------------------------------------------------------
@@ -258,7 +258,7 @@ API to upgrade the security index, submitting the request with the credentials
 for the temporary superuser:
 +
 --
-[source,json]
+[source,js]
 ----------------------------------------------------------
 POST /_xpack/migration/upgrade/.security
 ----------------------------------------------------------


### PR DESCRIPTION
Related to https://github.com/elastic/stack-docs/commit/0710eb98a82e2b2c94b3a16c6d46c7e245e2d1b3#diff-1b1f73e4c70b7a175ec378eb5576e953 

This PR attempts to enable code snippet testing for the documentation in this repo such that gold- and platinum-level features work. 

It copies missing content from https://github.com/elastic/elasticsearch/blob/master/x-pack/docs/build.gradle
