### PR TITLE
[DOCS] Adds breaking changes page with content re-use

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -1,0 +1,31 @@
+[[elastic-stack-breaking-changes]]
+== Breaking changes
+
+Before you upgrade, you must review the breaking changes for each product you
+use and make the necessary changes so your code is compatible with {version}. 
+
+** {beats-ref}/breaking-changes.html[Beats {version} breaking changes]
+** {apm-server-ref}/breaking-changes.html[APM Server {version} breaking changes]
+** {ref}/breaking-changes.html[Elasticsearch {version} breaking changes]
+** {hadoop-ref}/breaking-changes.html[Elasticsearch Hadoop {version} breaking changes]
+** {kibana-ref}/breaking-changes.html[Kibana {version} breaking changes]
+** {logstash-ref}/breaking-changes.html[Logstash {version} breaking changes]
+
+[IMPORTANT]
+===============================
+
+* If you're upgrading from 2.n, make sure you check the breaking changes from
+2.n to 5.n, as well as from 5.n to 6.n!
+* If you are using {ml} {dfeeds} that contain discontinued search or query
+domain specific language (DSL), the upgrade will fail. In 5.6.5 and later, the
+Upgrade Assistant provides information about which {dfeeds} need to be updated.
+
+===============================
+
+
+ifdef::asciidoctor-builds[]
+include::{es-repo-dir}/reference/migration/migrate_7_0.asciidoc[tag=notable-breaking-changes]
+
+include::{kib-repo-dir}/migration/migrate_7_0.asciidoc[tag=notable-breaking-changes]
+
+endif::asciidoctor-builds[]

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,8 +1,11 @@
 [[elastic-stack]]
-= Elastic Stack
+= Installation and Upgrade Guide
+
+:es-repo-dir:        {docdir}/../../elasticsearch/docs
+:kib-repo-dir:       {docdir}/../../kibana/docs
 
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
-include::{docdir}/../../elasticsearch/docs/Versions.asciidoc[]
+include::{es-repo-dir}/Versions.asciidoc[]
 
 == Overview
 
@@ -31,5 +34,4 @@ include::installing-stack.asciidoc[]
 
 include::upgrading-stack.asciidoc[]
 
-
-
+include::en/install-upgrade/breaking.asciidoc[]

--- a/docs/upgrading-stack.asciidoc
+++ b/docs/upgrading-stack.asciidoc
@@ -41,27 +41,8 @@ you're using any deprecated features and update your code accordingly.
 By default, deprecation log messages are enabled at the `WARN` level.
 
 . Review the breaking changes for each product you use
-and make the necessary changes so your code is compatible with {version}:
-+
---
-** {beats-ref}/breaking-changes.html[Beats {version} breaking changes]
-** {apm-server-ref}/breaking-changes.html[APM Server {version} breaking changes]
-** {ref}/breaking-changes.html[Elasticsearch {version} breaking changes]
-** {hadoop-ref}/breaking-changes.html[Elasticsearch Hadoop {version} breaking changes]
-** {kibana-ref}/breaking-changes.html[Kibana {version} breaking changes]
-** {logstash-ref}/breaking-changes.html[Logstash {version} breaking changes]
-
-[IMPORTANT]
-===============================
-
-* If you're upgrading from 2.n, make sure you check the breaking changes from
-2.n to 5.n, as well as from 5.n to 6.n!
-* If you are using {ml} {dfeeds} that contain discontinued search or query
-domain specific language (DSL), the upgrade will fail. In 5.6.5 and later, the
-Upgrade Assistant provides information about which {dfeeds} need to be updated.
-
-===============================
---
+and make the necessary changes so your code is compatible with {version}. See
+<<elastic-stack-breaking-changes>>.
 
 . {ref}/docs-reindex.html[Reindex] or delete any indices created on 2.n. We recommend
 upgrading to the most recent 5.6 and using the {xpack} Reindex Helper to reindex 2.n indices.


### PR DESCRIPTION
This PR adds a "Breaking Changes" page to the Installation and Upgrade Guide (https://www.elastic.co/guide/en/elastic-stack/master/index.html) and lays the groundwork for adding highlighted breaking changes from across the stack to this book.

After we move to an Asciidoctor build for this book, we can use tagged regions to pull in content from  breaking change pages across the library (per https://asciidoctor.org/docs/user-manual/#by-tagged-regions). At that time, the build command will need to change as follows (with --resources parameters added for each repo we pull from):

 docbldstk  --resource=elasticsearch/docs --resource=kibana/docs --asciidoctor

NOTE: The presence of these tagged regions cannot be processed by our current asciidoc builds, thus the following line must be added to the index.asciidoc to preview the tagged regions:

> :asciidoctor-builds: true
