### PR TITLE
Fix ML built in role docs

### DIFF
--- a/docs/en/stack/security/authorization/built-in-roles.asciidoc
+++ b/docs/en/stack/security/authorization/built-in-roles.asciidoc
@@ -90,13 +90,15 @@ suitable for use within a Logstash pipeline.
 --
 
 [[built-in-roles-ml-admin]] `machine_learning_admin`::
-Grants `manage_ml` cluster privileges and read access to the `.ml-*` indices.
+Grants `manage_ml` cluster privileges, read access to `.ml-anomalies*`,
+`.ml-notifications*`, `.ml-state*`, `.ml-meta*` indices and write access to
+`.ml-annotations*` indices.
 
 [[built-in-roles-ml-user]] `machine_learning_user`::
 Grants the minimum privileges required to view {ml} configuration,
-status, and results. This role grants `monitor_ml` cluster privileges and
-read access to the `.ml-notifications` and `.ml-anomalies*` indices,
-which store {ml} results.
+status, and work with results. This role grants `monitor_ml` cluster privileges,
+read access to the `.ml-notifications` and `.ml-anomalies*` indices
+(which store {ml} results), and write access to `.ml-annotations*` indices.
 
 [[built-in-roles-monitoring-user]] `monitoring_user`::
 Grants the minimum privileges required for any user of {monitoring} other than those


### PR DESCRIPTION
The ML built in roles were adjusted in 6.6 because:

1. We added a .ml-config index that we do not want
   any user to access directly
2. We added a .ml-annotations index that users as
   well as admins require write access to