### PR TITLE
[DOCS] Stack Overview cleanup

### DIFF
--- a/docs/en/stack/license.asciidoc
+++ b/docs/en/stack/license.asciidoc
@@ -1,5 +1,5 @@
 [[license-management]]
-= License Management
+= License management
 
 [partintro]
 --
@@ -23,24 +23,24 @@ the trial, or https://www.elastic.co/subscriptions/[purchase a subscription].
 
 [float]
 [[installing-license]]
-== Updating Your License
+== Updating Your license
 
 You can update your license at runtime without shutting down your nodes. License
 updates take effect immediately. The license is provided as a _JSON_ file that
 you install in {kib} or by using the {ref}/update-license.html[update license API].
 
-TIP: If you are using a basic or trial license, {security} is disabled by 
-default. In all other licenses, {security} is enabled by default; you must 
-{xpack-ref}/security-getting-started.html[secure the Elastic Stack] or disable 
-{security}. 
+TIP: If you are using a basic or trial license, {security-features} are disabled
+by default. In all other licenses, {security-features} are enabled by default;
+you must {stack-ov}/security-getting-started.html[secure the {stack}] or disable
+the {security-features}. 
 
 --
 
 [[license-expiration]]
-== License Expiration
+== License expiration
 
 Your {xpack} license is time based and expires at a future date. If you're
-using {monitoring} and your license will expire within 30 days, a license
+using {monitor-features} and your license will expire within 30 days, a license
 expiration warning is displayed prominently. Warnings are also displayed on
 startup and written to the {es} log starting 30 days from the expiration date.
 These error messages tell you when the license expires and what features will be

--- a/docs/en/stack/ml/analyzing.asciidoc
+++ b/docs/en/stack/ml/analyzing.asciidoc
@@ -2,7 +2,7 @@
 [[ml-analyzing]]
 === Analyzing the past and present
 
-The {xpackml} features automate the analysis of time-series data by creating
+The {ml-features} automate the analysis of time-series data by creating
 accurate baselines of normal behavior in the data and identifying anomalous
 patterns in that data. You can submit your data for analysis in batches or
 continuously in real-time {dfeeds}.
@@ -25,5 +25,5 @@ occur outside these bounds.
 [role="screenshot"]
 image::ml/images/ml-gs-job-analysis.jpg["Example screenshot from the Machine Learning Single Metric Viewer in Kibana"]
 
-For a more detailed walk-through of {xpackml} features, see
+For a more detailed walk-through of {ml-features}, see
 <<ml-getting-started>>.

--- a/docs/en/stack/ml/architecture.asciidoc
+++ b/docs/en/stack/ml/architecture.asciidoc
@@ -2,9 +2,7 @@
 [[ml-nodes]]
 === Machine learning nodes
 
-A {ml} node is a node that has `xpack.ml.enabled` and `node.ml` set to `true`,
-which is the default behavior. If you set `node.ml` to `false`, the node can
-service API requests but it cannot run jobs. If you want to use {xpackml}
-features, there must be at least one {ml} node in your cluster. For more
-information, see 
-{ref}/modules-node.html#ml-node[Machine learning node].
+A {ml} node is a node that has `xpack.ml.enabled` and `node.ml` set to `true`, which is the default behavior. If you set `node.ml` to `false`, the node can
+service API requests but it cannot run jobs. If you want to use {ml-features},
+there must be at least one {ml} node in your cluster. For more
+information, see {ref}/modules-node.html#ml-node[Machine learning node].

--- a/docs/en/stack/ml/buckets.asciidoc
+++ b/docs/en/stack/ml/buckets.asciidoc
@@ -5,7 +5,7 @@
 <titleabbrev>Buckets</titleabbrev>
 ++++
 
-The {xpackml} features use the concept of a _bucket_ to divide the time series
+The {ml-features} use the concept of a _bucket_ to divide the time series
 into batches for processing.
 
 The _bucket span_ is part of the configuration information for a job. It defines

--- a/docs/en/stack/ml/forecasting.asciidoc
+++ b/docs/en/stack/ml/forecasting.asciidoc
@@ -2,7 +2,7 @@
 [[ml-forecasting]]
 === Forecasting the future
 
-After the {xpackml} features create baselines of normal behavior for your data,
+After the {ml-features} create baselines of normal behavior for your data,
 you can use that information to extrapolate future behavior.
 
 You can use a forecast to estimate a time series value at a specific future date.
@@ -20,8 +20,6 @@ that you created at different times. You can create a forecast by using the
 
 [role="screenshot"]
 image::ml/images/ml-gs-job-forecast.jpg["Example screenshot from the Machine Learning Single Metric Viewer in Kibana"]
-
-//For a more detailed walk-through of {xpackml} features, see <<ml-getting-started>>.
 
 The yellow line in the chart represents the predicted data values. The
 shaded yellow area represents the bounds for the predicted values, which also

--- a/docs/en/stack/ml/getting-started-data.asciidoc
+++ b/docs/en/stack/ml/getting-started-data.asciidoc
@@ -42,8 +42,8 @@ are received by various applications and services in a system. A system
 administrator might use this type of information to track the total number of
 requests across all of the infrastructure. If the number of requests increases
 or decreases unexpectedly, for example, this might be an indication that there
-is a problem or that resources need to be redistributed. By using the {xpack}
-{ml} features to model the behavior of this data, it is easier to identify
+is a problem or that resources need to be redistributed. By using the
+{ml-features} to model the behavior of this data, it is easier to identify
 anomalies and take appropriate action.
 
 Download the sample data and scripts by clicking here:

--- a/docs/en/stack/ml/getting-started-data.asciidoc
+++ b/docs/en/stack/ml/getting-started-data.asciidoc
@@ -4,7 +4,7 @@
 
 For the purposes of this tutorial, we provide sample data that you can play with
 and search in {es}. When you consider your own data, however, it's important to
-take a moment and think about where the {xpackml} features will be most
+take a moment and think about where the {ml-features} will be most
 impactful.
 
 The first consideration is that it must be time series data. The {ml} features
@@ -32,7 +32,7 @@ for you under the covers.
 
 [float]
 [[ml-gs-sampledata]]
-==== Obtaining a Sample Data Set
+==== Obtaining a sample data set
 
 In this step we will upload some sample data to {es}. This is standard
 {es} functionality, and is needed to set the stage for using {ml}.
@@ -86,7 +86,7 @@ particular time. If your data is stored in {es}, you can generate
 this type of sum or average by using aggregations. One of the benefits of
 summarizing data this way is that {es} automatically distributes
 these calculations across your cluster. You can then feed this summarized data
-into {xpackml} instead of raw results, which reduces the volume
+into {ml} instead of raw results, which reduces the volume
 of data that must be considered while detecting anomalies. For the purposes of
 this tutorial, however, these summary values are stored in {es}. For more
 information, see <<ml-configuring-aggregation>>.

--- a/docs/en/stack/ml/getting-started-forecast.asciidoc
+++ b/docs/en/stack/ml/getting-started-forecast.asciidoc
@@ -68,7 +68,7 @@ image::ml/images/ml-gs-forecast-actual.jpg["View a forecast over actual data in 
 The chart contains the actual data values, the bounds for the expected values,
 the anomalies, the forecast data values, and the bounds for the forecast. This
 combination of actual and forecast data gives you an indication of how well the
-{xpack} {ml} features can extrapolate the future behavior of the data.
+{ml-features} can extrapolate the future behavior of the data.
 --
 
 Now that you have seen how easy it is to create forecasts with the sample data,

--- a/docs/en/stack/ml/getting-started-multi.asciidoc
+++ b/docs/en/stack/ml/getting-started-multi.asciidoc
@@ -131,9 +131,9 @@ use the `create_multi_metric_noauth.sh` script instead. For API reference
 information, see {ref}/ml-apis.html[Machine Learning APIs].
 
 [[ml-gs-job2-analyze]]
-=== Exploring Multi-metric Job Results
+=== Exploring multi-metric job results
 
-The {xpackml} features analyze the input stream of data, model its behavior, and
+The {ml-features} analyze the input stream of data, model its behavior, and
 perform analysis based on the two detectors you defined in your job. When an
 event occurs outside of the model, that event is identified as an anomaly.
 

--- a/docs/en/stack/ml/getting-started-single.asciidoc
+++ b/docs/en/stack/ml/getting-started-single.asciidoc
@@ -64,7 +64,7 @@ NOTE: Some functions such as `count` and `rare` do not require fields.
 interval that the analysis is aggregated into.
 +
 --
-The {xpackml} features use the concept of a bucket to divide up the time series
+The {ml-features} use the concept of a bucket to divide up the time series
 into batches for processing. For example, if you are monitoring
 the total number of requests in the system,
 using a bucket span of 1 hour would mean that at the end of each hour, it
@@ -201,7 +201,7 @@ the job or {dfeed}, and clone or delete the job, for example.
 
 [float]
 [[ml-gs-job1-datafeed]]
-==== Managing {dfeeds-cap}
+==== Managing {dfeeds}
 
 A {dfeed} can be started and stopped multiple times throughout its lifecycle.
 If you want to retrieve more data from {es} and the {dfeed} is stopped, you must
@@ -238,9 +238,9 @@ button: image:ml/images/ml-stop-feed.jpg["Stop {dfeed}"]
 Now that you have processed all the data, let's start exploring the job results.
 
 [[ml-gs-job1-analyze]]
-=== Exploring Single Metric Job Results
+=== Exploring single metric job results
 
-The {xpackml} features analyze the input stream of data, model its behavior,
+The {ml-features} analyze the input stream of data, model its behavior,
 and perform analysis based on the detectors you defined in your job. When an
 event occurs outside of the model, that event is identified as an anomaly.
 

--- a/docs/en/stack/ml/getting-started-wizards.asciidoc
+++ b/docs/en/stack/ml/getting-started-wizards.asciidoc
@@ -15,7 +15,7 @@ This tutorial uses {kib} to create jobs and view results, but you can
 alternatively use APIs to accomplish most tasks.
 For API reference information, see {ref}/ml-apis.html[Machine Learning APIs].
 
-The {xpackml} features in {kib} use pop-ups. You must configure your
+The {ml-features} in {kib} use pop-ups. You must configure your
 web browser so that it does not block pop-up windows or create an
 exception for your {kib} URL.
 --

--- a/docs/en/stack/ml/getting-started.asciidoc
+++ b/docs/en/stack/ml/getting-started.asciidoc
@@ -5,7 +5,7 @@
 <titleabbrev>Getting started</titleabbrev>
 ++++
 
-Ready to get some hands-on experience with the {xpackml} features? This
+Ready to get some hands-on experience with the {ml-features}? This
 tutorial shows you how to:
 
 * Load a sample data set into {es}
@@ -51,7 +51,7 @@ authority to perform the steps in this tutorial.
 +
 --
 [[ml-gs-users]]
-The {xpackml} features use cluster privileges and built-in roles to make it 
+The {ml-features} use cluster privileges and built-in roles to make it 
 easier to control which users have authority to view and manage the jobs,
 {dfeeds}, and results.
 

--- a/docs/en/stack/ml/limitations.asciidoc
+++ b/docs/en/stack/ml/limitations.asciidoc
@@ -23,7 +23,7 @@ future release.
 === Pop-ups must be enabled in browsers
 //See x-pack-elasticsearch/#844
 
-The {xpackml} features in {kib} use pop-ups. You must configure your
+The {ml-features} in {kib} use pop-ups. You must configure your
 web browser so that it does not block pop-up windows or create an
 exception for your {kib} URL.
 
@@ -108,7 +108,7 @@ analyzed.
 === Time-based index patterns are not supported
 //See x-pack-elasticsearch/#1910
 
-It is not possible to create an {xpackml} analysis job that uses time-based
+It is not possible to create a {ml} analysis job that uses time-based
 index patterns, for example `[logstash-]YYYY.MM.DD`.
 This applies to the single metric or multi metric job creation wizards in {kib}.
 
@@ -148,7 +148,7 @@ Likewise, when you create a single or multi-metric job in {kib}, in some cases
 it uses aggregations on the data that it retrieves from {es}. One of the
 benefits of summarizing data this way is that {es} automatically distributes
 these calculations across your cluster. This summarized data is then fed into
-{xpackml} instead of raw results, which reduces the volume of data that must
+{ml} instead of raw results, which reduces the volume of data that must
 be considered while detecting anomalies.  However, if you have two jobs, one of
 which uses pre-aggregated data and another that does not, their results might
 differ. This difference is due to the difference in precision of the input data.

--- a/docs/en/stack/ml/troubleshooting.asciidoc
+++ b/docs/en/stack/ml/troubleshooting.asciidoc
@@ -1,8 +1,8 @@
 [role="xpack"]
 [[ml-troubleshooting]]
-== Machine learning troubleshooting
+== Troubleshooting {ml}
 ++++
-<titleabbrev>{ml}</titleabbrev>
+<titleabbrev>Machine learning</titleabbrev>
 ++++
 
 Use the information in this section to troubleshoot common problems and find
@@ -32,9 +32,8 @@ For example: `unable to install ml metadata upon startup`
 
 *Resolution:*
 
-After you upgrade all master-eligible nodes to {es} {version} and {xpack}
-{version}, restart the current master node, which triggers the {ml-features}
-to re-initialize.
+After you upgrade all master-eligible nodes to {es} {version}, restart the
+current master node, which triggers the {ml-features} to re-initialize.
 
 For more information, see {ref}/rolling-upgrades.html[Rolling upgrades].
 

--- a/docs/en/stack/ml/troubleshooting.asciidoc
+++ b/docs/en/stack/ml/troubleshooting.asciidoc
@@ -1,8 +1,8 @@
 [role="xpack"]
 [[ml-troubleshooting]]
-== {xpackml} Troubleshooting
+== Machine learning troubleshooting
 ++++
-<titleabbrev>{xpackml}</titleabbrev>
+<titleabbrev>{ml}</titleabbrev>
 ++++
 
 Use the information in this section to troubleshoot common problems and find
@@ -17,7 +17,7 @@ To get help, see <<help>>.
 === Machine learning features unavailable after rolling upgrade
 
 This problem occurs after you upgrade all of the nodes in your cluster to
-{version} by using rolling upgrades. When you try to use {xpackml} features for
+{version} by using rolling upgrades. When you try to use {ml-features} for
 the first time, all attempts fail, though `GET _xpack` and `GET _xpack/usage`
 indicate that {xpack} is enabled.
 
@@ -33,8 +33,8 @@ For example: `unable to install ml metadata upon startup`
 *Resolution:*
 
 After you upgrade all master-eligible nodes to {es} {version} and {xpack}
-{version}, restart the current master node, which triggers the {xpackml}
-features to re-initialize.
+{version}, restart the current master node, which triggers the {ml-features}
+to re-initialize.
 
 For more information, see {ref}/rolling-upgrades.html[Rolling upgrades].
 

--- a/docs/en/stack/monitoring/troubleshooting.asciidoc
+++ b/docs/en/stack/monitoring/troubleshooting.asciidoc
@@ -1,7 +1,7 @@
 [[monitoring-troubleshooting]]
-== {monitoring} Troubleshooting
+== Troubleshooting monitoring
 ++++
-<titleabbrev>{monitoring}</titleabbrev>
+<titleabbrev>Monitoring</titleabbrev>
 ++++
 
 See

--- a/docs/en/stack/security/authorization/built-in-roles.asciidoc
+++ b/docs/en/stack/security/authorization/built-in-roles.asciidoc
@@ -81,7 +81,7 @@ suitable for use within a Logstash pipeline.
 Grants `manage_ml` cluster privileges and read access to the `.ml-*` indices.
 
 [[built-in-roles-ml-user]] `machine_learning_user`::
-Grants the minimum privileges required to view {xpackml} configuration,
+Grants the minimum privileges required to view {ml} configuration,
 status, and results. This role grants `monitor_ml` cluster privileges and
 read access to the `.ml-notifications` and `.ml-anomalies*` indices,
 which store {ml} results.

--- a/docs/en/stack/security/limitations.asciidoc
+++ b/docs/en/stack/security/limitations.asciidoc
@@ -1,6 +1,6 @@
 [role="xpack"]
 [[security-limitations]]
-== Security Limitations
+== Security limitations
 
 [float]
 === Plugins
@@ -14,21 +14,21 @@ For this reason, third-party plugins are not officially supported on clusters
 with {security} enabled.
 
 [float]
-=== Changes in Index Wildcard Behavior
+=== Changes in index wildcard behavior
 
 Elasticsearch clusters with {security} enabled apply the `/_all` wildcard, and
 all other wildcards, to the indices that the current user has privileges for, not
 the set of all indices on the cluster.
 
 [float]
-=== Multi Document APIs
+=== Multi document APIs
 
 Multi get and multi term vectors API throw IndexNotFoundException when trying to access non existing indices that the user is
 not authorized for. By doing that they leak information regarding the fact that the index doesn't exist, while the user is not
 authorized to know anything about those indices.
 
 [float]
-=== Filtered Index Aliases
+=== Filtered index aliases
 
 Aliases containing filters are not a secure way to restrict access to individual
 documents, due to the limitations described in <<alias-limitations, Index and Field Names Can Be Leaked When Using Aliases>>.
@@ -36,7 +36,7 @@ documents, due to the limitations described in <<alias-limitations, Index and Fi
 <<field-and-document-access-control, document-level security>> feature.
 
 [float]
-=== Field and Document Level Security Limitations
+=== Field and document level security limitations
 
 When a user's role enables document or field level security for an index:
 
@@ -67,7 +67,7 @@ When a user's role enables document level security for an index:
 
 [float]
 [[alias-limitations]]
-=== Index and Field Names Can Be Leaked When Using Aliases
+=== Index and field names can be leaked when using aliases
 
 Calling certain Elasticsearch APIs on an alias can potentially leak information
 about indices that the user isn't authorized to access. For example, when you get
@@ -78,7 +78,7 @@ Until this limitation is addressed, avoid index and field names that contain
 confidential or sensitive information.
 
 [float]
-=== LDAP Realm
+=== LDAP realm
 
 The <<ldap-realm, LDAP Realm>> does not currently support the discovery of nested
 LDAP Groups.  For example, if a user is a member of `group_1` and `group_1` is a

--- a/docs/en/stack/security/troubleshooting.asciidoc
+++ b/docs/en/stack/security/troubleshooting.asciidoc
@@ -1,8 +1,8 @@
 [role="xpack"]
 [[security-troubleshooting]]
-== {security} Troubleshooting
+== Troubleshooting security
 ++++
-<titleabbrev>{security}</titleabbrev>
+<titleabbrev>Security</titleabbrev>
 ++++
 
 Use the information in this section to troubleshoot common problems and find

--- a/docs/en/stack/troubleshooting.asciidoc
+++ b/docs/en/stack/troubleshooting.asciidoc
@@ -22,7 +22,7 @@ Having trouble? Here are solutions to common problems you might encounter.
 --
 
 [[help]]
-== Getting Help
+== Getting help
 
 For issues that you cannot fix yourself … we’re here to help.
 If you are an existing Elastic customer with a support contract, please create
@@ -31,7 +31,7 @@ https://support.elastic.co/customers/s/login/[Elastic Support portal].
 Or post in the https://discuss.elastic.co/[Elastic forum].
 
 It might also be helpful to collect the following information, since it contains
-build information and indicates which {xpack} features are enabled:
+build information and indicates which {stack} features are enabled:
 
 [source,js]
 --------------------------------------------------

--- a/docs/en/stack/watcher/limitations.asciidoc
+++ b/docs/en/stack/watcher/limitations.asciidoc
@@ -1,9 +1,9 @@
 [role="xpack"]
 [[watcher-limitations]]
-== Watcher Limitations
+== Watcher limitations
 
 [float]
-=== Watches Are Not Updated When File Based Scripts Change
+=== Watches are not updated when file based scripts change
 
 When you refer to a file script in a watch, the watch itself is not updated
 if you change the script on the filesystem.
@@ -21,7 +21,7 @@ Make sure to save your changes before leaving the page.
 image::images/watcher-ui-edit-watch.png[Editing a watch in Kibana]
 
 [float]
-=== Security Integration
+=== Security integration
 
 When {security} is enabled, a watch stores information about what the user who
 stored the watch is allowed to execute **at that time**. This means, if those

--- a/docs/en/stack/watcher/troubleshooting.asciidoc
+++ b/docs/en/stack/watcher/troubleshooting.asciidoc
@@ -1,9 +1,9 @@
 [role="xpack"]
 [testenv="gold"]
 [[watcher-troubleshooting]]
-== {xpack} {watcher} Troubleshooting
+== Troubleshooting {watcher}
 ++++
-<titleabbrev>{xpack} {watcher}</titleabbrev>
+<titleabbrev>{watcher}</titleabbrev>
 ++++
 
 [float]

--- a/docs/en/stack/xpack-enabling.asciidoc
+++ b/docs/en/stack/xpack-enabling.asciidoc
@@ -1,21 +1,19 @@
 [role="xpack"]
 [[xpack-enabling]]
-==== Enabling and disabling {xpack} features
+==== Enabling and disabling {stack} features
 
-By default, all basic {xpack} features are enabled. You can enable or disable
-specific {xpack} features in the `elasticsearch.yml`, `kibana.yml`, and
+By default, all basic {stack} features are enabled. You can enable or disable
+specific features in the `elasticsearch.yml`, `kibana.yml`, and
 `logstash.yml` configuration files.
 
 [options="header"]
 |======
 | Setting                           | Description
-| `xpack.graph.enabled`             | Set to `false` to disable {graph} features.
-| `xpack.ml.enabled`                | Set to `false` to disable {xpackml} features.
-| `xpack.monitoring.enabled`        | Set to `false` to disable {monitoring} features.
-| `xpack.reporting.enabled`         | Set to `false` to disable {reporting} features.
-| `xpack.security.enabled`          | Set to `false` to disable {security} features.
+| `xpack.graph.enabled`             | Set to `false` to disable {graph-features}.
+| `xpack.ml.enabled`                | Set to `false` to disable {ml-features}.
+| `xpack.monitoring.enabled`        | Set to `false` to disable {monitor-features} features.
+| `xpack.reporting.enabled`         | Set to `false` to disable {report-features}.
+| `xpack.security.enabled`          | Set to `false` to disable {security-features} features.
 | `xpack.watcher.enabled`           | Set to `false` to disable {watcher}.
 |======
 
-//For more information about which settings exist in each configuration file, see
-//{xpack-ref}/xpack-settings.html[X-Pack Settings].

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -6,7 +6,7 @@ include::{docdir}/../../elasticsearch/docs/Versions.asciidoc[]
 
 == Overview
 
-The products in the https://www.elastic.co/products[Elastic Stack]
+The products in the https://www.elastic.co/products[{stack}]
 are designed to be used together and releases are synchronized
 to simplify the installation and upgrade process. The full stack
 consists of:
@@ -17,10 +17,9 @@ consists of:
 * {hadoop-ref}/index.html[Elasticsearch Hadoop {branch}]
 * {kibana-ref}/index.html[Kibana {branch}]
 * {logstash-ref}/index.html[Logstash {branch}]
-* {xpack-ref}/index.html[X-Pack {branch}]
 
 This guide provides information about installing and upgrading
-when you are using more than one Elastic Stack product. It specifies
+when you are using more than one {stack} product. It specifies
 the recommended order of installation and the steps you need to take
 to prepare for a stack upgrade.
 


### PR DESCRIPTION
This PR replaces the X-Pack-specific attributes with feature-specific attributes to remove a lot of X-Pack terminology from the Stack Overview. It also changes the titles to sentence case. 