### PR TITLE
[DOCS] Moves security config file info

### DIFF
--- a/docs/en/getting-started/get-started-stack.asciidoc
+++ b/docs/en/getting-started/get-started-stack.asciidoc
@@ -861,8 +861,9 @@ Congratulations! You've successfully set up the {stack}. You learned how to
 stream system metrics to {es} and visualize the data in {kib}. You also learned
 how to use {ls} to filter events collected by {metricbeat}.
 
-Next, you'll want to set up {security} and activate your trial license so
-you can unlock the full capabilities of the {stack}. To learn how, read:
+Next, you'll want to set up the {stack} {security-features} and activate your
+trial license so you can unlock the full capabilities of the {stack}. To learn
+how, read:
 
 * {stack-ov}/elasticsearch-security.html[Securing the {stack}]
 * {stack-ov}/license-management.html[License Management]

--- a/docs/en/stack/limitations.asciidoc
+++ b/docs/en/stack/limitations.asciidoc
@@ -13,13 +13,11 @@ For a list of known issues in the 6.0.0 alpha release, see
 https://www.elastic.co/blog/elastic-stack-6-0-0-alpha1-released[Elastic Stack 6.0.0-alpha1 Released].
 ////
 
-* <<security-limitations, {security}>>
+* <<security-limitations>>
 
-* <<watcher-limitations, {watcher}>>
+* <<watcher-limitations>>
 
-* {kibana-ref}/graph-limitations.html[{graph}]
-
-* <<ml-limitations, X-Pack machine learning>>
+* <<ml-limitations>>
 
 --
 :edit_url: https://github.com/elastic/stack-docs/edit/{branch}/docs/en/stack/security/limitations.asciidoc

--- a/docs/en/stack/ml/datafeeds.asciidoc
+++ b/docs/en/stack/ml/datafeeds.asciidoc
@@ -24,12 +24,12 @@ stopped multiple times throughout its lifecycle.
 
 [IMPORTANT]
 --
-When {security} is enabled, a {dfeed} stores the roles of the user who created
-or updated the {dfeed} at that time. This means that if those roles are updated,
-the {dfeed} subsequently runs with the new permissions that are associated with
-the roles. However, if the user’s roles are adjusted after creating or updating
-the {dfeed}, the {dfeed} continues to run with the permissions that were
-associated with the original roles.
+When the {es} {security-features} are enabled, a {dfeed} stores the roles of the
+user who created or updated the {dfeed} at that time. This means that if those
+roles are updated, the {dfeed} subsequently runs with the new permissions that
+are associated with the roles. However, if the user’s roles are adjusted after
+creating or updating the {dfeed}, the {dfeed} continues to run with the
+permissions that were associated with the original roles.
 
 One way to update the roles that are stored within the {dfeed} without changing
 any other settings is to submit an empty JSON document ({}) to the

--- a/docs/en/stack/ml/getting-started-data.asciidoc
+++ b/docs/en/stack/ml/getting-started-data.asciidoc
@@ -96,11 +96,11 @@ for the fields. Mappings divide the documents in the index into logical groups
 and specify a field's characteristics, such as the field's searchability or
 whether or not it's _tokenized_, or broken up into separate words.
 
-You can use scripts to create the mappings and load the data set. If {security} 
-is enabled, use the `upload_server_metrics.sh` script. Before you run it, 
-however, you must edit the USERNAME and PASSWORD variables with your actual user 
-ID and password. If {security} is not enabled, use the 
-`upload_server_metrics_noauth.sh` script instead. 
+You can use scripts to create the mappings and load the data set. If the {es}
+{security-features} are enabled, use the `upload_server_metrics.sh` script.
+Before you run it, however, you must edit the USERNAME and PASSWORD variables
+with your actual user ID and password. If the {es} {security-features} are not
+enabled, use the `upload_server_metrics_noauth.sh` script instead. 
 
 The scripts run a `curl` command that makes the following create index API 
 request:

--- a/docs/en/stack/ml/getting-started-multi.asciidoc
+++ b/docs/en/stack/ml/getting-started-multi.asciidoc
@@ -126,9 +126,9 @@ results.
 TIP: The `create_multi_metric.sh` script, which is included with the   
 <<ml-gs-sampledata,sample data>>, creates a similar job and {dfeed} by
 using the {ml} APIs. Before you run it, you must edit the USERNAME and PASSWORD 
-variables with your actual user ID and password. If {security} is not enabled, 
-use the `create_multi_metric_noauth.sh` script instead. For API reference 
-information, see {ref}/ml-apis.html[Machine Learning APIs].
+variables with your actual user ID and password. If the {es} {security-features}
+are not enabled, use the `create_multi_metric_noauth.sh` script instead. For API
+reference information, see {ref}/ml-apis.html[Machine Learning APIs].
 
 [[ml-gs-job2-analyze]]
 === Exploring multi-metric job results

--- a/docs/en/stack/ml/getting-started-single.asciidoc
+++ b/docs/en/stack/ml/getting-started-single.asciidoc
@@ -131,9 +131,9 @@ manage jobs and {dfeeds} before we view the results.
 TIP: The `create_single_metric.sh` script, which is included with the   
 <<ml-gs-sampledata,sample data>>, creates a similar job and {dfeed} by
 using the {ml} APIs. Before you run it, you must edit the USERNAME and PASSWORD 
-variables with your actual user ID and password. If {security} is not enabled, 
-use the `create_single_metric_noauth.sh` script instead. For API reference 
-information, see {ref}/ml-apis.html[Machine Learning APIs].
+variables with your actual user ID and password. If the {es} {security-features}
+are not enabled, use the `create_single_metric_noauth.sh` script instead. For
+API reference information, see {ref}/ml-apis.html[Machine Learning APIs].
 
 [[ml-gs-job1-manage]]
 === Managing Jobs

--- a/docs/en/stack/ml/getting-started.asciidoc
+++ b/docs/en/stack/ml/getting-started.asciidoc
@@ -46,8 +46,8 @@ example, http://127.0.0.1:5601[http://127.0.0.1:5601].
 include::{docdir}/get-started-trial.asciidoc[]
 --
 
-. If {security} is enabled in your cluster, you need a user that has appropriate 
-authority to perform the steps in this tutorial. 
+. If the {es} {security-features} are enabled in your cluster, you need a user
+that has appropriate authority to perform the steps in this tutorial. 
 +
 --
 [[ml-gs-users]]

--- a/docs/en/stack/ml/limitations.asciidoc
+++ b/docs/en/stack/ml/limitations.asciidoc
@@ -162,11 +162,11 @@ For more information, see {ref}/ml-datafeed-resource.html[Datafeed Resources].
 [float]
 === Security integration
 
-When {security} is enabled, a {dfeed} stores the roles of the user who created
-or updated the {dfeed} **at that time**. This means that if those roles are
-updated then the {dfeed} subsequently runs with the new permissions that are
-associated with the roles. However, if the user's roles are adjusted after
-creating or updating the {dfeed}, the {dfeed} continues to run with the
+When the {es} {security-features} are enabled, a {dfeed} stores the roles of the
+user who created or updated the {dfeed} **at that time**. This means that if those
+roles are updated then the {dfeed} subsequently runs with the new permissions
+that are associated with the roles. However, if the user's roles are adjusted
+after creating or updating the {dfeed}, the {dfeed} continues to run with the
 permissions that were associated with the original roles. For more information,
 see <<ml-dfeeds>>.
 

--- a/docs/en/stack/redirects.asciidoc
+++ b/docs/en/stack/redirects.asciidoc
@@ -19,3 +19,16 @@ See {stack-gs}/get-started-elastic-stack.html#logstash-setup[Configure Logstash 
 === Securing the {stack}
 
 See <<elasticsearch-security>>. 
+
+[role="exclude",id="security-reference"]
+=== Reference
+* <<security-privileges,Security privileges>>
+* {ref}/security-settings.html[Security settings]
+* {ref}/security-files.html[Security files]
+* {ref}/security-api.html[Security API]
+* {ref}/xpack-commands.html[Security commands]
+
+[role="exclude",id="security-files"]
+=== Security files
+
+See {ref}/security-files.html[Security files].

--- a/docs/en/stack/security/authentication/kerberos-realm.asciidoc
+++ b/docs/en/stack/security/authentication/kerberos-realm.asciidoc
@@ -10,7 +10,7 @@ and on the transport network layer.
 
 To authenticate users with Kerberos, you need to
 {ref}/configuring-kerberos-realm.html[configure a Kerberos realm] and
-<<mapping-roles, map users to {security} roles>>.
+<<mapping-roles, map users to roles>>.
 For more information on realm settings, see
 {ref}/security-settings.html#ref-kerberos-settings[Kerberos realm settings].
 

--- a/docs/en/stack/security/authentication/overview.asciidoc
+++ b/docs/en/stack/security/authentication/overview.asciidoc
@@ -19,7 +19,7 @@ Directory.
 `pki`, `file`, and `saml`. If none of the built-in realms meet your needs, you 
 can also build your own custom realm and plug it into the {stack}. 
 
-When {security} is enabled, depending on the realms you've configured, you must 
-attach your user credentials to the requests sent to {es}. For example, when 
-using realms that support usernames and passwords you can simply attach 
+When {security-features} are enabled, depending on the realms you've configured,
+you must attach your user credentials to the requests sent to {es}. For example,
+when using realms that support usernames and passwords you can simply attach 
 {wikipedia}/Basic_access_authentication[basic auth] header to the requests.

--- a/docs/en/stack/security/authorization/privileges.asciidoc
+++ b/docs/en/stack/security/authorization/privileges.asciidoc
@@ -32,10 +32,10 @@ All {ml} operations, such as creating and deleting {dfeeds}, jobs, and model
 snapshots.
 +
 --
-NOTE: {dfeeds-cap} that were created prior to version 6.2 or created when {security}
-was disabled run as a system user with elevated privileges, including permission
-to read all indices. Newer {dfeeds} run with the security roles of the user who created
-or updated them.
+NOTE: {dfeeds-cap} that were created prior to version 6.2 or created when
+{security-features} were disabled run as a system user with elevated privileges,
+including permission to read all indices. Newer {dfeeds} run with the security
+roles of the user who created or updated them.
 
 --
 
@@ -54,10 +54,10 @@ Service.
 All watcher operations, such as putting watches, executing, activate or acknowledging.
 +
 --
-NOTE: Watches that were created prior to version 6.1 or created when {security}
-was disabled run as a system user with elevated privileges, including permission
-to read and write all indices. Newer watches run with the security roles of the user
-who created or updated them.
+NOTE: Watches that were created prior to version 6.1 or created when the
+{security-features} were disabled run as a system user with elevated privileges,
+including permission to read and write all indices. Newer watches run with the
+security roles of the user who created or updated them.
 
 --
 

--- a/docs/en/stack/security/get-started-security.asciidoc
+++ b/docs/en/stack/security/get-started-security.asciidoc
@@ -1,7 +1,7 @@
 [role="xpack"]
 [testenv="trial"]
 [[security-getting-started]]
-== Getting started with security
+== Tutorial: Getting started with security
 
 In this tutorial, you learn how to secure a cluster by configuring users and 
 roles in {es}, {kib}, {ls}, and {metricbeat}. 
@@ -37,9 +37,9 @@ include::{docdir}/get-started-trial.asciidoc[]
 include::get-started-enable-security.asciidoc[]
 
 NOTE: This tutorial involves a single node cluster, but if you had multiple 
-nodes, you would enable {security} on every node in the cluster and configure 
-Transport Layer Security (TLS) for internode-communication, which is beyond the 
-scope of this tutorial. 
+nodes, you would enable {es} {security-features} on every node in the cluster
+and configure Transport Layer Security (TLS) for internode-communication, which
+is beyond the scope of this tutorial. 
 
 [role="xpack"]
 [[get-started-built-in-users]]

--- a/docs/en/stack/security/index.asciidoc
+++ b/docs/en/stack/security/index.asciidoc
@@ -90,9 +90,6 @@ Head over to our {security-forum}[Security Discussion Forum]
 to share your experience, questions, and suggestions.
 --
 
-:edit_url: https://github.com/elastic/stack-docs/edit/{branch}/docs/en/stack/security/get-started-security.asciidoc
-include::get-started-security.asciidoc[]
-
 :edit_url: https://github.com/elastic/stack-docs/edit/{branch}/docs/en/stack/security/how-security-works.asciidoc
 include::how-security-works.asciidoc[]
 
@@ -114,3 +111,5 @@ include::{xes-repo-dir}/security/using-ip-filtering.asciidoc[]
 :edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/ccs-clients-integrations.asciidoc
 include::{xes-repo-dir}/security/ccs-clients-integrations.asciidoc[]
 
+:edit_url: https://github.com/elastic/stack-docs/edit/{branch}/docs/en/stack/security/get-started-security.asciidoc
+include::get-started-security.asciidoc[]

--- a/docs/en/stack/security/index.asciidoc
+++ b/docs/en/stack/security/index.asciidoc
@@ -83,11 +83,6 @@ issues.
   shows you how to interact with an Elasticsearch cluster protected by
   {security}.
 
-* <<security-reference, Reference>>
-  provides detailed information about the access privileges you can grant to
-  users, the settings you can configure for Security in `elasticsearch.yml`,
-  and the files where Security configuration information is stored.
-
 [float]
 === Have Comments, Questions, or Feedback?
 
@@ -119,5 +114,3 @@ include::{xes-repo-dir}/security/using-ip-filtering.asciidoc[]
 :edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/ccs-clients-integrations.asciidoc
 include::{xes-repo-dir}/security/ccs-clients-integrations.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/reference.asciidoc
-include::{xes-repo-dir}/security/reference.asciidoc[]

--- a/docs/en/stack/security/limitations.asciidoc
+++ b/docs/en/stack/security/limitations.asciidoc
@@ -11,14 +11,14 @@ additional functionality, when it comes to security, this high extensibility lev
 comes at a cost. We have no control over the third-party plugins' code (open
 source or not) and therefore we cannot guarantee their compliance with {security}.
 For this reason, third-party plugins are not officially supported on clusters
-with {security} enabled.
+with {security-features} enabled.
 
 [float]
 === Changes in index wildcard behavior
 
-Elasticsearch clusters with {security} enabled apply the `/_all` wildcard, and
-all other wildcards, to the indices that the current user has privileges for, not
-the set of all indices on the cluster.
+Elasticsearch clusters with the {security-features} enabled apply the `/_all`
+wildcard, and all other wildcards, to the indices that the current user has
+privileges for, not the set of all indices on the cluster.
 
 [float]
 === Multi document APIs

--- a/docs/en/stack/security/troubleshooting.asciidoc
+++ b/docs/en/stack/security/troubleshooting.asciidoc
@@ -95,7 +95,7 @@ scenarios.
 | _group to role mapping_|
 
 Either the `role_mapping.yml` file or the location for this file could be
-misconfigured. See <<security-files, Security Files>> for more.
+misconfigured. For more information, see {ref}/security-files.html[Security files].
 
 |_role definition_|
 
@@ -771,10 +771,9 @@ log that indicate a config file is in a deprecated location.
 
 *Resolution:*
 
-By default, in 6.2 and earlier releases, the 
-<<security-files,security configuration files>> are located in the 
-`ES_PATH_CONF/x-pack` directory, where `ES_PATH_CONF` is an environment 
-variable that defines the location of the 
+By default, in 6.2 and earlier releases, the security configuration files are
+located in the `ES_PATH_CONF/x-pack` directory, where `ES_PATH_CONF` is an
+environment variable that defines the location of the 
 {ref}/settings.html#config-files-location[config directory]. 
 
 In 6.3 and later releases, the config directory no longer contains an `x-pack` 

--- a/docs/en/stack/troubleshooting.asciidoc
+++ b/docs/en/stack/troubleshooting.asciidoc
@@ -5,19 +5,15 @@
 --
 Having trouble? Here are solutions to common problems you might encounter.
 
-* <<help,Getting Help>>
+* <<help>>
 
-* <<security-troubleshooting, {security}>>
+* <<security-troubleshooting>>
 
-* <<watcher-troubleshooting, X-Pack {watcher}>>
+* <<watcher-troubleshooting>>
 
-* {kibana-ref}/graph-troubleshooting.html[{graph}]
+* <<monitoring-troubleshooting>>
 
-* <<monitoring-troubleshooting, {monitoring}>>
-
-* {kibana-ref}/reporting-troubleshooting.html[{reporting}]
-
-* <<ml-troubleshooting, X-Pack machine learning>>
+* <<ml-troubleshooting>>
 
 --
 

--- a/docs/en/stack/watcher/limitations.asciidoc
+++ b/docs/en/stack/watcher/limitations.asciidoc
@@ -23,7 +23,7 @@ image::images/watcher-ui-edit-watch.png[Editing a watch in Kibana]
 [float]
 === Security integration
 
-When {security} is enabled, a watch stores information about what the user who
-stored the watch is allowed to execute **at that time**. This means, if those
-permissions change over time, the watch will still be able to execute with the
-permissions that existed when the watch was created.
+When the {security-features} are enabled, a watch stores information about what
+the user who stored the watch is allowed to execute **at that time**. This means,
+if those permissions change over time, the watch will still be able to execute
+with the permissions that existed when the watch was created.


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/36232

This PR cleans up the references to the "Security files" page in the Stack Overview.

It also updates the location and title of the "Getting started with security" tutorial and cleans up some out-dated uses of the {security} attribute.