### PR TITLE
[DOCS] Deprecate X-Pack-centric ML endpoints

### DIFF
--- a/docs/en/stack/ml/api-quickref.asciidoc
+++ b/docs/en/stack/ml/api-quickref.asciidoc
@@ -6,7 +6,7 @@ All {ml} endpoints have the following base:
 
 [source,js]
 ----
-/_xpack/ml/
+/_ml/
 ----
 // NOTCONSOLE
 

--- a/docs/en/stack/ml/getting-started-next.asciidoc
+++ b/docs/en/stack/ml/getting-started-next.asciidoc
@@ -19,9 +19,9 @@ For example, the following APIs retrieve information about the jobs and {dfeeds}
 
 [source,js]
 --------------------------------------------------
-GET _xpack/ml/anomaly_detectors
+GET _ml/anomaly_detectors
 
-GET _xpack/ml/datafeeds
+GET _ml/datafeeds
 --------------------------------------------------
 // CONSOLE
 

--- a/docs/en/stack/ml/troubleshooting.asciidoc
+++ b/docs/en/stack/ml/troubleshooting.asciidoc
@@ -28,7 +28,7 @@ indicate that {xpack} is enabled.
 * Errors when you click *Machine Learning* in {kib}.
 For example: `Jobs list could not be created` and `An internal server error occurred`.
 * Null pointer and remote transport exceptions when you run {ml} APIs such as
-`GET _xpack/ml/anomaly_detectors` and `GET _xpack/ml/datafeeds`.
+`GET _ml/anomaly_detectors` and `GET _ml/datafeeds`.
 * Errors in the log files on the master nodes.
 For example: `unable to install ml metadata upon startup`
 


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/36315

This PR removes occurrences of /_xpack/ml