### PR TITLE
[DOCS] Removes beta tags from monitoring

### DIFF
--- a/docs/en/stack/monitoring/how-monitoring-works.asciidoc
+++ b/docs/en/stack/monitoring/how-monitoring-works.asciidoc
@@ -16,7 +16,7 @@ production and monitoring clusters:
 
 image::monitoring/images/architecture10.png["A typical monitoring environment",width="100%"]
 
-beta[] In 6.4 and later, you can use {metricbeat} to collect and ship data about 
+In 6.4 and later, you can use {metricbeat} to collect and ship data about 
 {kib}, rather than routing it through {es}. In 6.5 and later, you can also use 
 {metricbeat} to collect and ship data about {es}. For example:
 

--- a/docs/en/stack/monitoring/intro.asciidoc
+++ b/docs/en/stack/monitoring/intro.asciidoc
@@ -5,7 +5,7 @@
 [partintro]
 --
 
-{monitoring} gives you insight into the operation of {es}, Logstash, and {kib}.
+{stack-monitor-features} give you insight into the operation of {es}, {ls}, and {kib}.
 All of the monitoring metrics are stored in {es}, which enables you to easily
 visualize the data from {kib}. From the {kib} Monitoring UI, you can spot issues
 at a glance and delve into the system behavior over time to diagnose operational

--- a/docs/en/stack/monitoring/production.asciidoc
+++ b/docs/en/stack/monitoring/production.asciidoc
@@ -7,7 +7,7 @@ In production, you should
 send data to a separate _monitoring cluster_ so that historical monitoring
 data is available even when the nodes you are monitoring are not. 
 
-beta[] In 6.4 and later, you can use {metricbeat} to ship monitoring data about 
+In 6.4 and later, you can use {metricbeat} to ship monitoring data about 
 {kib} to a separate monitoring cluster. In 6.5 and later, you can do the same 
 for {es}. 
 
@@ -60,7 +60,7 @@ credentials must be valid on both the {kib} server and the monitoring cluster.
 
 --
 
-*** beta[] If you plan to use {metricbeat} to collect data about {es} or {kib}, 
+*** If you plan to use {metricbeat} to collect data about {es} or {kib}, 
 create a user that has the `remote_monitoring_collector` built-in role and a 
 user that has the `remote_monitoring_agent` 
 <<built-in-roles-remote-monitoring-agent,built-in role>>. Alternatively, use the 
@@ -93,7 +93,7 @@ Alternatively, use the `remote_monitoring_user` <<built-in-users,built-in user>>
 . Configure your production cluster to collect data and send it to the 
 monitoring cluster. 
 
-** beta[] {ref}/configuring-metricbeat.html[Use {metricbeat}]. This option 
+** {ref}/configuring-metricbeat.html[Use {metricbeat}]. This option 
 is available in 6.5 and later versions. 
 
 ** {ref}/configuring-monitoring.html[Use HTTP exporters].
@@ -109,7 +109,7 @@ data to the monitoring cluster. It cannot be accomplished by using {metricbeat}.
 
 . (Optional) Configure {kib} to collect data and send it to the monitoring cluster:
 
-** beta[] {kibana-ref}/monitoring-metricbeat.html[Use {metricbeat}]. This 
+** {kibana-ref}/monitoring-metricbeat.html[Use {metricbeat}]. This 
 option is available in 6.4 and later versions. 
 
 ** {kibana-ref}/monitoring-kibana.html[Use HTTP exporters].

--- a/docs/en/stack/monitoring/troubleshooting.asciidoc
+++ b/docs/en/stack/monitoring/troubleshooting.asciidoc
@@ -5,4 +5,4 @@
 ++++
 
 See
-{logstash-ref}/monitoring-troubleshooting.html[Troubleshooting {monitoring} in Logstash].
+{logstash-ref}/monitoring-troubleshooting.html[Troubleshooting monitoring in Logstash].


### PR DESCRIPTION
Related to https://github.com/elastic/beats/pull/10222

This PR removes the "beta[]" tags from the Metricbeat monitoring information in the Stack Overview.

It also replaces outdated "X-Pack monitoring" terminology ({monitoring} attribute) with {stack-monitor-features}, which resolves to "Elastic Stack monitoring features". 

