### PR TITLE
Fixes link to Cloud documentation

### DIFF
--- a/docs/en/install-upgrade/upgrading-stack.asciidoc
+++ b/docs/en/install-upgrade/upgrading-stack.asciidoc
@@ -281,8 +281,8 @@ permanently swap in the new cluster.
 only for the time that the new cluster runs in parallel with your old cluster.
 Usage is billed on an hourly basis.
 
-To learn more about the upgrade process on Elastic Cloud, see {cloudref}/upgrading.html[
-Upgrade Versions] and {cloudref}/cluster-config.html[Configuring Elastic Cloud].
+To learn more about the upgrade process on Elastic Cloud, see 
+{cloud}/ec-upgrade-cluster.html[Upgrade versions].
 
 NOTE: Elastic Cloud only supports upgrades to released versions. Preview
 releases and master snapshots are not supported.


### PR DESCRIPTION
The Installation and Upgrade Guide (https://www.elastic.co/guide/en/elastic-stack/master/upgrading-elastic-stack.html#upgrade-elastic-stack-for-elastic-cloud) contains broken links to Cloud documentation:

![image](https://user-images.githubusercontent.com/26471269/54312076-46b09f00-4593-11e9-87ff-ac4c185e1d99.png)

This PR fixes the link to go to https://www.elastic.co/guide/en/cloud/current/ec-upgrade-cluster.html