### PR TITLE
[DOCS] Adds manage_saml privilege

### DIFF
--- a/docs/en/stack/security/authorization/privileges.asciidoc
+++ b/docs/en/stack/security/authorization/privileges.asciidoc
@@ -52,6 +52,10 @@ All operations on ingest pipelines.
 All rollup operations, including creating, starting, stopping and deleting
 rollup jobs.
 
+`manage_saml`::
+Enables the use of internal {es} APIs to initiate and manage SAML authentication
+on behalf of other users.
+
 `manage_security`::
 All security-related operations such as CRUD operations on users and roles and
 cache clearing.


### PR DESCRIPTION
This PR adds the manage_saml cluster privilege to https://www.elastic.co/guide/en/elastic-stack-overview/master/security-privileges.html