### PR TITLE
[DOCS] Drafts rollup privileges

### DIFF
--- a/docs/en/stack/security/authorization/privileges.asciidoc
+++ b/docs/en/stack/security/authorization/privileges.asciidoc
@@ -48,6 +48,9 @@ roles of the user who created or updated them.
 `manage_pipeline`::
 All operations on ingest pipelines.
 
+`manage_rollup`::
+All rollup operations.
+
 `manage_security`::
 All security-related operations such as CRUD operations on users and roles and
 cache clearing.
@@ -74,6 +77,9 @@ node info, node and cluster stats, and pending cluster tasks.
 `monitor_ml`::
 All read only {ml} operations, such as getting information about {dfeeds}, jobs,
 model snapshots, or results.
+
+`monitor_rollup`::
+All read only rollup operations. 
 
 `monitor_watcher`::
 All read only watcher operations, such as getting a watch and watcher stats.


### PR DESCRIPTION
This PR adds the monitor_rollup and manage_rollup privileges to the list here:
https://www.elastic.co/guide/en/elastic-stack-overview/master/security-privileges.html