### PR TITLE
[DOCS] Update version detail in upgrade instructions

### DIFF
--- a/docs/en/install-upgrade/upgrading-stack.asciidoc
+++ b/docs/en/install-upgrade/upgrading-stack.asciidoc
@@ -23,8 +23,8 @@ Rolling upgrades are supported when upgrading from Elasticsearch 5.6 and
 Elasticsearch 6.0-6.2 to {version}. Upgrading from any
 version prior to 5.6 requires a full cluster restart.
 
-IMPORTANT: 2.x indices are not compatible with {version}. You must
-remove or reindex them on your 5.n cluster before upgrading to {version}. The internal
+IMPORTANT: 6.x indices are not compatible with {version}. You must
+remove or reindex them on your 7.x cluster before upgrading to {version}. The internal
 Kibana and {xpack} indices and the default Beats and Logstash mapping templates
 also need to be updated to work with {version}.
 

--- a/docs/en/install-upgrade/upgrading-stack.asciidoc
+++ b/docs/en/install-upgrade/upgrading-stack.asciidoc
@@ -23,7 +23,7 @@ Rolling upgrades are supported when upgrading from Elasticsearch 5.6 and
 Elasticsearch 6.0-6.2 to {version}. Upgrading from any
 version prior to 5.6 requires a full cluster restart.
 
-IMPORTANT: 6.x indices are not compatible with {version}. You must
+IMPORTANT: 6.x and older indices are not compatible with {version}. You must
 remove or reindex them on your 7.x cluster before upgrading to {version}. The internal
 Kibana and {xpack} indices and the default Beats and Logstash mapping templates
 also need to be updated to work with {version}.


### PR DESCRIPTION
This PR updates the "important" warning at the top of https://www.elastic.co/guide/en/elastic-stack/master/upgrading-elastic-stack.html

Per https://github.com/elastic/stack-docs/pull/219#issuecomment-465162904

> ... The "2.x" in that bit should be whatever is two major versions earlier, so for 8.x it should be 6.x and for 7.x it should be 5.x.



