### PR TITLE
[DOCS] Updates location of authorization pages

### DIFF
--- a/docs/en/stack/security/authorization/index.asciidoc
+++ b/docs/en/stack/security/authorization/index.asciidoc
@@ -5,8 +5,8 @@ include::overview.asciidoc[]
 :edit_url: https://github.com/elastic/stack-docs/edit/{branch}/docs/en/stack/security/authorization/built-in-roles.asciidoc
 include::built-in-roles.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/authorization/managing-roles.asciidoc
-include::{xes-repo-dir}/security/authorization/managing-roles.asciidoc[]
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/docs/reference/security/authorization/managing-roles.asciidoc
+include::{es-repo-dir}/security/authorization/managing-roles.asciidoc[]
 
 :edit_url: https://github.com/elastic/stack-docs/edit/{branch}/docs/en/stack/security/authorization/privileges.asciidoc
 include::privileges.asciidoc[]
@@ -17,17 +17,17 @@ include::document-level-security.asciidoc[]
 :edit_url: https://github.com/elastic/stack-docs/edit/{branch}/docs/en/stack/security/authorization/field-level-security.asciidoc
 include::field-level-security.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/authorization/alias-privileges.asciidoc
-include::{xes-repo-dir}/security/authorization/alias-privileges.asciidoc[]
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/docs/reference/security/authorization/alias-privileges.asciidoc
+include::{es-repo-dir}/security/authorization/alias-privileges.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/authorization/mapping-roles.asciidoc
-include::{xes-repo-dir}/security/authorization/mapping-roles.asciidoc[]
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/docs/reference/security/authorization/mapping-roles.asciidoc
+include::{es-repo-dir}/security/authorization/mapping-roles.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/authorization/field-and-document-access-control.asciidoc
-include::{xes-repo-dir}/security/authorization/field-and-document-access-control.asciidoc[]
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/docs/reference/security/authorization/field-and-document-access-control.asciidoc
+include::{es-repo-dir}/security/authorization/field-and-document-access-control.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/authorization/run-as-privilege.asciidoc
-include::{xes-repo-dir}/security/authorization/run-as-privilege.asciidoc[]
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/docs/reference/security/authorization/run-as-privilege.asciidoc
+include::{es-repo-dir}/security/authorization/run-as-privilege.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/authorization/custom-roles-provider.asciidoc
-include::{xes-repo-dir}/security/authorization/custom-roles-provider.asciidoc[]
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/docs/reference/security/authorization/custom-roles-provider.asciidoc
+include::{es-repo-dir}/security/authorization/custom-roles-provider.asciidoc[]


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/issues/30665

This PR must be merged at the same time as https://github.com/elastic/elasticsearch/pull/33482

This PR updates the Stack Overview to obtain the authorization information from the appropriate location in the elasticsearch repo.