### PR TITLE
[DOCS] Clarify version compability in monitoring docs

### DIFF
--- a/docs/en/stack/monitoring/how-monitoring-works.asciidoc
+++ b/docs/en/stack/monitoring/how-monitoring-works.asciidoc
@@ -29,8 +29,8 @@ differences between various subscription levels, see: https://www.elastic.co/sub
 IMPORTANT: In general, the monitoring cluster and the clusters being monitored
 should be running the same version of the stack. A monitoring cluster cannot
 monitor production clusters running newer versions of the stack. If necessary,
-the monitoring cluster can monitor production clusters running older versions,
-but the versions cannot differ by more than one major version.
+the monitoring cluster can monitor production clusters running the latest
+release of the previous major version.
 
 If you use {kib} to visualize data and administer the cluster, you might want to 
 create a dedicated {kib} instance for monitoring, rather than using a single 


### PR DESCRIPTION
Per https://github.com/elastic/stack-docs/issues/226#issuecomment-467457287, 

> ...the monitoring docs say: "A monitoring cluster cannot monitor production clusters running newer versions of the stack. If necessary, the monitoring cluster can monitor production clusters running older versions, but the versions cannot differ by more than one major version." The last part is wrong. It should say - the same major version, or major-1.latest to major.latest (in some more human-readable form).

This PR addresses that inaccuracy.