### PR TITLE
[DOCS] Minimizes the duplicated information in the production monitoring page

### DIFF
--- a/docs/en/stack/monitoring/production.asciidoc
+++ b/docs/en/stack/monitoring/production.asciidoc
@@ -6,12 +6,12 @@ By default, {metricbeat} and the {xpack} monitoring agents on {es} index data
 into the cluster where they're running. In production, you should
 send data to a separate monitoring cluster so that historical monitoring
 data is available even if the nodes you are monitoring are not. Using
-a dedicated monitoring cluster also enables you to monitor multiple
+a dedicated _monitoring cluster_ also enables you to monitor multiple
 clusters from a central location.
 
 To store monitoring data in a separate cluster:
 
-. {ref}/configuring-monitoring.html[Set up the {es} cluster you want to use for monitoring]. 
+. Set up the {es} cluster you want to use as the monitoring cluster. 
 For example, you might set up a two host cluster with the nodes `es-mon-1` and 
 `es-mon-2`.
 +
@@ -20,6 +20,9 @@ NOTE: To monitor an {es} 7.x cluster, you must run {es}
 7.x on the monitoring cluster.
 
 --
+
+. Configure {monitoring} in {es}, such that it sends its data to the monitoring 
+cluster. 
 
 . {kibana-ref}/monitoring-xpack-kibana.html[Configure {monitoring}] in {kib}.
 +

--- a/docs/en/stack/monitoring/production.asciidoc
+++ b/docs/en/stack/monitoring/production.asciidoc
@@ -4,10 +4,11 @@
 
 By default, {metricbeat} and the {monitoring} agents on {es} index data
 into the cluster where they're running. In production, you should
-send data to a separate monitoring cluster so that historical monitoring
-data is available even if the nodes you are monitoring are not. Using
-a dedicated _monitoring cluster_ also enables you to monitor multiple
-clusters from a central location.
+send data to a separate _monitoring cluster_ so that historical monitoring
+data is available even if the nodes you are monitoring are not. 
+
+If you have at least a gold license, using a dedicated monitoring cluster also 
+enables you to monitor multiple clusters from a central location.
 
 To store monitoring data in a separate cluster:
 
@@ -21,18 +22,32 @@ NOTE: To monitor an {es} 7.x cluster, you must run {es}
 
 --
 
-. If you want to collect monitoring data about your production cluster, 
-configure it to send its data to the monitoring cluster. 
+. Configure your production cluster to collect data and send it to the 
+monitoring cluster. 
 
-** To use {metricbeat} to collect and send the data, see 
-{ref}/configuring-metricbeat.html[Monitoring {es} with {metricbeat}].
+** beta[] To use {metricbeat}, see 
+{ref}/configuring-metricbeat.html[Monitoring {es} with {metricbeat}]. This option 
+is available in 6.5 and later versions. 
 
-** To use exporters, see {ref}/configuring-monitoring.html[Configuring monitoring in {es}].
+** To use HTTP exporters, see {ref}/configuring-monitoring.html[Configuring monitoring in {es}].
 
-. (Optional) {logstash-ref}/configuring-logstash.html[Configure monitoring in {ls}]. 
+. (Optional)
+{logstash-ref}/configuring-logstash.html[Configure {ls} to collect data and send it to the monitoring cluster]. 
++
+--
+NOTE: You must configure HTTP exporters in the production cluster to route this 
+data to the monitoring cluster. It cannot be accomplished by using {metricbeat}. 
 
-. (Optional) {kibana-ref}/monitoring-xpack-kibana.html[Configure {kib} to collect and send 
-monitoring data].
+--
+
+. (Optional) Configure {kib} to collect data and send it to the monitoring cluster:
+
+** beta[] To use {metricbeat}, see 
+{kibana-ref}/monitoring-metricbeat.html[Monitoring {kib} with {metricbeat}]. This 
+option is available in 6.4 and later versions. 
+
+** To use HTTP exporters, see 
+{kibana-ref}/monitoring-xpack-kibana.html[Configuring monitoring in {kib}].
 
 . {kibana-ref}/monitoring-data.html[View the monitoring data in {kib}]. 
 +

--- a/docs/en/stack/monitoring/production.asciidoc
+++ b/docs/en/stack/monitoring/production.asciidoc
@@ -2,7 +2,7 @@
 [[monitoring-production]]
 == Monitoring in a production environment
 
-By default, {metricbeat} and the {xpack} monitoring agents on {es} index data
+By default, {metricbeat} and the {monitoring} agents on {es} index data
 into the cluster where they're running. In production, you should
 send data to a separate monitoring cluster so that historical monitoring
 data is available even if the nodes you are monitoring are not. Using
@@ -24,82 +24,17 @@ NOTE: To monitor an {es} 7.x cluster, you must run {es}
 . If you want to collect monitoring data about your production cluster, 
 configure it to send its data to the monitoring cluster. 
 
-.. To use {metricbeat} to collect and send the data, see 
+** To use {metricbeat} to collect and send the data, see 
 {ref}/configuring-metricbeat.html[Monitoring {es} with {metricbeat}].
 
-.. To use exporters, see {ref}/configuring-monitoring.html[Configuring monitoring in {es}].
-... Configure each {es} node in the cluster you are monitoring to send metrics 
-to your monitoring cluster by configuring an HTTP exporter in the
-`xpack.monitoring.exporters` settings in `elasticsearch.yml`.
-+
---
-[source,yaml]
---------------------------------------------------
-xpack.monitoring.exporters:
-  id1:
-    type: http
-    host: ["http://es-mon-1:9200", "http://es-mon2:9200"] <1>
-    auth.username: remote_monitor <2>
-    auth.password: changeme
---------------------------------------------------
-<1> If SSL/TLS is enabled on the monitoring cluster, you must
-connect through HTTPS.
-<2> If {security} is disabled on the monitoring cluster, you can
-omit `auth.username` and `auth.password`.
---
+** To use exporters, see {ref}/configuring-monitoring.html[Configuring monitoring in {es}].
 
-... If SSL/TLS is enabled on the monitoring cluster, specify the trusted
-CA certificates that will be used to verify the identity of the nodes
-in the monitoring cluster.
-+
---
-To add a CA certificate to an {es} node's trusted certificates, you
-can specify the location of the PEM encoded certificate with the
-`certificate_authorities` setting:
+. (Optional) {logstash-ref}/configuring-logstash.html[Configure monitoring in {ls}]. 
 
-[source,yaml]
---------------------------------------------------
-xpack.monitoring.exporters:
-  id1:
-    type: http
-    host: ["https://es-mon1:9200", "https://es-mon2:9200"]
-    auth:
-      username: agent-user
-      password: password
-    ssl:
-      certificate_authorities: [ "/path/to/ca.crt" ]
---------------------------------------------------
-
-Alternatively, you can configure trusted certificates using a truststore
-(a Java Keystore file that contains the certificates):
-
-[source,yaml]
---------------------------------------------------
-xpack.monitoring.exporters:
-  id1:
-    type: http
-    host: ["https://es-mon1:9200", "https://es-mon2:9200"]
-    auth:
-      username: remote_monitor
-      password: changeme
-    ssl:
-      truststore.path: /path/to/file
-      truststore.password: password
---------------------------------------------------
-
---
-
-... Restart {es} on the nodes in your production cluster.
-+
---
-TIP: You may want to temporarily {ref}/modules-cluster.html[disable shard
-allocation] before you restart your nodes to avoid unnecessary shard
-reallocation during the install process.
-
---
-
-. {kibana-ref}/monitoring-xpack-kibana.html[Configure {kib} to collect and send 
+. (Optional) {kibana-ref}/monitoring-xpack-kibana.html[Configure {kib} to collect and send 
 monitoring data].
+
+. {kibana-ref}/monitoring-data.html[View the monitoring data in {kib}]. 
 +
 --
 NOTE: {kib} makes requests to the monitoring cluster as the logged in user.
@@ -107,60 +42,3 @@ The username and password credentials must therefore be valid on both the {kib}
 server and the monitoring cluster.
 
 --
-
-. Create a user on the monitoring cluster that has the
-`remote_monitoring_agent` role. These credentials will be used when
-data is shipped from the {es} cluster you are monitoring to
-your dedicated monitoring cluster. For example, the following request
-creates a `remote_monitor` user that has the `remote_monitoring_agent` role:
-+
---
-[source, sh]
----------------------------------------------------------------
-POST /_xpack/security/user/remote_monitor
-{
-  "password" : "changeme",
-  "roles" : [ "remote_monitoring_agent"],
-  "full_name" : "Internal Agent For Remote Monitoring"
-}
----------------------------------------------------------------
-// CONSOLE
---
-
-. To verify your {monitoring} installation, point your web browser at your {kib}
-host, and select **Monitoring** from the side navigation. When security is enabled,
-to view the monitoring dashboards you must log in to {kib} as a user who has
-both the `kibana_user` and `monitoring_user` roles. For example:
-+
---
-[source,js]
---------------------------------------------------
-POST /_xpack/security/user/stack-monitor
-{
-  "password" : "changeme",
-  "roles" : [ "kibana_user", "monitoring_user" ]
-}
---------------------------------------------------
-// CONSOLE
-
-//image:images/monitoring.jpg["Monitoring",link="images/monitoring.jpg"]
---
-////
-. If you are using {metricbeat} to monitor the {stack} and {security} is enabled, 
-you must provide a user ID and password in your configuration files so that 
-{metricbeat} collect metrics successfully. You must also add this information to 
-your `metricbeat.yml` file so that {metricbeat} can send the metrics to your 
-monitoring cluster. 
-+
---
-TIP: There is a `stack_monitoring_agent` built-in role that grants the privileges 
-necessary for {metricbeat} to monitor {stack} products. See <<built-in-roles>>.
- 
---
-
-.. Create or identify a user that you want to use in the {metricbeat} configuration 
-files. Give this user the `stack_monitoring_agent` role. 
-
-.. Add the `username` and `password` settings to the {kib} module configuration 
-file. 
- ////

--- a/docs/en/stack/monitoring/production.asciidoc
+++ b/docs/en/stack/monitoring/production.asciidoc
@@ -2,10 +2,14 @@
 [[monitoring-production]]
 == Monitoring in a production environment
 
-By default, {metricbeat} and the {monitoring} agents on {es} index data
+By default, the {monitoring} agents on {es} index data
 into the cluster where they're running. In production, you should
 send data to a separate _monitoring cluster_ so that historical monitoring
 data is available even if the nodes you are monitoring are not. 
+
+beta[] In 6.4 and later, you can use {metricbeat} to ship monitoring data about 
+{kib} to a separate monitoring cluster. In 6.5 and later, you can do the same 
+for {es}. 
 
 If you have at least a gold license, using a dedicated monitoring cluster also 
 enables you to monitor multiple clusters from a central location.
@@ -43,18 +47,44 @@ PUT _cluster/settings
 // CONSOLE
 --
 
-. (Optional) Create a dedicated {kib} instance for monitoring, rather than using 
-a single {kib} instance to access both your production cluster and monitoring 
-cluster. 
+.. If the {es} {security-features} are enabled on the monitoring cluster, create 
+users that can send and retrieve monitoring data. 
++
+--
+NOTE: If you plan to use {kib} to view monitoring data, username and password 
+credentials must be valid on both the {kib} server and the monitoring cluster. 
 
-.. Set the `elasticsearch.url` setting in the `kibana.yml` file such that it 
-contains the appropriate URL for your monitoring cluster. For more information 
-about this setting, see {kibana-ref}/settings.html[Configuring {kib}]. 
+--
 
-.. (Optional) Disable the collection of monitoring data in this {kib} instance. 
-Set the `xpack.monitoring.kibana.collection.enabled` setting to `false` in the 
-`kibana.yml` file. For more information about this setting, see 
-{kibana-ref}/monitoring-settings-kb.html[Monitoring settings in {kib}]. 
+*** beta[] If you plan to use {metricbeat} to collect data about {es} or {kib}, 
+create a user that has the `remote_monitoring_collector` built-in role and a 
+user that has the `remote_monitoring_agent` 
+<<built-in-roles-remote-monitoring-agent,built-in role>>. Alternatively, use the 
+`remote_monitoring_user` <<built-in-users,built-in user>>. 
+
+*** If you plan to use HTTP exporters to route data through your production 
+cluster, create a user that has the `remote_monitoring_agent` 
+<<built-in-roles-remote-monitoring-agent,built-in role>>. 
++
+--
+For example, the 
+following request creates a `remote_monitor` user that has the 
+`remote_monitoring_agent` role:
+
+[source, sh]
+---------------------------------------------------------------
+POST /_xpack/security/user/remote_monitor
+{
+  "password" : "changeme",
+  "roles" : [ "remote_monitoring_agent"],
+  "full_name" : "Internal Agent For Remote Monitoring"
+}
+---------------------------------------------------------------
+// CONSOLE
+// TEST[skip:needs-gold+-license]
+
+Alternatively, use the `remote_monitoring_user` <<built-in-users,built-in user>>. 
+--
 
 . Configure your production cluster to collect data and send it to the 
 monitoring cluster. 
@@ -83,11 +113,13 @@ option is available in 6.4 and later versions.
 ** To use HTTP exporters, see 
 {kibana-ref}/monitoring-xpack-kibana.html[Configuring monitoring in {kib}].
 
-. {kibana-ref}/monitoring-data.html[View the monitoring data in {kib}]. 
-+
---
-NOTE: {kib} makes requests to the monitoring cluster as the logged in user.
-The username and password credentials must therefore be valid on both the {kib}
-server and the monitoring cluster.
+. (Optional) Create a dedicated {kib} instance for monitoring, rather than using 
+a single {kib} instance to access both your production cluster and monitoring 
+cluster.
 
---
+.. (Optional) Disable the collection of monitoring data in this {kib} instance. 
+Set the `xpack.monitoring.kibana.collection.enabled` setting to `false` in the 
+`kibana.yml` file. For more information about this setting, see 
+{kibana-ref}/monitoring-settings-kb.html[Monitoring settings in {kib}]. 
+
+. {kibana-ref}/monitoring-data.html[Configure {kib} to retrieve and display the monitoring data]. 

--- a/docs/en/stack/monitoring/production.asciidoc
+++ b/docs/en/stack/monitoring/production.asciidoc
@@ -89,11 +89,10 @@ Alternatively, use the `remote_monitoring_user` <<built-in-users,built-in user>>
 . Configure your production cluster to collect data and send it to the 
 monitoring cluster. 
 
-** beta[] To use {metricbeat}, see 
-{ref}/configuring-metricbeat.html[Monitoring {es} with {metricbeat}]. This option 
+** beta[] {ref}/configuring-metricbeat.html[Use {metricbeat}]. This option 
 is available in 6.5 and later versions. 
 
-** To use HTTP exporters, see {ref}/configuring-monitoring.html[Configuring monitoring in {es}].
+** {ref}/configuring-monitoring.html[Use HTTP exporters].
 
 . (Optional)
 {logstash-ref}/configuring-logstash.html[Configure {ls} to collect data and send it to the monitoring cluster]. 
@@ -106,12 +105,10 @@ data to the monitoring cluster. It cannot be accomplished by using {metricbeat}.
 
 . (Optional) Configure {kib} to collect data and send it to the monitoring cluster:
 
-** beta[] To use {metricbeat}, see 
-{kibana-ref}/monitoring-metricbeat.html[Monitoring {kib} with {metricbeat}]. This 
+** beta[] {kibana-ref}/monitoring-metricbeat.html[Use {metricbeat}]. This 
 option is available in 6.4 and later versions. 
 
-** To use HTTP exporters, see 
-{kibana-ref}/monitoring-xpack-kibana.html[Configuring monitoring in {kib}].
+** {kibana-ref}/monitoring-kibana.html[Use HTTP exporters].
 
 . (Optional) Create a dedicated {kib} instance for monitoring, rather than using 
 a single {kib} instance to access both your production cluster and monitoring 

--- a/docs/en/stack/monitoring/production.asciidoc
+++ b/docs/en/stack/monitoring/production.asciidoc
@@ -21,40 +21,15 @@ NOTE: To monitor an {es} 7.x cluster, you must run {es}
 
 --
 
-. Configure {monitoring} in {es}, such that it sends its data to the monitoring 
-cluster. 
+. If you want to collect monitoring data about your production cluster, 
+configure it to send its data to the monitoring cluster. 
 
-. {kibana-ref}/monitoring-xpack-kibana.html[Configure {monitoring}] in {kib}.
-+
---
-NOTE: {kib} makes requests to the monitoring cluster as the logged in user.
-The username and password credentials must therefore be valid on both the {kib}
-server and the monitoring cluster.
+.. To use {metricbeat} to collect and send the data, see 
+{ref}/configuring-metricbeat.html[Monitoring {es} with {metricbeat}].
 
---
-
-. Create a user on the monitoring cluster that has the
-`remote_monitoring_agent` role. These credentials will be used when
-data is shipped from the {es} cluster you are monitoring to
-your dedicated monitoring cluster. For example, the following request
-creates a `remote_monitor` user that has the `remote_monitoring_agent` role:
-+
---
-[source, sh]
----------------------------------------------------------------
-POST /_xpack/security/user/remote_monitor
-{
-  "password" : "changeme",
-  "roles" : [ "remote_monitoring_agent"],
-  "full_name" : "Internal Agent For Remote Monitoring"
-}
----------------------------------------------------------------
-// CONSOLE
---
-
-. Configure each {es} node in the cluster you are
-monitoring to send metrics to your monitoring cluster by
-configuring an HTTP exporter in the
+.. To use exporters, see {ref}/configuring-monitoring.html[Configuring monitoring in {es}].
+... Configure each {es} node in the cluster you are monitoring to send metrics 
+to your monitoring cluster by configuring an HTTP exporter in the
 `xpack.monitoring.exporters` settings in `elasticsearch.yml`.
 +
 --
@@ -73,7 +48,7 @@ connect through HTTPS.
 omit `auth.username` and `auth.password`.
 --
 
-. If SSL/TLS is enabled on the monitoring cluster, specify the trusted
+... If SSL/TLS is enabled on the monitoring cluster, specify the trusted
 CA certificates that will be used to verify the identity of the nodes
 in the monitoring cluster.
 +
@@ -114,13 +89,42 @@ xpack.monitoring.exporters:
 
 --
 
-. Restart {es} on the nodes in your production cluster.
+... Restart {es} on the nodes in your production cluster.
 +
 --
 TIP: You may want to temporarily {ref}/modules-cluster.html[disable shard
 allocation] before you restart your nodes to avoid unnecessary shard
 reallocation during the install process.
 
+--
+
+. {kibana-ref}/monitoring-xpack-kibana.html[Configure {kib} to collect and send 
+monitoring data].
++
+--
+NOTE: {kib} makes requests to the monitoring cluster as the logged in user.
+The username and password credentials must therefore be valid on both the {kib}
+server and the monitoring cluster.
+
+--
+
+. Create a user on the monitoring cluster that has the
+`remote_monitoring_agent` role. These credentials will be used when
+data is shipped from the {es} cluster you are monitoring to
+your dedicated monitoring cluster. For example, the following request
+creates a `remote_monitor` user that has the `remote_monitoring_agent` role:
++
+--
+[source, sh]
+---------------------------------------------------------------
+POST /_xpack/security/user/remote_monitor
+{
+  "password" : "changeme",
+  "roles" : [ "remote_monitoring_agent"],
+  "full_name" : "Internal Agent For Remote Monitoring"
+}
+---------------------------------------------------------------
+// CONSOLE
 --
 
 . To verify your {monitoring} installation, point your web browser at your {kib}

--- a/docs/en/stack/monitoring/production.asciidoc
+++ b/docs/en/stack/monitoring/production.asciidoc
@@ -145,3 +145,22 @@ POST /_xpack/security/user/stack-monitor
 
 //image:images/monitoring.jpg["Monitoring",link="images/monitoring.jpg"]
 --
+////
+. If you are using {metricbeat} to monitor the {stack} and {security} is enabled, 
+you must provide a user ID and password in your configuration files so that 
+{metricbeat} collect metrics successfully. You must also add this information to 
+your `metricbeat.yml` file so that {metricbeat} can send the metrics to your 
+monitoring cluster. 
++
+--
+TIP: There is a `stack_monitoring_agent` built-in role that grants the privileges 
+necessary for {metricbeat} to monitor {stack} products. See <<built-in-roles>>.
+ 
+--
+
+.. Create or identify a user that you want to use in the {metricbeat} configuration 
+files. Give this user the `stack_monitoring_agent` role. 
+
+.. Add the `username` and `password` settings to the {kib} module configuration 
+file. 
+ ////

--- a/docs/en/stack/monitoring/production.asciidoc
+++ b/docs/en/stack/monitoring/production.asciidoc
@@ -22,6 +22,40 @@ NOTE: To monitor an {es} 7.x cluster, you must run {es}
 
 --
 
+.. (Optional) Verify that the collection of monitoring data is disabled on the 
+monitoring cluster. By default, the `xpack.monitoring.collection.enabled` setting 
+is `false`. 
++ 
+--
+For example, you can use the following APIs to review and change this setting:
+
+[source,js]
+----------------------------------
+GET _cluster/settings
+
+PUT _cluster/settings
+{
+  "persistent": {
+    "xpack.monitoring.collection.enabled": false
+  }
+}
+----------------------------------
+// CONSOLE
+--
+
+. (Optional) Create a dedicated {kib} instance for monitoring, rather than using 
+a single {kib} instance to access both your production cluster and monitoring 
+cluster. 
+
+.. Set the `elasticsearch.url` setting in the `kibana.yml` file such that it 
+contains the appropriate URL for your monitoring cluster. For more information 
+about this setting, see {kibana-ref}/settings.html[Configuring {kib}]. 
+
+.. (Optional) Disable the collection of monitoring data in this {kib} instance. 
+Set the `xpack.monitoring.kibana.collection.enabled` setting to `false` in the 
+`kibana.yml` file. For more information about this setting, see 
+{kibana-ref}/monitoring-settings-kb.html[Monitoring settings in {kib}]. 
+
 . Configure your production cluster to collect data and send it to the 
 monitoring cluster. 
 

--- a/docs/en/stack/monitoring/production.asciidoc
+++ b/docs/en/stack/monitoring/production.asciidoc
@@ -2,7 +2,7 @@
 [[monitoring-production]]
 == Monitoring in a production environment
 
-By default, {xpack} monitoring agents on {es} index data
+By default, {metricbeat} and the {xpack} monitoring agents on {es} index data
 into the cluster where they're running. In production, you should
 send data to a separate monitoring cluster so that historical monitoring
 data is available even if the nodes you are monitoring are not. Using


### PR DESCRIPTION
This PR cleans up the content in the following page: https://www.elastic.co/guide/en/elastic-stack-overview/master/monitoring-production.html

Related to https://github.com/elastic/elasticsearch/pull/35111