### PR TITLE
[DOCS] Adds intro for Kubernetes

### DIFF
--- a/docs/en/getting-started/get-started-kubernetes.asciidoc
+++ b/docs/en/getting-started/get-started-kubernetes.asciidoc
@@ -1,6 +1,10 @@
 [[get-started-kubernetes]]
 == Running the {stack} on Kubernetes
 
+You can use Docker images for {auditbeat}, {filebeat}, and {metricbeat} on 
+Kubernetes. For more information, see:
+
+* Official Elastic Docker images: https://www.docker.elastic.co/
 * {auditbeat-ref}/running-on-kubernetes.html[Running {auditbeat} on Kubernetes]
 * {filebeat-ref}/running-on-kubernetes.html[Running {filebeat} on Kubernetes]
 * {metricbeat-ref}/running-on-kubernetes.html[Running {metricbeat} on Kubernetes]


### PR DESCRIPTION
Related to https://github.com/elastic/stack-docs/issues/140

This PR adds introductory text to the list of Kubernetes links.  When this PR is backported, I will remove the Auditbeat links, since that page doesn't exist in 6.x or earlier branches.