### PR TITLE
[DOCS] Replace use of custom-roles-provider.asciidoc

### DIFF
--- a/docs/en/stack/security/authorization/index.asciidoc
+++ b/docs/en/stack/security/authorization/index.asciidoc
@@ -30,4 +30,4 @@ include::{xes-repo-dir}/security/authorization/field-and-document-access-control
 include::{xes-repo-dir}/security/authorization/run-as-privilege.asciidoc[]
 
 :edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/authorization/custom-roles-provider.asciidoc
-include::{xes-repo-dir}/security/authorization/custom-roles-provider.asciidoc[]
+include::{xes-repo-dir}/security/authorization/custom-authorization.asciidoc[]


### PR DESCRIPTION
The custom-roles-provider.asciidoc file is removed in https://github.com/elastic/elasticsearch/pull/37785
and replaced by custom-authorization.asciidoc

This PR updates the Stack Overview to use the new file.