### PR TITLE
[DOCS] Adding stack_monitoring_agent role

### DIFF
--- a/docs/en/stack/security/authentication/built-in-users.asciidoc
+++ b/docs/en/stack/security/authentication/built-in-users.asciidoc
@@ -12,6 +12,9 @@ passwords have been set. The `elastic` user can be used to
 `logstash_system`:: The user Logstash uses when storing monitoring information in Elasticsearch.
 `beats_system`:: The user the Beats use when storing monitoring information in Elasticsearch.
 `apm_system`:: The user the APM server uses when storing monitoring information in {es}.
+`remote_monitoring_user`:: The user {metricbeat} uses when collecting and 
+storing monitoring information in {es}. It has the `remote_monitoring_agent` and 
+`remote_monitoring_collector` built-in roles. 
 
 
 [float]
@@ -59,8 +62,8 @@ The +elasticsearch-setup-passwords+ tool is the simplest method to set the
 built-in users' passwords for the first time. It uses the `elastic` user's
 bootstrap password to run user management API requests. For example, you can run
 the command in an "interactive" mode, which prompts you to enter new passwords
-for the `elastic`, `kibana`, `logstash_system`, `beats_system`, and `apm_system` 
-users:
+for the `elastic`, `kibana`, `logstash_system`, `beats_system`, `apm_system`, 
+and `remote_monitoring_user` users:
 
 [source,shell]
 --------------------------------------------------
@@ -95,9 +98,11 @@ submit Change Password API requests for each built-in user. These methods are
 better suited for changing your passwords after the initial setup is complete,
 since at that point the bootstrap password is no longer required.
 
-[float]
 [[add-built-in-user-passwords]]
-==== Adding built-in user passwords to {kib}, Logstash, Beats, and APM
+
+[float]
+[[add-built-in-user-kibana]]
+==== Adding built-in user passwords to {kib}
 
 After the `kibana` user password is set, you need to update the {kib} server
 with the new password by setting `elasticsearch.password` in the `kibana.yml`
@@ -107,6 +112,12 @@ configuration file:
 -----------------------------------------------
 elasticsearch.password: kibanapassword
 -----------------------------------------------
+
+See {kibana-ref}/using-kibana-with-security.html[Configuring security in {kib}].
+
+[float]
+[[add-built-in-user-logstash]]
+==== Adding built-in user passwords to {ls} 
 
 The `logstash_system` user is used internally within Logstash when
 monitoring is enabled for Logstash.
@@ -130,6 +141,12 @@ PUT _xpack/security/user/logstash_system/_enable
 ---------------------------------------------------------------------
 // CONSOLE
 
+See {logstash-ref}/ls-security.html#ls-monitoring-user[Configuring credentials for {ls} monitoring]. 
+
+[float]
+[[add-built-in-user-beats]]
+==== Adding built-in user passwords to Beats
+
 The `beats_system` user is used internally within Beats when monitoring is
 enabled for Beats.
 
@@ -141,6 +158,21 @@ of your beats to reference the correct username and password. For example:
 xpack.monitoring.elasticsearch.username: beats_system
 xpack.monitoring.elasticsearch.password: beatspassword
 ----------------------------------------------------------
+
+For example, see {metricbeat-ref}/monitoring.html[Monitoring {metricbeat}]. 
+
+The `remote_monitoring_user` is used when {metricbeat} collects and stores 
+monitoring data for the {stack}. See <<monitoring-production>>. 
+
+If you have upgraded from an older version of {es}, then you may not have set a
+password for the `beats_system` or `remote_monitoring_user` users. If this is 
+the case, then you should use the *Management > Users* page in {kib} or the
+{ref}/security-api-change-password.html[Change Password API] to set a password
+for these users.
+
+[float]
+[[add-built-in-user-apm]]
+==== Adding built-in user passwords to APM
 
 The `apm_system` user is used internally within APM when monitoring is enabled.
 
@@ -154,8 +186,10 @@ xpack.monitoring.elasticsearch.username: apm_system
 xpack.monitoring.elasticsearch.password: apmserverpassword
 ----------------------------------------------------------
 
+See {apm-server-ref}/monitoring.html[Monitoring APM Server]. 
+
 If you have upgraded from an older version of {es}, then you may not have set a
-password for the `apm_system` or `beats_system` users. If this is the case, 
+password for the `apm_system` user. If this is the case, 
 then you should use the *Management > Users* page in {kib} or the
 {ref}/security-api-change-password.html[Change Password API] to set a password
 for these users.

--- a/docs/en/stack/security/authorization/built-in-roles.asciidoc
+++ b/docs/en/stack/security/authorization/built-in-roles.asciidoc
@@ -103,6 +103,10 @@ user has access to only their own reports. Reporting users should also be
 assigned the `kibana_user` role and a role that grants them access to the data 
 that will be used to generate reports.
 
+[[built-in-roles-stack-monitoring-agent]] `stack_monitoring_agent`::
+Grants the minimum privileges required for {metricbeat} to collect monitoring 
+data for the {stack} and write it into the monitoring indices (`.monitoring-*`). 
+
 [[built-in-roles-superuser]] `superuser`::
 Grants full access to the cluster, including all indices and data. A user with
 the `superuser` role can also manage users and roles and

--- a/docs/en/stack/security/authorization/built-in-roles.asciidoc
+++ b/docs/en/stack/security/authorization/built-in-roles.asciidoc
@@ -93,8 +93,12 @@ privileges necessary for reading basic cluster information. Monitoring users sho
 also be assigned the `kibana_user` role.
 
 [[built-in-roles-remote-monitoring-agent]] `remote_monitoring_agent`::
-Grants the minimum privileges required for a remote monitoring agent to write data
-into this cluster.
+Grants the minimum privileges required to write data into the monitoring indices
+(`.monitoring-*`). This role also has the privileges necessary to create 
+{metricbeat} indices (`metricbeat-*`) and write data into them. 
+
+[[built-in-roles-remote-monitoring-collector]] `remote_monitoring_collector`::
+Grants the minimum privileges required to collect monitoring data for the {stack}.
 
 [[built-in-roles-reporting-user]] `reporting_user`::
 Grants the specific privileges required for users of {reporting} other than those
@@ -103,9 +107,6 @@ user has access to only their own reports. Reporting users should also be
 assigned the `kibana_user` role and a role that grants them access to the data 
 that will be used to generate reports.
 
-[[built-in-roles-stack-monitoring-agent]] `stack_monitoring_agent`::
-Grants the minimum privileges required for {metricbeat} to collect monitoring 
-data for the {stack} and write it into the monitoring indices (`.monitoring-*`). 
 
 [[built-in-roles-superuser]] `superuser`::
 Grants full access to the cluster, including all indices and data. A user with


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/34369

Updates to https://www.elastic.co/guide/en/elastic-stack-overview/master/monitoring-production.html will occur in a separate PR.