### PR TITLE
[DOCS] Adds apm_system user and role

### DIFF
--- a/docs/en/stack/security/authentication/built-in-users.asciidoc
+++ b/docs/en/stack/security/authentication/built-in-users.asciidoc
@@ -11,6 +11,7 @@ passwords have been set. The `elastic` user can be used to
 `kibana`:: The user Kibana uses to connect and communicate with Elasticsearch.
 `logstash_system`:: The user Logstash uses when storing monitoring information in Elasticsearch.
 `beats_system`:: The user the Beats use when storing monitoring information in Elasticsearch.
+`apm_system`:: The user APM uses when storing monitoring information in {es}.
 
 
 [float]
@@ -58,7 +59,8 @@ The +elasticsearch-setup-passwords+ tool is the simplest method to set the
 built-in users' passwords for the first time. It uses the `elastic` user's
 bootstrap password to run user management API requests. For example, you can run
 the command in an "interactive" mode, which prompts you to enter new passwords
-for the `elastic`, `kibana`, `logstash_system`, and `beats_system` users:
+for the `elastic`, `kibana`, `logstash_system`, `beats_system`, and `apm_system` 
+users:
 
 [source,shell]
 --------------------------------------------------

--- a/docs/en/stack/security/authentication/built-in-users.asciidoc
+++ b/docs/en/stack/security/authentication/built-in-users.asciidoc
@@ -11,7 +11,7 @@ passwords have been set. The `elastic` user can be used to
 `kibana`:: The user Kibana uses to connect and communicate with Elasticsearch.
 `logstash_system`:: The user Logstash uses when storing monitoring information in Elasticsearch.
 `beats_system`:: The user the Beats use when storing monitoring information in Elasticsearch.
-`apm_system`:: The user APM uses when storing monitoring information in {es}.
+`apm_system`:: The user the APM server uses when storing monitoring information in {es}.
 
 
 [float]

--- a/docs/en/stack/security/authentication/built-in-users.asciidoc
+++ b/docs/en/stack/security/authentication/built-in-users.asciidoc
@@ -97,7 +97,7 @@ since at that point the bootstrap password is no longer required.
 
 [float]
 [[add-built-in-user-passwords]]
-==== Adding Built-in User Passwords To {kib}, Logstash, and Beats
+==== Adding built-in user passwords to {kib}, Logstash, Beats, and APM
 
 After the `kibana` user password is set, you need to update the {kib} server
 with the new password by setting `elasticsearch.password` in the `kibana.yml`
@@ -142,11 +142,23 @@ xpack.monitoring.elasticsearch.username: beats_system
 xpack.monitoring.elasticsearch.password: beatspassword
 ----------------------------------------------------------
 
+The `apm_system` user is used internally within APM when monitoring is enabled.
+
+To enable this feature in APM, you need to update the 
+{apm-server-ref}/configuring-howto-apm-server.html[APM configuration file] to 
+reference the correct username and password. For example:
+
+[source,yaml]
+----------------------------------------------------------
+xpack.monitoring.elasticsearch.username: apm_system
+xpack.monitoring.elasticsearch.password: apmserverpassword
+----------------------------------------------------------
+
 If you have upgraded from an older version of {es}, then you may not have set a
-password for the `beats_system` user. If this is the case, then you should use
-the *Management > Users* page in {kib} or the
+password for the `apm_system` or `beats_system` users. If this is the case, 
+then you should use the *Management > Users* page in {kib} or the
 {ref}/security-api-change-password.html[Change Password API] to set a password
-for this user.
+for these users.
 
 [float]
 [[disabling-default-password]]

--- a/docs/en/stack/security/authorization/built-in-roles.asciidoc
+++ b/docs/en/stack/security/authorization/built-in-roles.asciidoc
@@ -10,6 +10,29 @@ themselves.
 {security} also provides a set of built-in roles you can explicitly assign
 to users. These roles have a fixed set of privileges and cannot be updated.
 
+[[built-in-roles-apm-system]] `apm_system` ::
+Grants access necessary for the APM system user to send system-level data
+(such as monitoring) to {es}.
+
+[[built-in-roles-beats-admin]] `beats_admin` ::
+Grants access to the `.management-beats` index, which contains configuration
+information for the Beats.
+
+[[built-in-roles-beats-system]] `beats_system` ::
+Grants access necessary for the Beats system user to send system-level data
+(such as monitoring) to {es}.
++
+--
+[NOTE] 
+===============================
+* This role should not be assigned to users as the granted permissions may
+change between releases.
+* This role does not provide access to the beats indices and is not
+suitable for writing beats output to {es}.
+===============================
+
+--
+
 [[built-in-roles-ingest-user]] `ingest_admin` ::
 Grants access to manage *all* index templates and *all* ingest pipeline configurations.
 +
@@ -44,25 +67,15 @@ Grants access necessary for the Logstash system user to send system-level data
 (such as monitoring) to {es}. For more information, see
 {logstash-ref}/ls-security.html[Configuring Security in Logstash].
 +
-NOTE: This role should not be assigned to users as the granted permissions may
+--
+[NOTE] 
+===============================
+* This role should not be assigned to users as the granted permissions may
 change between releases.
-+
-NOTE: This role does not provide access to the logstash indices and is not
+* This role does not provide access to the logstash indices and is not
 suitable for use within a Logstash pipeline.
-
-[[built-in-roles-beats-admin]] `beats_admin` ::
-Grants access to the `.management-beats` index, which contains configuration
-information for the Beats.
-
-[[built-in-roles-beats-system]] `beats_system` ::
-Grants access necessary for the Beats system user to send system-level data
-(such as monitoring) to {es}.
-+
-NOTE: This role should not be assigned to users as the granted permissions may
-change between releases.
-+
-NOTE: This role does not provide access to the beats indices and is not
-suitable for writing beats output to {es}.
+===============================
+--
 
 [[built-in-roles-ml-admin]] `machine_learning_admin`::
 Grants `manage_ml` cluster privileges and read access to the `.ml-*` indices.

--- a/docs/en/stack/security/get-started-builtin-users.asciidoc
+++ b/docs/en/stack/security/get-started-builtin-users.asciidoc
@@ -1,5 +1,5 @@
 There are built-in users that you can use for specific administrative purposes:
-`elastic`, `kibana`, `logstash_system`, and `beats_system`. 
+`elastic`, `kibana`, `logstash_system`, `apm_system`, and `beats_system`. 
 
 Before you can use them, you must set their passwords:
 

--- a/docs/en/stack/security/get-started-security.asciidoc
+++ b/docs/en/stack/security/get-started-security.asciidoc
@@ -50,9 +50,9 @@ include::get-started-builtin-users.asciidoc[]
 You need these built-in users in subsequent steps, so choose passwords that you 
 can remember!
 
-NOTE: This tutorial does not use the built-in `logstash_system` and 
-`beats_system` users, which are typically associated with monitoring. For more 
-information, see 
+NOTE: This tutorial does not use the built-in `apm_system`, `logstash_system`, 
+and `beats_system` users, which are typically associated with monitoring. For 
+more information, see 
 {logstash-ref}/ls-security.html#ls-monitoring-user[Configuring credentials for {ls} monitoring]
 and {metricbeat-ref}/monitoring.html[Monitoring {metricbeat}].  
   


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/32515

This PR adds information about the apm_system builtin user and role to the Stack Overview. 
