### PR TITLE
[DOCS] Adds CCR to Stack Overview

### DIFF
--- a/docs/en/stack/index.asciidoc
+++ b/docs/en/stack/index.asciidoc
@@ -32,7 +32,7 @@ include::{xes-repo-dir}/watcher/index.asciidoc[]
 :edit_url: https://github.com/elastic/stack-docs/edit/{branch}/docs/en/stack/ml/index.asciidoc
 include::ml/index.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/docs/ccr/index.asciidoc
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/docs/reference/ccr/index.asciidoc
 include::{es-repo-dir}/ccr/index.asciidoc[]
 
 :edit_url:

--- a/docs/en/stack/index.asciidoc
+++ b/docs/en/stack/index.asciidoc
@@ -32,6 +32,9 @@ include::{xes-repo-dir}/watcher/index.asciidoc[]
 :edit_url: https://github.com/elastic/stack-docs/edit/{branch}/docs/en/stack/ml/index.asciidoc
 include::ml/index.asciidoc[]
 
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/docs/ccr/index.asciidoc
+include::{es-repo-dir}/ccr/index.asciidoc[]
+
 :edit_url:
 include::troubleshooting.asciidoc[]
 


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/34726

This PR adds the "Overview" and "Getting started" content for cross-cluster replication to the Elastic Stack Overview. For example:

![ccrtoc](https://user-images.githubusercontent.com/26471269/47449024-67a85d00-d776-11e8-8071-c0af4ae0a7df.gif)



NOTE: This PR must be merged *after* https://github.com/elastic/elasticsearch/pull/34726
