### PR TITLE
add ILM privilege descriptions

### DIFF
--- a/docs/en/stack/security/authorization/privileges.asciidoc
+++ b/docs/en/stack/security/authorization/privileges.asciidoc
@@ -24,6 +24,9 @@ patterns. It also includes the authority to grant the privileges necessary to
 manage follower indices and auto-follow patterns. This privilege is necessary 
 only on clusters that contain follower indices. 
 
+`manage_ilm`::
+All {Ilm} operations related to managing policies
+
 `manage_index_templates`::
 All operations on index templates.
 
@@ -78,6 +81,10 @@ metadata for leader indices in the cluster. It also includes the authority to
 check whether users have the appropriate privileges to follow leader indices. 
 This privilege is necessary only on clusters that contain leader indices. 
 
+`read_ilm`::
+All read only {Ilm} operations, such as getting policies and checking the
+status of {Ilm}
+
 `transport_client`::
 All privileges necessary for a transport client to connect.  Required by the remote
 cluster to enable <<cross-cluster-configuring,Cross Cluster Search>>.
@@ -125,6 +132,11 @@ All actions that are required to manage the lifecycle of a follower index, which
 includes creating a follower index, closing it, and converting it to a regular 
 index. This privilege is necessary only on clusters that contain follower indices. 
 
+`manage_ilm`::
+All {Ilm} operations relating to managing the execution of policies of an index
+This includes operations like retrying policies, and removing a policy
+from an index.
+
 `monitor`::
 All actions that are required for monitoring (recovery, segments info, index 
 stats and status).
@@ -139,7 +151,7 @@ Read only access to the search action from a <<cross-cluster-configuring,remote 
 
 `view_index_metadata`::
 Read-only access to index metadata (aliases, aliases exists, get index, exists, field mappings,
-mappings, search shards, type exists, validate, warmers, settings). This
+mappings, search shards, type exists, validate, warmers, settings, ilm). This
 privilege is primarily available for use by {kib} users.
 
 `write`::


### PR DESCRIPTION
This adds details about ILM-specific roles:

- manage_ilm (index), manage_ilm (cluster)
- read_ilm (cluster)
- changes to view_index_metadata (index)

relates to: https://github.com/elastic/elasticsearch/pull/36749 and https://github.com/elastic/elasticsearch/pull/36493