### PR TITLE
Adds notable breaking changes from Elasticsearch

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -22,10 +22,18 @@ Upgrade Assistant provides information about which {dfeeds} need to be updated.
 
 ===============================
 
+[float]
+[[elasticsearch-breaking-changes]]
+=== Notable {es} breaking changes
 
-ifdef::asciidoctor-builds[]
 include::{es-repo-dir}/reference/migration/migrate_8_0.asciidoc[tag=notable-breaking-changes]
-endif::asciidoctor-builds[]
+
+
+[float]
+[[kibana-breaking-changes]]
+=== Notable {kib} breaking changes
+
+coming[8.0.0]
 
 include::{kib-repo-dir}/migration/migrate_8_0.asciidoc[tag=notable-breaking-changes]
 


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/38238 

This PR starts including the tagged region from the elasticsearch repo in the Installation and Upgrade Guide.  It also adds a section title for the Kibana breaking changes too.

