### PR TITLE
[DOCS] Adds read_ccr and manage_ccr privileges

### DIFF
--- a/docs/en/stack/security/authorization/privileges.asciidoc
+++ b/docs/en/stack/security/authorization/privileges.asciidoc
@@ -29,6 +29,9 @@ This includes snapshotting, updating settings, and rerouting. It also includes
 obtaining snapshot and restore status. This privilege does not include the 
 ability to manage security.
 
+`manage_ccr`::
+TBD
+
 `manage_index_templates`::
 All operations on index templates.
 
@@ -61,6 +64,9 @@ to read and write all indices. Newer watches run with the security roles of the 
 who created or updated them.
 
 --
+
+`read_ccr`::
+TBD
 
 `transport_client`::
 All privileges necessary for a transport client to connect.  Required by the remote

--- a/docs/en/stack/security/authorization/privileges.asciidoc
+++ b/docs/en/stack/security/authorization/privileges.asciidoc
@@ -30,7 +30,9 @@ obtaining snapshot and restore status. This privilege does not include the
 ability to manage security.
 
 `manage_ccr`::
-TBD
+All {ccr} operations related to managing follower indices and auto-follow 
+patterns. It also includes the authority to grant the privileges necessary to 
+manage follower indices and auto-follow patterns.
 
 `manage_index_templates`::
 All operations on index templates.
@@ -66,7 +68,9 @@ who created or updated them.
 --
 
 `read_ccr`::
-TBD
+All read only {ccr} operations, such as getting information about indices and 
+metadata for leader indices in the cluster. It also includes the authority to 
+check whether users have the appropriate privileges to follow leader indices. 
 
 `transport_client`::
 All privileges necessary for a transport client to connect.  Required by the remote
@@ -89,7 +93,8 @@ close, delete, exists, flush, mapping, open, force merge, refresh, settings,
 search shards, templates, validate).
 
 `manage_follow_index`::
-TBD
+All actions that are required to manage a follower index, which includes pausing
+and resuming {ccr}. 
 
 `view_index_metadata`::
 Read-only access to index metadata (aliases, aliases exists, get index, exists, field mappings,

--- a/docs/en/stack/security/authorization/privileges.asciidoc
+++ b/docs/en/stack/security/authorization/privileges.asciidoc
@@ -32,7 +32,8 @@ ability to manage security.
 `manage_ccr`::
 All {ccr} operations related to managing follower indices and auto-follow 
 patterns. It also includes the authority to grant the privileges necessary to 
-manage follower indices and auto-follow patterns.
+manage follower indices and auto-follow patterns. This privilege is necessary 
+only on clusters that contain follower indices. 
 
 `manage_index_templates`::
 All operations on index templates.
@@ -71,6 +72,7 @@ who created or updated them.
 All read only {ccr} operations, such as getting information about indices and 
 metadata for leader indices in the cluster. It also includes the authority to 
 check whether users have the appropriate privileges to follow leader indices. 
+This privilege is necessary only on clusters that contain leader indices. 
 
 `transport_client`::
 All privileges necessary for a transport client to connect.  Required by the remote
@@ -93,8 +95,9 @@ close, delete, exists, flush, mapping, open, force merge, refresh, settings,
 search shards, templates, validate).
 
 `manage_follow_index`::
-All actions that are required to manage a follower index, which includes pausing
-and resuming {ccr}. 
+All actions that are required to manage the lifecycle of a follower index, which
+includes creating a follower index, closing it, and converting it to a regular 
+index. This privilege is necessary only on clusters that contain follower indices. 
 
 `view_index_metadata`::
 Read-only access to index metadata (aliases, aliases exists, get index, exists, field mappings,

--- a/docs/en/stack/security/authorization/privileges.asciidoc
+++ b/docs/en/stack/security/authorization/privileges.asciidoc
@@ -88,6 +88,9 @@ All `monitor` privileges plus index administration (aliases, analyze, cache clea
 close, delete, exists, flush, mapping, open, force merge, refresh, settings,
 search shards, templates, validate).
 
+`manage_follow_index`::
+TBD
+
 `view_index_metadata`::
 Read-only access to index metadata (aliases, aliases exists, get index, exists, field mappings,
 mappings, search shards, type exists, validate, warmers, settings). This


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/35434

This PR documents the new read_ccr and manage_ccr cluster privileges.