### PR TITLE
Add Cluster privileges 's   `manage_ingest_pipelines`

### DIFF
--- a/docs/en/stack/security/authorization/privileges.asciidoc
+++ b/docs/en/stack/security/authorization/privileges.asciidoc
@@ -27,6 +27,9 @@ only on clusters that contain follower indices.
 `manage_index_templates`::
 All operations on index templates.
 
+`manage_ingest_pipelines`::
+All operations on ingest node pipelines.
+
 `manage_ml`::
 All {ml} operations, such as creating and deleting {dfeeds}, jobs, and model
 snapshots.


### PR DESCRIPTION
Hellow.
I using ElasticCloud for role change when I lookup  `manage_ingest_pipelines`.
but It was not in the document.