### PR TITLE
Add description of manage_leader_index privilege

### DIFF
--- a/docs/en/stack/security/authorization/privileges.asciidoc
+++ b/docs/en/stack/security/authorization/privileges.asciidoc
@@ -157,6 +157,11 @@ All actions that are required to manage the lifecycle of a follower index, which
 includes creating a follower index, closing it, and converting it to a regular 
 index. This privilege is necessary only on clusters that contain follower indices. 
 
+`manage_leader_index`::
+All actions that are required to manage the lifecycle of a leader index, which
+includes {ref}/ccr-post-forget-follower.html[forgetting a follower]. This
+privilege is necessary only on clusters that contain leader indices.
+
 `manage_ilm`::
 All {Ilm} operations relating to managing the execution of policies of an index
 This includes operations like retrying policies, and removing a policy

--- a/docs/en/stack/security/authorization/privileges.asciidoc
+++ b/docs/en/stack/security/authorization/privileges.asciidoc
@@ -157,15 +157,15 @@ All actions that are required to manage the lifecycle of a follower index, which
 includes creating a follower index, closing it, and converting it to a regular 
 index. This privilege is necessary only on clusters that contain follower indices. 
 
-`manage_leader_index`::
-All actions that are required to manage the lifecycle of a leader index, which
-includes {ref}/ccr-post-forget-follower.html[forgetting a follower]. This
-privilege is necessary only on clusters that contain leader indices.
-
 `manage_ilm`::
 All {Ilm} operations relating to managing the execution of policies of an index
 This includes operations like retrying policies, and removing a policy
 from an index.
+
+`manage_leader_index`::
+All actions that are required to manage the lifecycle of a leader index, which
+includes {ref}/ccr-post-forget-follower.html[forgetting a follower]. This
+privilege is necessary only on clusters that contain leader indices.
 
 `monitor`::
 All actions that are required for monitoring (recovery, segments info, index 


### PR DESCRIPTION
This commit adds a description of the manage_leader_index privilege, which is required to manage a leader index (specifically for use of the forget follower API).

Relates elastic/elasticsearch#39718