### PR TITLE
[DOCS] Work around for titleabbrev errors

### DIFF
--- a/docs/en/stack/watcher/troubleshooting.asciidoc
+++ b/docs/en/stack/watcher/troubleshooting.asciidoc
@@ -2,6 +2,7 @@
 [testenv="gold"]
 [[watcher-troubleshooting]]
 == Troubleshooting {watcher}
+[subs="attributes"]
 ++++
 <titleabbrev>{watcher}</titleabbrev>
 ++++


### PR DESCRIPTION
This PR works around https://github.com/elastic/docs/issues/760 by adding a substitutions attribute for the abbreviated title in https://www.elastic.co/guide/en/elastic-stack-overview/master/watcher-troubleshooting.html