### PR TITLE
Adds Elasticsearch 8.0 notable breaking changes

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -64,13 +64,15 @@ the complete list, go to {ref}/breaking-changes.html[{es} breaking changes].
 include::{es-repo-dir}/reference/migration/migrate_8_0.asciidoc[tag=notable-breaking-changes]
 include::{es-repo-dir}/reference/migration/migrate_8_0/analysis.asciidoc[tag=notable-breaking-changes]
 include::{es-repo-dir}/reference/migration/migrate_8_0/discovery.asciidoc[tag=notable-breaking-changes]
+include::{es-repo-dir}/reference/migration/migrate_8_0/http.asciidoc[tag=notable-breaking-changes]
 include::{es-repo-dir}/reference/migration/migrate_8_0/ilm.asciidoc[tag=notable-breaking-changes]
 include::{es-repo-dir}/reference/migration/migrate_8_0/java.asciidoc[tag=notable-breaking-changes]
 include::{es-repo-dir}/reference/migration/migrate_8_0/mappings.asciidoc[tag=notable-breaking-changes]
+include::{es-repo-dir}/reference/migration/migrate_8_0/network.asciidoc[tag=notable-breaking-changes]
 include::{es-repo-dir}/reference/migration/migrate_8_0/packaging.asciidoc[tag=notable-breaking-changes]
 include::{es-repo-dir}/reference/migration/migrate_8_0/security.asciidoc[tag=notable-breaking-changes]
 include::{es-repo-dir}/reference/migration/migrate_8_0/snapshots.asciidoc[tag=notable-breaking-changes]
-
+include::{es-repo-dir}/reference/migration/migrate_8_0/transport.asciidoc[tag=notable-breaking-changes]
 
 [[elasticsearch-hadoop-breaking-changes]]
 === {es} Hadoop breaking changes


### PR DESCRIPTION
Depends on https://github.com/elastic/elasticsearch/pull/40918

This PR re-uses notable breaking changes from the Elasticsearch Reference (https://www.elastic.co/guide/en/elasticsearch/reference/master/breaking-changes-8.0.html) in the Installation and Upgrade Guide (https://www.elastic.co/guide/en/elastic-stack/master/elasticsearch-breaking-changes.html)