### PR TITLE
Fix broken link to ECE docs

### DIFF
--- a/docs/en/glossary/glossary.asciidoc
+++ b/docs/en/glossary/glossary.asciidoc
@@ -64,7 +64,7 @@ zone or some other logical constraint that creates a failure boundary. In a
 highly available cluster, the nodes of a cluster are spread across two or three
 availability zones to ensure that the cluster can survive the failure of an
 entire availability zone. Also see
-{ece-ref}/ece-planning.html#ece-ha[high availability].
+{ece-ref}/ece-ha.html[Fault Tolerance (High Availability)].
 +
 //Source: Cloud
 endif::cloud-terms[]


### PR DESCRIPTION
This link from the glossary was broken after merging our ECE docs reshuffle.