### PR TITLE
Splits highlights and breaking changes into multiple pages

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -22,34 +22,43 @@ Upgrade Assistant provides information about which {dfeeds} need to be updated.
 
 ===============================
 
-The following sections summarize the most important breaking changes in {version}:
-
-[float]
-[[elasticsearch-breaking-changes]]
-=== {es}
-
-coming[8.0.0]
-
-For the complete list, go to {ref}/breaking-changes.html[{es} breaking changes].
-
-include::{es-repo-dir}/reference/migration/migrate_8_0.asciidoc[tag=notable-breaking-changes]
-
-
-[float]
-[[kibana-breaking-changes]]
-=== {kib}
-
-coming[8.0.0]
-
-For the complete list, go to {kibana-ref}/breaking-changes.html[{kib} breaking changes].
-
-include::{kib-repo-dir}/migration/migrate_8_0.asciidoc[tag=notable-breaking-changes]
-
-[float]
 [[beats-breaking-changes]]
-=== Beats
+=== Beats breaking changes
+++++
+<titleabbrev>Beats</titleabbrev>
+++++
 
+This list summarizes the most important breaking changes in Beats. 
 For the complete list, go to {beats-ref}/breaking-changes.html[Beats breaking changes].
 
 include::{beats-repo-dir}/breaking.asciidoc[tag=notable-breaking-changes]
+
+
+[[elasticsearch-breaking-changes]]
+=== {es} breaking changes
+[subs="attributes"]
+++++
+<titleabbrev>{es}</titleabbrev>
+++++
+
+coming[8.0.0]
+
+This list summarizes the most important breaking changes in {es} {version}. For
+the complete list, go to {ref}/breaking-changes.html[{es} breaking changes].
+
+include::{es-repo-dir}/reference/migration/migrate_8_0.asciidoc[tag=notable-breaking-changes]
+
+[[kibana-breaking-changes]]
+=== {kib} breaking changes
+[subs="attributes"]
+++++
+<titleabbrev>{kib}</titleabbrev>
+++++
+
+coming[8.0.0]
+
+This list summarizes the most important breaking changes in {kib} {version}. For
+the complete list, go to {kibana-ref}/breaking-changes.html[{kib} breaking changes].
+
+include::{kib-repo-dir}/migration/migrate_8_0.asciidoc[tag=notable-breaking-changes]
 

--- a/docs/en/install-upgrade/highlights.asciidoc
+++ b/docs/en/install-upgrade/highlights.asciidoc
@@ -1,14 +1,22 @@
 [[elastic-stack-highlights]]
-== Highlights
+== Highlights 
 
-This section summarizes the most important enhancements in {version}.
+Each release brings new features and product improvements. This section
+highlights notable new features and enhancements in {version}.
 
-[float]
+** <<elasticsearch-highlights,{es}>>
+** <<kibana-higlights,{kib}>>
+
 [[elasticsearch-highlights]]
-=== {es}
+=== {es} highlights
+[subs="attributes"]
+++++
+<titleabbrev>{es}</titleabbrev>
+++++
 
 coming[8.0.0]
 
+This list summarizes the most important enhancements in {es} {version}.
 For the complete list, go to {ref}/release-highlights.html[{es} release highlights].
 
 :leveloffset: +1
@@ -17,12 +25,16 @@ include::{es-repo-dir}/reference/release-notes/highlights-8.0.0.asciidoc[tag=not
 
 :leveloffset: -1
 
-[float]
 [[kibana-higlights]]
-=== {kib}
+=== {kib} highlights
+[subs="attributes"]
+++++
+<titleabbrev>{kib}</titleabbrev>
+++++
 
 coming[8.0.0]
 
+This list summarizes the most important enhancements in {kib} {version}.
 For the complete list, go to {kibana-ref}/release-highlights.html[{kib} release highlights].
 
 :leveloffset: +1


### PR DESCRIPTION
Related to https://github.com/elastic/docs/pull/768

This page splits the Highlights and Breaking Changes pages in the Installation and Upgrade Guide (https://www.elastic.co/guide/en/elastic-stack/master/index.html) into multiple sub-pages. It also adds an introductory sentence and a bulleted list of links in the Highlights page 