### PR TITLE
Add missing `host` and `cloud` metadata processors

### DIFF
--- a/docs/en/infraops/installation.asciidoc
+++ b/docs/en/infraops/installation.asciidoc
@@ -67,6 +67,8 @@ To populate the *Hosts* view and add logs, enable:
 * {filebeat-ref}/filebeat-module-system.html[{filebeat} `system` module]
 * {filebeat-ref}/filebeat-modules.html[Other {filebeat} modules] needed for
 your environment, such as `apache2`, `redis`, and so on
+* {metricbeat-ref}/add-host-metadata.html[{metricbeat} `add_host_metadata` processor]
+* {metricbeat-ref}/add-cloud-metadata.html[{metricbeat} `add_cloud_metadata` processor]
 
 To populate the *Docker* view and add logs, enable:
 

--- a/docs/en/infraops/installation.asciidoc
+++ b/docs/en/infraops/installation.asciidoc
@@ -63,12 +63,12 @@ to populate the {infra-ui} UI with data.
 
 To populate the *Hosts* view and add logs, enable: 
 
-* {metricbeat-ref}/metricbeat-module-system.html[{metricbeat} `system` module]
+* {metricbeat-ref}/metricbeat-module-system.html[{metricbeat} `system` module] (enabled by default)
 * {filebeat-ref}/filebeat-module-system.html[{filebeat} `system` module]
 * {filebeat-ref}/filebeat-modules.html[Other {filebeat} modules] needed for
 your environment, such as `apache2`, `redis`, and so on
-* {metricbeat-ref}/add-host-metadata.html[{metricbeat} `add_host_metadata` processor]
-* {metricbeat-ref}/add-cloud-metadata.html[{metricbeat} `add_cloud_metadata` processor]
+* {metricbeat-ref}/add-host-metadata.html[{metricbeat} `add_host_metadata` processor] (enabled by default)
+* {metricbeat-ref}/add-cloud-metadata.html[{metricbeat} `add_cloud_metadata` processor] (enabled by default)
 
 To populate the *Docker* view and add logs, enable:
 


### PR DESCRIPTION
Infrastructure UI makes use of the data collected by these processors, they are enabled by default starting with Beats 6.5 but I think its good to add them to the list of required info for awareness.