### PR TITLE
[Infra UI] Fixing Kubernetes memory field typo

### DIFF
--- a/docs/en/infraops/installation.asciidoc
+++ b/docs/en/infraops/installation.asciidoc
@@ -136,7 +136,7 @@ This metric relies on the same indices as the logs.
 
 *CPU Usage*:: Average of `kubernetes.pod.cpu.usage.node.pct`
 
-*Memory Usage*:: Average of `kubernetes.pod.memory.usage.pct`
+*Memory Usage*:: Average of `kubernetes.pod.memory.usage.node.pct`
 
 *Inbound Traffic*:: Derivative of the max of `kubernetes.pod.network.rx.bytes` scaled to a 1 second rate
 


### PR DESCRIPTION
This PR fixes a typo with the Kubernetes Memory field, it changes `kubernetes.pod.memory.usage.pct` to `kubernetes.pod.memory.usage.node.pct`