### PR TITLE
[DOCS] Fixes broken links in Glossary

### DIFF
--- a/docs/en/glossary/index.asciidoc
+++ b/docs/en/glossary/index.asciidoc
@@ -6,8 +6,8 @@
 :logstash-terms:       true
 :xpack-terms:          true
 
-include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 include::{asciidoc-dir}/../../shared/versions.asciidoc[]
+include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
 include::intro.asciidoc[]
 include::glossary.asciidoc[]


### PR DESCRIPTION
Fixes https://github.com/elastic/stack-docs/issues/130

The {ref} attribute value contains a {branch} attribute, so the versions.asciidoc (which defines :branch:) must be included before the attributes.asciidoc (which defines :ref:).