### PR TITLE
Adds more Elasticsearch breaking changes

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -62,6 +62,14 @@ This list summarizes the most important breaking changes in {es} {version}. For
 the complete list, go to {ref}/breaking-changes.html[{es} breaking changes].
 
 include::{es-repo-dir}/reference/migration/migrate_8_0.asciidoc[tag=notable-breaking-changes]
+include::{es-repo-dir}/reference/migration/migrate_8_0/analysis.asciidoc[tag=notable-breaking-changes]
+include::{es-repo-dir}/reference/migration/migrate_8_0/discovery.asciidoc[tag=notable-breaking-changes]
+include::{es-repo-dir}/reference/migration/migrate_8_0/java.asciidoc[tag=notable-breaking-changes]
+include::{es-repo-dir}/reference/migration/migrate_8_0/mappings.asciidoc[tag=notable-breaking-changes]
+include::{es-repo-dir}/reference/migration/migrate_8_0/packaging.asciidoc[tag=notable-breaking-changes]
+include::{es-repo-dir}/reference/migration/migrate_8_0/security.asciidoc[tag=notable-breaking-changes]
+include::{es-repo-dir}/reference/migration/migrate_8_0/snapshots.asciidoc[tag=notable-breaking-changes]
+
 
 [[elasticsearch-hadoop-breaking-changes]]
 === {es} Hadoop breaking changes


### PR DESCRIPTION
Depends on https://github.com/elastic/elasticsearch/pull/40990

This PR re-uses content from the Elasticsearch Reference's breaking changes in the Installation and Upgrade Guide.