### PR TITLE
[DOCS] Deprecate X-Pack-centric migration endpoints

### DIFF
--- a/docs/upgrading-stack.asciidoc
+++ b/docs/upgrading-stack.asciidoc
@@ -69,9 +69,9 @@ upgrading to the most recent 5.6 and using the {xpack} Reindex Helper to reindex
 . If Kibana and {xpack} are part of your stack, upgrade the internal Kibana
 and {xpack} indices. We recommend using the {xpack} 5.6 Reindex Helper to
 upgrade the internal indices. If you're performing a full cluster restart upgrade
-from an earlier version, you can also <<upgrade-internal-indices,use the
- `_xpack/migration/upgrade` API>> directly to upgrade the
-internal indices after you install Elasticsearch {version}.
+from an earlier version, you can also
+<<upgrade-internal-indices,use the `_migration/upgrade` API>> directly to
+upgrade the internal indices after you install Elasticsearch {version}.
 
 . If you use {xpack} to secure your cluster:
 .. Make sure TLS is enabled to encrypt communications between nodes. TLS must
@@ -201,11 +201,11 @@ need to be migrated or deleted, and upgrade the internal indices to the
 +
 You can also call the Elasticsearch migration APIs directly:
 +
-`/_xpack/migration/assistance`:: Runs a series of checks on your cluster,
+`/_migration/assistance`:: Runs a series of checks on your cluster,
 nodes, and indices and returns a list of issues that need to be
 fixed before you can upgrade to {version}.
 +
-`/_xpack/migration/upgrade`:: Upgrades the {watcher} and {security} indices to a
+`/_migration/upgrade`:: Upgrades the {watcher} and {security} indices to a
 single-type format compatible with Elasticsearch 6.x.
 
 . Once you've resolved all of the migration issues, perform
@@ -242,25 +242,25 @@ version prior to 5.6, you must upgrade them after after installing
 Elasticsearch {version}.
 
 To get a list of the indices that need to be upgraded, install {xpack} and use
-the {ref}/migration-api-assistance.html[`_xpack/migration/assistance` API]:
+the {ref}/migration-api-assistance.html[`_migration/assistance` API]:
 
 [source,json]
 ----------------------------------------------------------
-GET /_xpack/migration/assistance
+GET /_migration/assistance
 ----------------------------------------------------------
 // CONSOLE
 
 To upgrade the `.security` index:
 
 . On a single node, add a temporary superuser account to the `file` realm.
-. Use the {ref}/migration-api-upgrade.html[`_xpack/migration/upgrade`]
+. Use the {ref}/migration-api-upgrade.html[`_migration/upgrade`]
 API to upgrade the security index, submitting the request with the credentials
 for the temporary superuser:
 +
 --
 [source,json]
 ----------------------------------------------------------
-POST /_xpack/migration/upgrade/.security
+POST /_migration/upgrade/.security
 ----------------------------------------------------------
 // CONSOLE
 --
@@ -268,7 +268,7 @@ POST /_xpack/migration/upgrade/.security
 . Delete the temporary superuser account from the file realm.
 
 You can use your regular administration credentials to upgrade the other
-internal indices using the `_xpack/migration/upgrade` API.
+internal indices using the `_migration/upgrade` API.
 
 TIP: Once you upgrade the `.kibana` index, you can run Kibana and use the
 {xpack} Reindex Helper UI to upgrade the other indices.


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/35976

Replaces occurrences of /_xpack/migration with /_migration.