### PR TITLE
Adds Logstash breaking changes to Install Upgrade Guide

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -9,7 +9,7 @@ use and make the necessary changes so your code is compatible with {version}.
 ** <<elasticsearch-breaking-changes,{es} {version} breaking changes>>
 ** <<elasticsearch-hadoop-breaking-changes,{es} Hadoop {version} breaking changes>>
 ** <<kibana-breaking-changes,Kibana {version} breaking changes>>
-** {logstash-ref}/breaking-changes.html[Logstash {version} breaking changes]
+** <<logstash-breaking-changes,{ls} {version} breaking changes>>
 
 [IMPORTANT]
 ===============================
@@ -91,4 +91,19 @@ This list summarizes the most important breaking changes in {kib} {version}. For
 the complete list, go to {kibana-ref}/breaking-changes.html[{kib} breaking changes].
 
 include::{kib-repo-dir}/migration/migrate_8_0.asciidoc[tag=notable-breaking-changes]
+
+[[logstash-breaking-changes]]
+=== {ls} breaking changes
+[subs="attributes"]
+++++
+<titleabbrev>{ls}</titleabbrev>
+++++
+
+coming[8.0.0]
+
+This list summarizes the most important breaking changes in {ls} {version}. For
+the complete list, go to
+{logstash-ref}/breaking-changes.html[Logstash breaking changes].
+
+include::{ls-repo-dir}/static/breaking-changes.asciidoc[tag=notable-breaking-changes]
 

--- a/docs/en/install-upgrade/index.asciidoc
+++ b/docs/en/install-upgrade/index.asciidoc
@@ -6,6 +6,7 @@
 :es-repo-dir:        {docdir}/../../../../elasticsearch/docs
 :hadoop-repo-dir:    {docdir}/../../../../elasticsearch-hadoop/docs/src/reference/asciidoc
 :kib-repo-dir:       {docdir}/../../../../kibana/docs
+:ls-repo-dir:        {docdir}/../../../../logstash/docs
 
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 include::{es-repo-dir}/Versions.asciidoc[]


### PR DESCRIPTION
Depends on https://github.com/elastic/docs/pull/791

This PR re-uses the tagged regions from the Logstash Reference > Breaking Changes (https://www.elastic.co/guide/en/logstash/master/breaking-changes.html) in the Installation and Upgrade Guide > Breaking Changes (https://www.elastic.co/guide/en/elastic-stack/master/elastic-stack-breaking-changes.html)