### PR TITLE
[DOCS] Adds apm_user role

### DIFF
--- a/docs/en/stack/security/authorization/built-in-roles.asciidoc
+++ b/docs/en/stack/security/authorization/built-in-roles.asciidoc
@@ -14,6 +14,10 @@ to users. These roles have a fixed set of privileges and cannot be updated.
 Grants access necessary for the APM system user to send system-level data
 (such as monitoring) to {es}.
 
+[[built-in-roles-apm-user]] `apm_user` ::
+Grants the privileges required for APM users (such as `read` and 
+`view_index_metadata` privileges on the `apm-*` and `.ml-anomalies*` indices).
+
 [[built-in-roles-beats-admin]] `beats_admin` ::
 Grants access to the `.management-beats` index, which contains configuration
 information for the Beats.


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/38206 and https://github.com/elastic/apm-server/issues/1874

It adds the apm_user role to https://www.elastic.co/guide/en/elastic-stack-overview/master/built-in-roles.html