### PR TITLE
[DOCS] Updates location of auditing pages

### DIFF
--- a/docs/en/stack/security/index.asciidoc
+++ b/docs/en/stack/security/index.asciidoc
@@ -107,8 +107,8 @@ include::authentication/index.asciidoc[]
 :edit_url: https://github.com/elastic/stack-docs/edit/{branch}/docs/en/stack/security/authorization/index.asciidoc
 include::authorization/index.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/auditing.asciidoc
-include::{xes-repo-dir}/security/auditing/index.asciidoc[]
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/docs/reference/security/auditing.asciidoc
+include::{es-repo-dir}/security/auditing/index.asciidoc[]
 
 :edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/securing-communications.asciidoc
 include::{xes-repo-dir}/security/securing-communications.asciidoc[]


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/issues/30665

This PR should be merged at the same time as https://github.com/elastic/elasticsearch/pull/33404

This PR updates the Stack Overview to obtain the auditing information from the appropriate location in the elasticsearch repo.