### PR TITLE
Add section for misconfigured sp entity id

### DIFF
--- a/docs/en/stack/security/troubleshooting.asciidoc
+++ b/docs/en/stack/security/troubleshooting.asciidoc
@@ -498,6 +498,32 @@ Authentication in {kib} fails and the following error is printed in the
 {es} logs:
 
 ....
+Authentication to realm saml1 failed - Provided SAML response is not valid for realm
+saml/saml1 (Caused by ElasticsearchSecurityException[Conditions [https://some-url-here...]
+do not match required audience [https://my.kibana.url]])
+....
+
+*Resolution:*
+
+We received a SAML response that is addressed to another SAML Service Provider. This
+usually means that the configured SAML Service Provider Entity ID in`elasticsearch.yml`
+(`sp.entity_id`) does not match what has been configured as SAML Service Provider Entity ID
+in the SAML Identity Provider documentation. To resolve this issue:
+
+.. Ensure that both the saml realm in {es} and the IdP are configured with the same string
+for the SAML Entity ID of the Service Provider.
+.. Note that these are also compared as case-sensitive strings and not as
+canonicalized URLs even when the values are URL-like. Be mindful of trailing slashes, port
+numbers etc.
+--
+
+. *Symptoms:*
++
+--
+Authentication in {kib} fails and the following error is printed in the
+{es} logs:
+
+....
 Cannot find metadata for entity [your:entity.id] in [metadata.xml]
 ....
 


### PR DESCRIPTION
This started popping up quite a lot in cloud, with the culprit
usually being trailing slashes in the SP entity ID that is set
in either `elasticsearch.yml` or the IdP configuration.