### PR TITLE
Adds 7.0 Elasticsearch breaking changes

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -32,6 +32,26 @@ For the complete list, go to {ref}/breaking-changes.html[{es} breaking changes].
 
 include::{es-repo-dir}/reference/migration/migrate_7_0.asciidoc[tag=notable-breaking-changes]
 
+include::{es-repo-dir}/reference/migration/migrate_7_0/api.asciidoc[tag=notable-breaking-changes]
+
+include::{es-repo-dir}/reference/migration/migrate_7_0/cluster.asciidoc[tag=notable-breaking-changes]
+
+include::{es-repo-dir}/reference/migration/migrate_7_0/discovery.asciidoc[tag=notable-breaking-changes]
+
+include::{es-repo-dir}/reference/migration/migrate_7_0/indices.asciidoc[tag=notable-breaking-changes]
+
+include::{es-repo-dir}/reference/migration/migrate_7_0/java_time.asciidoc[tag=notable-breaking-changes]
+
+//include::{es-repo-dir}/reference/migration/migrate_7_0/logging.asciidoc[tag=notable-breaking-changes]
+
+include::{es-repo-dir}/reference/migration/migrate_7_0/mappings.asciidoc[tag=notable-breaking-changes]
+
+include::{es-repo-dir}/reference/migration/migrate_7_0/plugins.asciidoc[tag=notable-breaking-changes]
+
+include::{es-repo-dir}/reference/migration/migrate_7_0/search.asciidoc[tag=notable-breaking-changes]
+
+include::{es-repo-dir}/reference/migration/migrate_7_0/settings.asciidoc[tag=notable-breaking-changes]
+
 [float]
 [[kibana-breaking-changes]]
 === {kib}

--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -32,6 +32,8 @@ For the complete list, go to {ref}/breaking-changes.html[{es} breaking changes].
 
 include::{es-repo-dir}/reference/migration/migrate_7_0.asciidoc[tag=notable-breaking-changes]
 
+include::{es-repo-dir}/reference/migration/migrate_7_0/aggregations.asciidoc[tag=notable-breaking-changes]
+
 include::{es-repo-dir}/reference/migration/migrate_7_0/api.asciidoc[tag=notable-breaking-changes]
 
 include::{es-repo-dir}/reference/migration/migrate_7_0/cluster.asciidoc[tag=notable-breaking-changes]
@@ -41,8 +43,6 @@ include::{es-repo-dir}/reference/migration/migrate_7_0/discovery.asciidoc[tag=no
 include::{es-repo-dir}/reference/migration/migrate_7_0/indices.asciidoc[tag=notable-breaking-changes]
 
 include::{es-repo-dir}/reference/migration/migrate_7_0/java_time.asciidoc[tag=notable-breaking-changes]
-
-//include::{es-repo-dir}/reference/migration/migrate_7_0/logging.asciidoc[tag=notable-breaking-changes]
 
 include::{es-repo-dir}/reference/migration/migrate_7_0/mappings.asciidoc[tag=notable-breaking-changes]
 


### PR DESCRIPTION
Depends on https://github.com/elastic/elasticsearch/pull/40478

This PR adds more Elasticsearch 7.0 breaking changes to the Installation and Upgrade Guide.