### PR TITLE
[DOCS] Adds remote_monitoring_user to security tutorial

### DIFF
--- a/docs/en/stack/security/get-started-builtin-users.asciidoc
+++ b/docs/en/stack/security/get-started-builtin-users.asciidoc
@@ -1,5 +1,6 @@
-There are built-in users that you can use for specific administrative purposes:
-`elastic`, `kibana`, `logstash_system`, `apm_system`, and `beats_system`. 
+There are <<built-in-users,built-in users>> that you can use for specific administrative purposes:
+`elastic`, `kibana`, `logstash_system`, `apm_system`, `beats_system`, and 
+`remote_monitoring_user`. 
 
 Before you can use them, you must set their passwords:
 

--- a/docs/en/stack/security/get-started-security.asciidoc
+++ b/docs/en/stack/security/get-started-security.asciidoc
@@ -51,8 +51,8 @@ You need these built-in users in subsequent steps, so choose passwords that you
 can remember!
 
 NOTE: This tutorial does not use the built-in `apm_system`, `logstash_system`, 
-and `beats_system` users, which are typically associated with monitoring. For 
-more information, see 
+`beats_system`, and `remote_monitoring_user` users, which are typically 
+associated with monitoring. For more information, see 
 {logstash-ref}/ls-security.html#ls-monitoring-user[Configuring credentials for {ls} monitoring]
 and {metricbeat-ref}/monitoring.html[Monitoring {metricbeat}].  
   


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/34369

This PR updates the security tutorial (https://www.elastic.co/guide/en/elastic-stack-overview/master/get-started-built-in-users.html) to include the remote_monitoring_user builtin user. 