### PR TITLE
[DOCS] Adds placeholders for Docker and Kubernetes pages

### DIFF
--- a/docs/en/getting-started/get-started-docker.asciidoc
+++ b/docs/en/getting-started/get-started-docker.asciidoc
@@ -1,0 +1,19 @@
+[[get-started-docker]]
+== Running the {stack} on Docker
+
+The Elastic Docker registry contains Docker images for all the products in the 
+{stack}. For more information, see:
+
+* https://www.docker.elastic.co/
+* {ref}/docker.html[Install {es} with Docker]
+* {apm-server-ref}/running-on-docker.html[Running APM Server on Docker]
+* {auditbeat-ref}/running-on-docker.html[Running {auditbeat} on Docker]
+* {filebeat-ref}/running-on-docker.html[Running {filebeat} on Docker]
+* {heartbeat-ref}/running-on-docker.html[Running {heartbeat} on Docker]
+* {kibana-ref}/docker.html[Running {kib} on Docker] 
+* {logstash-ref}/docker.html[Running {ls} on Docker]
+* {metricbeat-ref}/running-on-docker.html[Running {metricbeat} on Docker]
+* {packetbeat-ref}/running-on-docker.html[Running {packetbeat} on Docker]
+
+
+

--- a/docs/en/getting-started/get-started-kubernetes.asciidoc
+++ b/docs/en/getting-started/get-started-kubernetes.asciidoc
@@ -1,12 +1,6 @@
 [[get-started-kubernetes]]
 == Running the {stack} on Kubernetes
 
-The Elastic Docker registry contains Docker images for all the products in the 
-{stack}. 
-//TBD: ... and you can use these images on Kubernetes?
-For more information, see:
-
-* https://www.docker.elastic.co/
 * {auditbeat-ref}/running-on-kubernetes.html[Running {auditbeat} on Kubernetes]
 * {filebeat-ref}/running-on-kubernetes.html[Running {filebeat} on Kubernetes]
 * {metricbeat-ref}/running-on-kubernetes.html[Running {metricbeat} on Kubernetes]

--- a/docs/en/getting-started/get-started-kubernetes.asciidoc
+++ b/docs/en/getting-started/get-started-kubernetes.asciidoc
@@ -1,0 +1,13 @@
+[[get-started-kubernetes]]
+== Running the {stack} on Kubernetes
+
+The Elastic Docker registry contains Docker images for all the products in the 
+{stack}. 
+//TBD: ... and you can use these images on Kubernetes?
+For more information, see:
+
+* https://www.docker.elastic.co/
+* {auditbeat-ref}/running-on-kubernetes.html[Running {auditbeat} on Kubernetes]
+* {filebeat-ref}/running-on-kubernetes.html[Running {filebeat} on Kubernetes]
+* {metricbeat-ref}/running-on-kubernetes.html[Running {metricbeat} on Kubernetes]
+

--- a/docs/en/getting-started/index.asciidoc
+++ b/docs/en/getting-started/index.asciidoc
@@ -18,3 +18,5 @@ include::{asciidoc-dir}/../../shared/versions.asciidoc[]
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
 include::get-started-stack.asciidoc[]
+include::get-started-docker.asciidoc[]
+//include::get-started-kubernetes.asciidoc[]


### PR DESCRIPTION
Related to https://github.com/elastic/stack-docs/issues/108

This PR creates placeholder pages for Docker and Kubernetes, which currently just link to the existing documentation. 