### PR TITLE
[DOCS] Deprecate _xpack/security in favor of _security

### DIFF
--- a/docs/en/stack/monitoring/production.asciidoc
+++ b/docs/en/stack/monitoring/production.asciidoc
@@ -73,7 +73,7 @@ following request creates a `remote_monitor` user that has the
 
 [source, sh]
 ---------------------------------------------------------------
-POST /_xpack/security/user/remote_monitor
+POST /_security/user/remote_monitor
 {
   "password" : "changeme",
   "roles" : [ "remote_monitoring_agent"],

--- a/docs/en/stack/security/authentication/built-in-users.asciidoc
+++ b/docs/en/stack/security/authentication/built-in-users.asciidoc
@@ -137,7 +137,7 @@ Once the password has been changed, you can enable the user via the following AP
 
 [source,js]
 ---------------------------------------------------------------------
-PUT _xpack/security/user/logstash_system/_enable
+PUT _security/user/logstash_system/_enable
 ---------------------------------------------------------------------
 // CONSOLE
 

--- a/docs/en/stack/security/authorization/document-level-security.asciidoc
+++ b/docs/en/stack/security/authorization/document-level-security.asciidoc
@@ -16,7 +16,7 @@ belong to the `click` category within all the `events-*` indices:
 
 [source,js]
 --------------------------------------------------
-POST /_xpack/security/role/click_role
+POST /_security/role/click_role
 {
   "indices": [
     {
@@ -40,7 +40,7 @@ For example, the following role grants read access only to the documents whose
 
 [source,js]
 --------------------------------------------------
-POST /_xpack/security/role/dept_role
+POST /_security/role/dept_role
 {
   "indices" : [
     {

--- a/docs/en/stack/security/authorization/field-level-security.asciidoc
+++ b/docs/en/stack/security/authorization/field-level-security.asciidoc
@@ -16,7 +16,7 @@ The following role definition grants read access only to the `category`,
 
 [source,js]
 --------------------------------------------------
-POST /_xpack/security/role/test_role1
+POST /_security/role/test_role1
 {
   "indices": [
     {
@@ -42,7 +42,7 @@ example grants read access to all fields that start with an `event_` prefix:
 
 [source,js]
 --------------------------------------------------
-POST /_xpack/security/role/test_role2
+POST /_security/role/test_role2
 {
   "indices" : [
     {
@@ -77,7 +77,7 @@ field:
 
 [source,js]
 --------------------------------------------------
-POST /_xpack/security/role/test_role3
+POST /_security/role/test_role3
 {
   "indices" : [
     {
@@ -97,7 +97,7 @@ only read access to the `customer` data:
 
 [source,js]
 --------------------------------------------------
-POST /_xpack/security/role/test_role4
+POST /_security/role/test_role4
 {
   "indices" : [
     {
@@ -116,7 +116,7 @@ You can deny permission to access fields with the following syntax:
 
 [source,js]
 --------------------------------------------------
-POST /_xpack/security/role/test_role5
+POST /_security/role/test_role5
 {
   "indices" : [
     {
@@ -145,7 +145,7 @@ For example:
 
 [source,js]
 --------------------------------------------------
-POST /_xpack/security/role/test_role6
+POST /_security/role/test_role6
 {
   "indices" : [
     {
@@ -173,7 +173,7 @@ permissions. For example, if these two roles are merged:
 
 [source,js]
 --------------------------------------------------
-POST /_xpack/security/role/test_role7
+POST /_security/role/test_role7
 {
   "indices" : [
     {
@@ -187,7 +187,7 @@ POST /_xpack/security/role/test_role7
   ]
 }
 
-POST /_xpack/security/role/test_role8
+POST /_security/role/test_role8
 {
   "indices" : [
     {

--- a/docs/en/stack/security/troubleshooting.asciidoc
+++ b/docs/en/stack/security/troubleshooting.asciidoc
@@ -699,7 +699,7 @@ Cannot connect to elasticsearch node.
 java.net.SocketException: Unexpected end of file from server
 ...
 ERROR: Failed to connect to elasticsearch at
-http://127.0.0.1:9200/_xpack/security/_authenticate?pretty.
+http://127.0.0.1:9200/_security/_authenticate?pretty.
 Is the URL correct and elasticsearch running?
 ------------------------------------------
 --
@@ -711,7 +711,7 @@ the following errors:
 [source, shell]
 ------------------------------------------
 SSL connection to
-https://127.0.0.1:9200/_xpack/security/_authenticate?pretty
+https://127.0.0.1:9200/_security/_authenticate?pretty
 failed: sun.security.validator.ValidatorException:
 PKIX path building failed:
 sun.security.provider.certpath.SunCertPathBuilderException:
@@ -720,7 +720,7 @@ Please check the elasticsearch SSL settings under
 xpack.security.http.ssl.
 ...
 ERROR: Failed to establish SSL connection to elasticsearch at
-https://127.0.0.1:9200/_xpack/security/_authenticate?pretty.
+https://127.0.0.1:9200/_security/_authenticate?pretty.
 ------------------------------------------
 --
 
@@ -731,7 +731,7 @@ following errors:
 [source, shell]
 ------------------------------------------
 SSL connection to
-https://idp.localhost.test:9200/_xpack/security/_authenticate?pretty
+https://idp.localhost.test:9200/_security/_authenticate?pretty
 failed: java.security.cert.CertificateException:
 No subject alternative DNS name matching
 elasticsearch.example.com found.
@@ -739,7 +739,7 @@ Please check the elasticsearch SSL settings under
 xpack.security.http.ssl.
 ...
 ERROR: Failed to establish SSL connection to elasticsearch at
-https://elasticsearch.example.com:9200/_xpack/security/_authenticate?pretty.
+https://elasticsearch.example.com:9200/_security/_authenticate?pretty.
 ------------------------------------------
 --
 


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/36293

This PR changes occurrences of /_xpack/security to /_security/