### PR TITLE
[DOCS] Documents built-in `beats_admin` role

### DIFF
--- a/docs/en/stack/security/authorization/built-in-roles.asciidoc
+++ b/docs/en/stack/security/authorization/built-in-roles.asciidoc
@@ -14,6 +14,9 @@ to users. These roles have a fixed set of privileges and cannot be updated.
 Grants access necessary for the APM system user to send system-level data
 (such as monitoring) to {es}.
 
+[[built-in-roles-beats-admin]] `beats_admin` ::
+Grants access to the `.management-beats` index for managing configurations.
+
 [[built-in-roles-beats-system]] `beats_system` ::
 Grants access necessary for the Beats system user to send system-level data
 (such as monitoring) to {es}.
@@ -26,7 +29,6 @@ change between releases.
 * This role does not provide access to the beats indices and is not
 suitable for writing beats output to {es}.
 ===============================
-
 --
 
 [[built-in-roles-ingest-user]] `ingest_admin` ::

--- a/docs/en/stack/security/authorization/built-in-roles.asciidoc
+++ b/docs/en/stack/security/authorization/built-in-roles.asciidoc
@@ -15,7 +15,8 @@ Grants access necessary for the APM system user to send system-level data
 (such as monitoring) to {es}.
 
 [[built-in-roles-beats-admin]] `beats_admin` ::
-Grants access to the `.management-beats` index for managing configurations.
+Grants access to the `.management-beats` index, which contains configuration 
+information for the Beats.
 
 [[built-in-roles-beats-system]] `beats_system` ::
 Grants access necessary for the Beats system user to send system-level data
@@ -73,7 +74,6 @@ change between releases.
 * This role does not provide access to the logstash indices and is not
 suitable for use within a Logstash pipeline.
 ===============================
---
 
 [[built-in-roles-ml-admin]] `machine_learning_admin`::
 Grants `manage_ml` cluster privileges and read access to the `.ml-*` indices.

--- a/docs/en/stack/security/authorization/built-in-roles.asciidoc
+++ b/docs/en/stack/security/authorization/built-in-roles.asciidoc
@@ -74,6 +74,7 @@ change between releases.
 * This role does not provide access to the logstash indices and is not
 suitable for use within a Logstash pipeline.
 ===============================
+--
 
 [[built-in-roles-ml-admin]] `machine_learning_admin`::
 Grants `manage_ml` cluster privileges and read access to the `.ml-*` indices.


### PR DESCRIPTION
Backport of https://github.com/elastic/stack-docs/pull/80.

Related to https://github.com/elastic/elasticsearch/pull/34305