### PR TITLE
Link to infrastructure monitoring docs from the stack getting started

### DIFF
--- a/docs/en/getting-started/get-started-stack.asciidoc
+++ b/docs/en/getting-started/get-started-stack.asciidoc
@@ -914,7 +914,7 @@ how, read:
 Want to get up and running quickly with infrastructure metrics monitoring and
 centralized log analytics? Try out the
 {infra-guide}/infrastructure-ui-overview.html[Infrastructure] and
-{infra-guide}/infrastructure-ui-overview.html[Logs] UIs
+{infra-guide}/logs-ui-overview.html[Logs] UIs
 in {kib}. For setup details, see the {infra-guide}/index.html[Infrastructure
 Monitoring Guide].
 

--- a/docs/en/getting-started/get-started-stack.asciidoc
+++ b/docs/en/getting-started/get-started-stack.asciidoc
@@ -8,7 +8,7 @@ the core open source products:
 * <<install-elasticsearch,{es}>>
 * <<install-kibana,{kib}>>
 * <<install-beats,{beats}>>
-* <<install-logstash,{ls}>>
+* <<install-logstash,{ls} (optional)>>
 
 Then you learn how to implement a system monitoring solution that uses
 {metricbeat} to collect server metrics and ship the data to {es}, where you can
@@ -592,12 +592,13 @@ same server--let's add {ls}.
 [float]
 [[install-logstash]]
 
-=== Install {ls}
+=== Install {ls} (optional)
 
 https://www.elastic.co/products/logstash[{ls}] is a powerful tool that
 integrates with a wide variety of deployments. It offers a large selection of
 plugins to help you parse, enrich, transform, and buffer data from a variety of
-sources.
+sources. If your data requires additional processing that is not available in
+{beats}, then you need to add {ls} to your deployment.
 
 To download and install {ls}, open a terminal window and use the commands that
 work with your system:
@@ -909,6 +910,13 @@ how, read:
 
 * {stack-ov}/elasticsearch-security.html[Securing the {stack}]
 * {stack-ov}/license-management.html[License Management]
+
+Want to get up and running quickly with infrastructure metrics monitoring and
+centralized log analytics? Try out the
+{infra-guide}/infrastructure-ui-overview.html[Infrastructure] and
+{infra-guide}/infrastructure-ui-overview.html[Logs] UIs
+in {kib}. For setup details, see the {infra-guide}/index.html[Infrastructure
+Monitoring Guide].
 
 Later, when you're ready to set up a production environment, also see the
 {stack-ref}/installing-elastic-stack.html[{stack} Installation and Upgrade


### PR DESCRIPTION
Added a link that points to the infrastructure monitoring docs.

I would have put this info earlier in the document to raise visibility, but it seemed wrong given the existing tutorial format. The getting started steps are still valid. I put the link in the "What's Next" section where we discuss other related resources.

I also made a small tweak to how we describe Logstash because it might help with some of the confusion customers experience when they are trying to understand whether they need to use Logstash. 

Closes #224 