### PR TITLE
[DOCS] Removes link to Kibana highlights

### DIFF
--- a/docs/en/install-upgrade/highlights.asciidoc
+++ b/docs/en/install-upgrade/highlights.asciidoc
@@ -35,7 +35,6 @@ include::{es-repo-dir}/reference/release-notes/highlights-7.0.0.asciidoc[tag=not
 coming[7.0.0]
 
 This list summarizes the most important enhancements in {kib} {version}.
-For the complete list, go to {kibana-ref}/release-highlights.html[{kib} release highlights].
 
 :leveloffset: +1
 


### PR DESCRIPTION
This PR removes the link to "full list of release highlights", since we are now pulling in all of the Kibana release highlights to the notable highlights page. 