### PR TITLE
Adds Elasticsearch Hadoop breaking changes to Install Upgrade Guide

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -7,7 +7,7 @@ use and make the necessary changes so your code is compatible with {version}.
 ** <<apm-breaking-changes,APM {version} breaking changes>>
 ** <<beats-breaking-changes,Beats {version} breaking changes>>
 ** <<elasticsearch-breaking-changes,{es} {version} breaking changes>>
-** {hadoop-ref}/breaking-changes.html[Elasticsearch Hadoop {version} breaking changes]
+** <<elasticsearch-hadoop-breaking-changes,{es} Hadoop {version} breaking changes>>
 ** <<kibana-breaking-changes,Kibana {version} breaking changes>>
 ** {logstash-ref}/breaking-changes.html[Logstash {version} breaking changes]
 
@@ -62,6 +62,21 @@ This list summarizes the most important breaking changes in {es} {version}. For
 the complete list, go to {ref}/breaking-changes.html[{es} breaking changes].
 
 include::{es-repo-dir}/reference/migration/migrate_8_0.asciidoc[tag=notable-breaking-changes]
+
+[[elasticsearch-hadoop-breaking-changes]]
+=== {es} Hadoop breaking changes
+[subs="attributes"]
+++++
+<titleabbrev>{es} Hadoop</titleabbrev>
+++++
+
+coming[8.0.0]
+
+This list summarizes the most important breaking changes in {es} Hadoop {version}.
+For the complete list, go to
+{hadoop-ref}/breaking-changes.html[Elasticsearch Hadoop breaking changes].
+
+include::{hadoop-repo-dir}/appendix/breaking.adoc[tag=notable-v8-breaking-changes]
 
 [[kibana-breaking-changes]]
 === {kib} breaking changes

--- a/docs/en/install-upgrade/index.asciidoc
+++ b/docs/en/install-upgrade/index.asciidoc
@@ -1,10 +1,11 @@
 [[elastic-stack]]
 = Installation and Upgrade Guide
 
-:es-repo-dir:        {docdir}/../../../../elasticsearch/docs
-:kib-repo-dir:       {docdir}/../../../../kibana/docs
-:beats-repo-dir:     {docdir}/../../../../beats/libbeat/docs
 :apm-repo-dir:       {docdir}/../../../../apm-server/docs/guide
+:beats-repo-dir:     {docdir}/../../../../beats/libbeat/docs
+:es-repo-dir:        {docdir}/../../../../elasticsearch/docs
+:hadoop-repo-dir:    {docdir}/../../../../elasticsearch-hadoop/docs/src/reference/asciidoc
+:kib-repo-dir:       {docdir}/../../../../kibana/docs
 
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 include::{es-repo-dir}/Versions.asciidoc[]


### PR DESCRIPTION
Depends on https://github.com/elastic/docs/pull/789 and https://github.com/elastic/elasticsearch-hadoop/pull/1271

This PR re-uses the tagged regions from the Elasticsearch Hadoop breaking changes (https://www.elastic.co/guide/en/elasticsearch/hadoop/master/breaking-changes.html) in the Installation and Upgrade Guide > Breaking Changes (https://www.elastic.co/guide/en/elastic-stack/master/elastic-stack-breaking-changes.html)