### PR TITLE
[DOCS] Deprecate X-Pack-centric license endpoints

### DIFF
--- a/docs/upgrading-stack.asciidoc
+++ b/docs/upgrading-stack.asciidoc
@@ -145,7 +145,7 @@ from Kibana, or with the Start Trial API:
 
 [source,json]
 ----------------------------------------------------------
-POST _xpack/license/start_trial
+POST _license/start_trial
 ----------------------------------------------------------
 // CONSOLE
 


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/35959
Replaces occurrences of /_xpack/license with /_license