### PR TITLE
[DOCS] Adds highlights to the Installation and Upgrade Guide

### DIFF
--- a/docs/en/install-upgrade/highlights.asciidoc
+++ b/docs/en/install-upgrade/highlights.asciidoc
@@ -1,0 +1,23 @@
+[[elastic-stack-highlights]]
+== Highlights
+
+This section summarizes the most important enhancements in {version}.
+
+[float]
+[[elasticsearch-highlights]]
+=== {es}
+
+coming[8.0.0]
+
+include::{es-repo-dir}/reference/release-notes/highlights-8.0.0.asciidoc[tag=notable-highlights]
+
+
+[float]
+[[kibana-higlights]]
+=== {kib}
+
+coming[8.0.0]
+
+include::{kib-repo-dir}/release-notes/highlights-8.0.0.asciidoc[tag=notable-highlights]
+
+

--- a/docs/en/install-upgrade/highlights.asciidoc
+++ b/docs/en/install-upgrade/highlights.asciidoc
@@ -18,6 +18,6 @@ include::{es-repo-dir}/reference/release-notes/highlights-8.0.0.asciidoc[tag=not
 
 coming[8.0.0]
 
-include::{kib-repo-dir}/release-notes/highlights-8.0.0.asciidoc[tag=notable-highlights]
+//include::{kib-repo-dir}/release-notes/highlights-8.0.0.asciidoc[tag=notable-highlights]
 
 

--- a/docs/en/install-upgrade/index.asciidoc
+++ b/docs/en/install-upgrade/index.asciidoc
@@ -13,6 +13,6 @@ include::installing-stack.asciidoc[]
 
 include::upgrading-stack.asciidoc[]
 
-include::breaking.asciidoc[]
-
 include::highlights.asciidoc[]
+
+include::breaking.asciidoc[]

--- a/docs/en/install-upgrade/index.asciidoc
+++ b/docs/en/install-upgrade/index.asciidoc
@@ -14,3 +14,5 @@ include::installing-stack.asciidoc[]
 include::upgrading-stack.asciidoc[]
 
 include::breaking.asciidoc[]
+
+include::highlights.asciidoc[]


### PR DESCRIPTION
This PR drafts a "Highlights" page in the Installation and Upgrade Guide and re-uses content that's tagged as "notable-highlights" from the Elasticsearch Reference and Kibana Guide.

Depends on https://github.com/elastic/kibana/pull/33675 and https://github.com/elastic/elasticsearch/pull/40330