### PR TITLE
[DOCS] Adds ML api size limitation

### DIFF
--- a/docs/en/stack/ml/limitations.asciidoc
+++ b/docs/en/stack/ml/limitations.asciidoc
@@ -236,5 +236,14 @@ generated. These objects belong to the space that was active when you created
 the job. If you change your active space, custom URLs from the {ml} results to 
 the dashboards or visualizations might fail. 
 
- 
+[float]
+[[ml-result-size-limitations]]
+=== Job and {dfeed} APIs have a maximum search size
+//https://github.com/elastic/elasticsearch/issues/34864
+
+In 6.6 and later releases, the {ref}/ml-get-job.html[get jobs API] and the
+{ref}/ml-get-job-stats.html[get job statistics API] return a maximum of 10,000
+jobs. Likewise, the {ref}/ml-get-datafeed.html[get {dfeeds} API] and the
+{ref}/ml-get-datafeed-stats.html[get {dfeed} statistics API] return a maximum of
+10,000 {dfeeds}.
  


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/issues/34864 and https://github.com/elastic/elasticsearch/pull/36792

This PR adds information about the search size limitation to the machine learning limitations in the Stack Overview (https://www.elastic.co/guide/en/elastic-stack-overview/master/ml-limitations.html).