### PR TITLE
[DOCS] Fixes anchor for asciidoctor

### DIFF
--- a/docs/en/getting-started/get-started-stack.asciidoc
+++ b/docs/en/getting-started/get-started-stack.asciidoc
@@ -540,8 +540,7 @@ The `setup` command loads the {kib} dashboards. If the dashboards are already
 set up, omit this command. The `-e` flag is optional and sends output to
 standard error instead of syslog.
 
-[[gs-start-metricbeat]]
-. Start {metricbeat}:
+. [[gs-start-metricbeat]]Start {metricbeat}:
 +
 *deb and rpm:*
 +


### PR DESCRIPTION
This PR fixes a problem with the numbering in a list in the Getting Started Guide when it's built via asciidoctor:

![image](https://user-images.githubusercontent.com/26471269/53375465-34d2c900-3910-11e9-9e0b-3b8d4fbcbb5a.png)

Per https://asciidoctor.org/docs/user-manual/#anchordef this problem can be fixed by using an inline anchor