### PR TITLE
[DOCS] Updates 6.x version information

### DIFF
--- a/docs/en/getting-started/index.asciidoc
+++ b/docs/en/getting-started/index.asciidoc
@@ -14,7 +14,7 @@
 :kib-repo-dir:      {docdir}/../../../../kibana/docs
 :xes-repo-dir:      {docdir}/../../../../elasticsearch/x-pack/docs/en
 
-include::{asciidoc-dir}/../../shared/versions65.asciidoc[]
+include::{asciidoc-dir}/../../shared/versions66.asciidoc[]
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
 include::get-started-stack.asciidoc[]

--- a/docs/en/stack/index.asciidoc
+++ b/docs/en/stack/index.asciidoc
@@ -15,7 +15,7 @@
 :xes-repo-dir:      {docdir}/../../../../elasticsearch/x-pack/docs/en
 :es-repo-dir:       {docdir}/../../../../elasticsearch/docs/reference
 
-include::{asciidoc-dir}/../../shared/versions65.asciidoc[]
+include::{asciidoc-dir}/../../shared/versions66.asciidoc[]
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
 include::introduction.asciidoc[]


### PR DESCRIPTION
Related to https://github.com/elastic/docs/pull/445

This PR updates the 6.x branch to use the appropriate version information from the shared docs files. 