### PR TITLE
Adds Beats highlights to Install Upgrade Guide

### DIFF
--- a/docs/en/install-upgrade/highlights.asciidoc
+++ b/docs/en/install-upgrade/highlights.asciidoc
@@ -4,8 +4,22 @@
 Each release brings new features and product improvements. This section
 highlights notable new features and enhancements in {version}.
 
+** <<beats-highlights,Beats>>
 ** <<elasticsearch-highlights,{es}>>
 ** <<kibana-higlights,{kib}>>
+
+[[beats-highlights]]
+=== Beats highlights
+++++
+<titleabbrev>Beats</titleabbrev>
+++++
+
+coming[8.0.0]
+
+This list summarizes the most important enhancements in Beats.
+For the complete list, go to {beats-ref}/release-highlights.html[Beats release highlights].
+
+//include::{beats-repo-dir}/highlights-8.0.0.asciidoc[tag=notable-highlights]
 
 [[elasticsearch-highlights]]
 === {es} highlights


### PR DESCRIPTION
Depends on https://github.com/elastic/beats/pull/11621

This PR adds Beats notable highlights to the following section of the Installation and Upgrade Guide: https://www.elastic.co/guide/en/elastic-stack/master/elastic-stack-highlights.html

The inclusion of the tagged region is commented out at this point since the 8.0.0 file does not exist yet.