### PR TITLE
[6.x] Documents built-in `beats_admin` role | Clarifying purpose of index

### DIFF
--- a/docs/en/stack/security/authorization/built-in-roles.asciidoc
+++ b/docs/en/stack/security/authorization/built-in-roles.asciidoc
@@ -14,6 +14,10 @@ to users. These roles have a fixed set of privileges and cannot be updated.
 Grants access necessary for the APM system user to send system-level data
 (such as monitoring) to {es}.
 
+[[built-in-roles-beats-admin]] `beats_admin` ::
+Grants access to the `.management-beats` index, which contains configuration
+information for the Beats.
+
 [[built-in-roles-beats-system]] `beats_system` ::
 Grants access necessary for the Beats system user to send system-level data
 (such as monitoring) to {es}.
@@ -72,6 +76,16 @@ change between releases.
 suitable for use within a Logstash pipeline.
 ===============================
 --
+
+[[built-in-roles-beats-system]] `beats_system` ::
+Grants access necessary for the Beats system user to send system-level data
+(such as monitoring) to {es}.
++
+NOTE: This role should not be assigned to users as the granted permissions may
+change between releases.
++
+NOTE: This role does not provide access to the beats indices and is not
+suitable for writing beats output to {es}.
 
 [[built-in-roles-ml-admin]] `machine_learning_admin`::
 Grants `manage_ml` cluster privileges and read access to the `.ml-*` indices.

--- a/docs/en/stack/security/authorization/built-in-roles.asciidoc
+++ b/docs/en/stack/security/authorization/built-in-roles.asciidoc
@@ -77,16 +77,6 @@ suitable for use within a Logstash pipeline.
 ===============================
 --
 
-[[built-in-roles-beats-system]] `beats_system` ::
-Grants access necessary for the Beats system user to send system-level data
-(such as monitoring) to {es}.
-+
-NOTE: This role should not be assigned to users as the granted permissions may
-change between releases.
-+
-NOTE: This role does not provide access to the beats indices and is not
-suitable for writing beats output to {es}.
-
 [[built-in-roles-ml-admin]] `machine_learning_admin`::
 Grants `manage_ml` cluster privileges and read access to the `.ml-*` indices.
 


### PR DESCRIPTION
Backports the following commits to 6.x:
 - Documents built-in `beats_admin` role (#80)
 - Clarifying purpose of index (#80)