### PR TITLE
[DOCS] Fixes broken link to Cloud documentation

### DIFF
--- a/docs/upgrading-stack.asciidoc
+++ b/docs/upgrading-stack.asciidoc
@@ -139,5 +139,5 @@ To avoid downtime on production clusters due to major version upgrades:
 
 . Delete the old cluster to stop incurring additional costs. You are billed extra only for the time that the additional cluster was running. Billing for usage is by the hour.
 
-To learn more about the upgrade process on Elastic Cloud, see {cloudref}/ec-upgrading.html[
+To learn more about the upgrade process on Elastic Cloud, see {cloudref}/ec-upgrade-cluster.html[
 Upgrade Versions] and {cloudref}/ec-configure.html[Configuring Elastic Cloud].


### PR DESCRIPTION
This PR fixes the following broken links:

> 14:41:18 Bad cross-document links:
> 14:41:18   html/en/elastic-stack/5.0/upgrading-elastic-stack.html:
> 14:41:18    - en/cloud/current/ec-upgrading.html
> 14:41:18   html/en/elastic-stack/5.1/upgrading-elastic-stack.html:
> 14:41:18    - en/cloud/current/ec-upgrading.html
> 14:41:18   html/en/elastic-stack/5.2/upgrading-elastic-stack.html:
> 14:41:18    - en/cloud/current/ec-upgrading.html
> 14:41:18   html/en/elastic-stack/5.3/upgrading-elastic-stack.html:
> 14:41:18    - en/cloud/current/ec-upgrading.html
> 14:41:18   html/en/elastic-stack/5.4/upgrading-elastic-stack.html:
> 14:41:18    - en/cloud/current/ec-upgrading.html
> 14:41:18   html/en/elastic-stack/5.5/upgrading-elastic-stack.html:
> 14:41:18    - en/cloud/current/ec-upgrading.html
> 14:41:18   html/en/elastic-stack/5.6/upgrading-elastic-stack.html:
> 14:41:18    - en/cloud/current/ec-upgrading.html