### PR TITLE
[DOCS] Adds missing anchor in Installation Upgrade Guide

### DIFF
--- a/docs/en/install-upgrade/index.asciidoc
+++ b/docs/en/install-upgrade/index.asciidoc
@@ -7,29 +7,7 @@
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 include::{es-repo-dir}/Versions.asciidoc[]
 
-[[overview]]
-== Overview
-
-The products in the https://www.elastic.co/products[{stack}]
-are designed to be used together and releases are synchronized
-to simplify the installation and upgrade process. The full stack
-consists of:
-
-* {beats-ref}/index.html[Beats {branch}]
-* {apm-server-ref}/index.html[APM Server {branch}]
-* {ref}/index.html[Elasticsearch {branch}]
-* {hadoop-ref}/index.html[Elasticsearch Hadoop {branch}]
-* {kibana-ref}/index.html[Kibana {branch}]
-* {logstash-ref}/index.html[Logstash {branch}]
-
-This guide provides information about installing and upgrading
-when you are using more than one {stack} product. It specifies
-the recommended order of installation and the steps you need to take
-to prepare for a stack upgrade.
-
-For detailed information about breaking changes in {version} and install
-and upgrade instructions for specific components, see the individual
-product reference guides.
+include::overview.asciidoc[]
 
 include::installing-stack.asciidoc[]
 

--- a/docs/en/install-upgrade/index.asciidoc
+++ b/docs/en/install-upgrade/index.asciidoc
@@ -7,6 +7,7 @@
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 include::{es-repo-dir}/Versions.asciidoc[]
 
+[[overview]]
 == Overview
 
 The products in the https://www.elastic.co/products[{stack}]

--- a/docs/en/install-upgrade/overview.asciidoc
+++ b/docs/en/install-upgrade/overview.asciidoc
@@ -1,0 +1,23 @@
+[[overview]]
+== Overview
+
+The products in the https://www.elastic.co/products[{stack}]
+are designed to be used together and releases are synchronized
+to simplify the installation and upgrade process. The full stack
+consists of:
+
+* {beats-ref}/index.html[Beats {branch}]
+* {apm-server-ref}/index.html[APM Server {branch}]
+* {ref}/index.html[Elasticsearch {branch}]
+* {hadoop-ref}/index.html[Elasticsearch Hadoop {branch}]
+* {kibana-ref}/index.html[Kibana {branch}]
+* {logstash-ref}/index.html[Logstash {branch}]
+
+This guide provides information about installing and upgrading
+when you are using more than one {stack} product. It specifies
+the recommended order of installation and the steps you need to take
+to prepare for a stack upgrade.
+
+For detailed information about breaking changes in {version} and install
+and upgrade instructions for specific components, see the individual
+product reference guides.


### PR DESCRIPTION
The "Overview" page in the Installation and Upgrade Guide (https://www.elastic.co/guide/en/elastic-stack/master/elastic-stack.html) does not have an anchor, so it's inheriting the "elastic-stack" anchor from the previous section.  That inheritance behaviour changes when we use Asciidoctor to build the book. Instead of relying on inheritance, this PR explicitly adds an anchor.

It also splits the "Overview" content into a separate source file to have a better 1:1 ratio between pages and source files. 