### PR TITLE
[DOCS] Adds placeholders for version-specific upgrade steps

### DIFF
--- a/docs/en/install-upgrade/index.asciidoc
+++ b/docs/en/install-upgrade/index.asciidoc
@@ -5,7 +5,7 @@
 :kib-repo-dir:       {docdir}/../../../../kibana/docs
 
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
-include::{es-repo-dir}/Versions.asciidoc[]
+include::{asciidoc-dir}/../../shared/versions.asciidoc[]
 
 include::overview.asciidoc[]
 

--- a/docs/en/install-upgrade/upgrading-stack-5x.asciidoc
+++ b/docs/en/install-upgrade/upgrading-stack-5x.asciidoc
@@ -1,0 +1,57 @@
+[[xpack-stack-upgrade]]
+=== Upgrading from 5.6 to {version}
+
+{xpack} 5.6 provides migration and upgrade APIs for Elasticsearch and a
+Upgrade Assistant UI for Kibana. These tools are included with the trial
+license and the free basic license.
+
+To upgrade to {version} from 5.6:
+
+. {ref}/setup-upgrade.html[Upgrade Elasticsearch] to the most recent 5.6 and
+install {xpack} on all nodes in your cluster. If you are upgrading from an
+earlier 5.x release, you can perform a rolling upgrade. To upgrade from older
+versions you must perform a full cluster restart.
++
+If your trial license expires,
+https://register.elastic.co/[register for a free Basic license]. To apply the
+license, upload the license file with the `license` API:
++
+[source,json]
+----------------------------------------------------------
+license -d @license.json
+----------------------------------------------------------
+
+. If {xpack} **IS NOT** normally a part of your {stack}, disable the
+{es} {security-features} in `elasticsearch.yml`:
++
+[source,yaml]
+----------------------------------------------------------
+xpack.security.enabled: false
+----------------------------------------------------------
+
+. Upgrade {kib} to the most recent 5.6 and install {xpack}.
+
+. If you disabled the {es} {security-features}, also disable the {kib}
+{security-features} in `kibana.yml`:
++
+[source,yaml]
+----------------------------------------------------------
+xpack.security.enabled: false
+----------------------------------------------------------
+
+. Use the Upgrade Assistant in Kibana to
+view incompatibilities that you need to fix, identify any 2.x indices that
+need to be migrated or deleted, and upgrade the internal indices to the
+{major-version} index format.
++
+You can also call the Elasticsearch migration APIs directly:
++
+`/_migration/assistance`:: Runs a series of checks on your cluster,
+nodes, and indices and returns a list of issues that need to be
+fixed before you can upgrade to {version}.
++
+`/_migration/upgrade`:: Upgrades the indices for the {watcher} and 
+{security-features} to a single-type format compatible with Elasticsearch 6.x.
+
+. Once you've resolved all of the migration issues, perform
+a {ref}/rolling-upgrades.html[rolling upgrade] from Elasticsearch 5.6 to {version}.

--- a/docs/en/install-upgrade/upgrading-stack-6x.asciidoc
+++ b/docs/en/install-upgrade/upgrading-stack-6x.asciidoc
@@ -1,0 +1,4 @@
+[[upgrading-elastic-stack-6.x]]
+=== Upgrading from 6.x to {version}
+
+coming[8.0.0]

--- a/docs/en/install-upgrade/upgrading-stack-7x.asciidoc
+++ b/docs/en/install-upgrade/upgrading-stack-7x.asciidoc
@@ -1,0 +1,4 @@
+[[upgrading-elastic-stack-7.x]]
+=== Upgrading from {prev-major-version} to {version}
+
+coming[8.0.0]

--- a/docs/en/install-upgrade/upgrading-stack.asciidoc
+++ b/docs/en/install-upgrade/upgrading-stack.asciidoc
@@ -94,6 +94,10 @@ for your Logstash instances and Beats agents. We recommend upgrading Logstash
 and Beats as soon as possible to take advantage of performance improvements
 and other enhancements.
 
+include::upgrading-stack-7x.asciidoc[]
+
+include::upgrading-stack-6x.asciidoc[]
+
 === Upgrading to 6.3
 Starting in 6.3, the default distributions of {es}, {ls}, and {kib}
 include {xpack} and a free Basic license that never expires.
@@ -134,64 +138,7 @@ POST _license/start_trial
 The 30-day trial enables you to try out the full set of platinum features,
 including security, machine learning, alerting, graph capabilities, and more.
 
-[role="xpack"]
-[[xpack-stack-upgrade]]
-=== Upgrading from 5.6
-
-{xpack} 5.6 provides migration and upgrade APIs for Elasticsearch and a
-Upgrade Assistant UI for Kibana. These tools are included with the trial
-license and the free basic license.
-
-To upgrade to {version} from 5.6:
-
-. {ref}/setup-upgrade.html[Upgrade Elasticsearch] to the most recent 5.6 and
-install {xpack} on all nodes in your cluster. If you are upgrading from an
-earlier 5.x release, you can perform a rolling upgrade. To upgrade from older
-versions you must perform a full cluster restart.
-+
-If your trial license expires,
-https://register.elastic.co/[register for a free Basic license]. To apply the
-license, upload the license file with the `license` API:
-+
-[source,json]
-----------------------------------------------------------
-license -d @license.json
-----------------------------------------------------------
-
-. If {xpack} **IS NOT** normally a part of your {stack}, disable the
-{es} {security-features} in `elasticsearch.yml`:
-+
-[source,yaml]
-----------------------------------------------------------
-xpack.security.enabled: false
-----------------------------------------------------------
-
-. Upgrade {kib} to the most recent 5.6 and install {xpack}.
-
-. If you disabled the {es} {security-features}, also disable the {kib}
-{security-features} in `kibana.yml`:
-+
-[source,yaml]
-----------------------------------------------------------
-xpack.security.enabled: false
-----------------------------------------------------------
-
-. Use the Upgrade Assistant in Kibana to
-view incompatibilities that you need to fix, identify any 2.x indices that
-need to be migrated or deleted, and upgrade the internal indices to the
-{major-version} index format.
-+
-You can also call the Elasticsearch migration APIs directly:
-+
-`/_migration/assistance`:: Runs a series of checks on your cluster,
-nodes, and indices and returns a list of issues that need to be
-fixed before you can upgrade to {version}.
-+
-`/_migration/upgrade`:: Upgrades the indices for the {watcher} and 
-{security-features} to a single-type format compatible with Elasticsearch 6.x.
-
-. Once you've resolved all of the migration issues, perform
-a {ref}/rolling-upgrades.html[rolling upgrade] from Elasticsearch 5.6 to {version}.
+include::upgrading-stack-5x.asciidoc[]
 
 [[oss-stack-upgrade]]
 === Upgrading from a pre-5.6 installation


### PR DESCRIPTION
Related to https://github.com/elastic/stack-docs/issues/226

This PR moves the existing "Upgrading from 5.6" content to a separate file and creates placeholders for equivalent pages for 6.x- and 7.x-specific instructions.

It also switches the Installation and Upgrade Guide to pulling its version information from the shared versions files, so that it can use the new "prev-major-version" attribute in https://github.com/elastic/docs/pull/675.