### PR TITLE
[DOCS] Kerberos troubleshooting documentation for problems with curl

### DIFF
--- a/docs/en/stack/security/troubleshooting.asciidoc
+++ b/docs/en/stack/security/troubleshooting.asciidoc
@@ -392,6 +392,30 @@ Kerberos/SPNEGO debug logging on JVM, add following JVM system properties:
 
 For more information about JVM system properties, see {ref}/jvm-options.html[configuring JVM options].
 
+`gss_init_sec_context() failed: An unsupported mechanism was requested`::
+
+`No credential found for: 1.2.840.113554.1.2.2 usage: Accept`::
++
+--
+
+You would usually see this error message on the client side when using `curl` to test {es} Kerberos
+setup, as the support for Kerberos Spnego is missing on the client due to an old version of curl.
+Kerberos realm in {es} only supports Spengo mechanism (Oid 1.3.6.1.5.5.2) and does not yet support
+Kerberos mechanism (Oid 1.2.840.113554.1.2.2).
+
+Make sure that:
+
+* you have installed curl version 7.49 or above as older versions of curl
+have known Kerberos bugs.
+
+* the curl installed on your machine has `GSS-API`, `Kerberos` and
+`SPNEGO` features listed when you invoke command `curl -V`. If not you will need to
+compile `curl` version with this support.
+
+To download latest curl version visit https://curl.haxx.se/download.html
+
+--
+
 [[trb-security-internalserver]]
 === Internal Server Error in Kibana
 

--- a/docs/en/stack/security/troubleshooting.asciidoc
+++ b/docs/en/stack/security/troubleshooting.asciidoc
@@ -368,6 +368,31 @@ the time on the machines within the domain is in sync.
 
 --
 
+`gss_init_sec_context() failed: An unsupported mechanism was requested`::
+
+`No credential found for: 1.2.840.113554.1.2.2 usage: Accept`::
++
+--
+
+You would usually see this error message on the client side when using `curl` to
+test {es} Kerberos setup, as the support for Kerberos Spnego is missing on the
+client due to an old version of curl. The Kerberos realm in {es} only supports
+Spengo mechanism (Oid 1.3.6.1.5.5.2); it does not yet support Kerberos mechanism
+(Oid 1.2.840.113554.1.2.2).
+
+Make sure that:
+
+* You have installed curl version 7.49 or above as older versions of curl have
+known Kerberos bugs.
+
+* The curl installed on your machine has `GSS-API`, `Kerberos` and `SPNEGO`
+features listed when you invoke command `curl -V`. If not, you will need to
+compile `curl` version with this support.
+
+To download latest curl version visit https://curl.haxx.se/download.html
+
+--
+
 As Kerberos logs are often cryptic in nature and many things can go wrong 
 as it depends on external services like DNS and NTP. You might 
 have to enable additional debug logs to determine the root cause of the issue.
@@ -391,30 +416,6 @@ Kerberos/SPNEGO debug logging on JVM, add following JVM system properties:
 `-Dsun.security.spnego.debug=true`
 
 For more information about JVM system properties, see {ref}/jvm-options.html[configuring JVM options].
-
-`gss_init_sec_context() failed: An unsupported mechanism was requested`::
-
-`No credential found for: 1.2.840.113554.1.2.2 usage: Accept`::
-+
---
-
-You would usually see this error message on the client side when using `curl` to test {es} Kerberos
-setup, as the support for Kerberos Spnego is missing on the client due to an old version of curl.
-Kerberos realm in {es} only supports Spengo mechanism (Oid 1.3.6.1.5.5.2) and does not yet support
-Kerberos mechanism (Oid 1.2.840.113554.1.2.2).
-
-Make sure that:
-
-* you have installed curl version 7.49 or above as older versions of curl
-have known Kerberos bugs.
-
-* the curl installed on your machine has `GSS-API`, `Kerberos` and
-`SPNEGO` features listed when you invoke command `curl -V`. If not you will need to
-compile `curl` version with this support.
-
-To download latest curl version visit https://curl.haxx.se/download.html
-
---
 
 [[trb-security-internalserver]]
 === Internal Server Error in Kibana

--- a/docs/en/stack/security/troubleshooting.asciidoc
+++ b/docs/en/stack/security/troubleshooting.asciidoc
@@ -374,11 +374,11 @@ the time on the machines within the domain is in sync.
 +
 --
 
-You would usually see this error message on the client side when using `curl` to
-test {es} Kerberos setup, as the support for Kerberos Spnego is missing on the
-client due to an old version of curl. The Kerberos realm in {es} only supports
-Spengo mechanism (Oid 1.3.6.1.5.5.2); it does not yet support Kerberos mechanism
-(Oid 1.2.840.113554.1.2.2).
+You would usually see this error message on the client side when using `curl` to 
+test {es} Kerberos setup. For example, these messages occur when you are using 
+an old version of curl on the client and therefore Kerberos Spnego support is missing.
+The Kerberos realm in {es} only supports Spengo mechanism (Oid 1.3.6.1.5.5.2); 
+it does not yet support Kerberos mechanism (Oid 1.2.840.113554.1.2.2).
 
 Make sure that:
 


### PR DESCRIPTION
Kerberos realm only supports Spnego mechanism (Oid 1.3.6.1.5.5.2) and
does not yet support Kerberos mechanism (Oid 1.2.840.113554.1.2.2).
Customers usually start initial testing using `curl` to test
Elasticsearch - Kerberos integration and may face problems
authenticating users using Kerberos.

Usually, the problems are due to:
- Known issues with older versions of `curl`.
It is recommended to use `curl` version 7.49 or above as earlier
versions are known to have issues
(like https://bugzilla.redhat.com/show_bug.cgi?id=1333004)
- Sometimes the support for `GSS-API`, `Kerberos` and `SPNEGO`
features are missing from the curl. One will need to download and install
the appropriate version of curl where these features exist or need to
compile with the required support.

This commit adds the troubleshooting documentation to help customers
when they face these issues and provide a way to resolve by installing
the appropriate version of curl with features that need to be supported.