### PR TITLE
[6.7] [DOCS] Adds missing anchor in Installation Upgrade Guide

### DIFF
--- a/docs/en/install-upgrade/index.asciidoc
+++ b/docs/en/install-upgrade/index.asciidoc
@@ -1,4 +1,3 @@
-[[elastic-stack]]
 = Installation and Upgrade Guide
 
 :es-repo-dir:        {docdir}/../../../../elasticsearch/docs
@@ -7,6 +6,7 @@
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 include::{es-repo-dir}/Versions.asciidoc[]
 
+[[elastic-stack]]
 == Overview
 
 The products in the https://www.elastic.co/products[{stack}]


### PR DESCRIPTION
Backports https://github.com/elastic/stack-docs/pull/222
... though in this case it uses the existing anchor and does not split out a separate file for the Overview.