### PR TITLE
[DOCS] Fixes undefined anchor

### DIFF
--- a/docs/en/getting-started/get-started-stack.asciidoc
+++ b/docs/en/getting-started/get-started-stack.asciidoc
@@ -897,6 +897,7 @@ Restart {ls} to pick up the changes. The event now includes a field called
 
 
 [float]
+[[whats_next]]
 ==== What's next?
 
 Congratulations! You've successfully set up the {stack}. You learned how to


### PR DESCRIPTION
This PR addresses a difference in the way Asciidoc and Asciidoctor handle sections that do not have anchors explicitly defined.  In particular:

Asciidoc generates:           <a id="_whats_next">
Asciidoctor generates:           <a id="_what_8217_s_next">

This PR explicitly defines an anchor rather than relying on generated text.

