### PR TITLE
[DOCS] Clarify description of reporting_user role

### DIFF
--- a/docs/en/stack/security/authorization/built-in-roles.asciidoc
+++ b/docs/en/stack/security/authorization/built-in-roles.asciidoc
@@ -98,9 +98,10 @@ into this cluster.
 
 [[built-in-roles-reporting-user]] `reporting_user`::
 Grants the specific privileges required for users of {reporting} other than those
-required to use {kib}. This role grants access to the reporting indices. Reporting
-users should also be assigned the `kibana_user` role and a role that grants them
-access to the data that will be used to generate reports with.
+required to use {kib}. This role grants access to the reporting indices; each 
+user has access to only their own reports. Reporting users should also be 
+assigned the `kibana_user` role and a role that grants them access to the data 
+that will be used to generate reports.
 
 [[built-in-roles-superuser]] `superuser`::
 Grants full access to the cluster, including all indices and data. A user with


### PR DESCRIPTION
Related to https://github.com/elastic/kibana/pull/23974 and https://github.com/elastic/kibana/issues/21592

This PR clarifies what members of the reporting_user role can do. 