### PR TITLE
[DOCS] Adds notable Beats breaking changes

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -5,7 +5,7 @@ Before you upgrade, you must review the breaking changes for each product you
 use and make the necessary changes so your code is compatible with {version}. 
 
 ** {apm-server-ref}/breaking-changes.html[APM Server {version} breaking changes]
-** {beats-ref}/breaking-changes.html[Beats {version} breaking changes]
+** <<beats-breaking-changes,Beats {version} breaking changes>>
 ** <<elasticsearch-breaking-changes,{es} {version} breaking changes>>
 ** {hadoop-ref}/breaking-changes.html[Elasticsearch Hadoop {version} breaking changes]
 ** <<kibana-breaking-changes,Kibana {version} breaking changes>>
@@ -59,4 +59,12 @@ include::{es-repo-dir}/reference/migration/migrate_7_0/settings.asciidoc[tag=not
 For the complete list, go to {kibana-ref}/breaking-changes.html[{kib} breaking changes].
 
 include::{kib-repo-dir}/migration/migrate_7_0.asciidoc[tag=notable-breaking-changes]
+
+[float]
+[[beats-breaking-changes]]
+=== Beats
+
+For the complete list, go to {beats-ref}/breaking-changes.html[Beats breaking changes].
+
+include::{beats-repo-dir}/breaking.asciidoc[tag=notable-breaking-changes]
 

--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -28,6 +28,8 @@ The following sections summarize the most important breaking changes in {version
 [[elasticsearch-breaking-changes]]
 === {es}
 
+coming[7.0.0]
+
 For the complete list, go to {ref}/breaking-changes.html[{es} breaking changes].
 
 include::{es-repo-dir}/reference/migration/migrate_7_0.asciidoc[tag=notable-breaking-changes]
@@ -56,6 +58,8 @@ include::{es-repo-dir}/reference/migration/migrate_7_0/settings.asciidoc[tag=not
 [[kibana-breaking-changes]]
 === {kib}
 
+coming[7.0.0]
+
 For the complete list, go to {kibana-ref}/breaking-changes.html[{kib} breaking changes].
 
 include::{kib-repo-dir}/migration/migrate_7_0.asciidoc[tag=notable-breaking-changes]
@@ -64,7 +68,9 @@ include::{kib-repo-dir}/migration/migrate_7_0.asciidoc[tag=notable-breaking-chan
 [[beats-breaking-changes]]
 === Beats
 
+coming[7.0.0]
+
 For the complete list, go to {beats-ref}/breaking-changes.html[Beats breaking changes].
 
-include::{beats-repo-dir}/breaking.asciidoc[tag=notable-breaking-changes]
+//include::{beats-repo-dir}/breaking.asciidoc[tag=notable-breaking-changes]
 

--- a/docs/en/install-upgrade/index.asciidoc
+++ b/docs/en/install-upgrade/index.asciidoc
@@ -3,6 +3,7 @@
 
 :es-repo-dir:        {docdir}/../../../../elasticsearch/docs
 :kib-repo-dir:       {docdir}/../../../../kibana/docs
+:beats-repo-dir:     {docdir}/../../../../beats/libbeat/docs
 
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 include::{es-repo-dir}/Versions.asciidoc[]


### PR DESCRIPTION
Backports https://github.com/elastic/stack-docs/pull/264

This PR looks for a tagged region ("notable-breaking-changes") in https://www.elastic.co/guide/en/beats/libbeat/7.0/breaking-changes-7.0.html so that it can be re-used in https://www.elastic.co/guide/en/elastic-stack/7.0/elastic-stack-breaking-changes.html