### PR TITLE
[Infra UI] Adding note required field for metric detail page and fixing typos

### DIFF
--- a/docs/en/infraops/installation.asciidoc
+++ b/docs/en/infraops/installation.asciidoc
@@ -93,13 +93,15 @@ module]
 * {filebeat-ref}/add-kubernetes-metadata.html[{filebeat} `add_kubernetes_metadata` processor]
 
 [float]
-==== Which fields are used for the metrics on the Infrastructue home page?
+==== Which fields are used for the metrics on the Infrastructure home page?
 
 The metrics listed below are provided by the Beats Shippers. Each system type requires their corresponding identity field to be in the same event document:
 
 * Hosts require `host.name`
 * Docker containers require `container.id`
-* Kibernetes pods require `kibernetes.pod.uid`
+* Kubernetes pods require `kubernetes.pod.uid`
+
+For the metrics detail page, `event.dataset` is a required field. This field is a combination of `metricset.module`, which is the Metricbeat module name, and `metricset.name` which is the sub module name.
 
 
 [float]

--- a/docs/en/infraops/installation.asciidoc
+++ b/docs/en/infraops/installation.asciidoc
@@ -101,7 +101,7 @@ The metrics listed below are provided by the Beats Shippers. Each system type re
 * Docker containers require `container.id`
 * Kubernetes pods require `kubernetes.pod.uid`
 
-For the metrics detail page, `event.dataset` is a required field. This field is a combination of `metricset.module`, which is the Metricbeat module name, and `metricset.name` which is the sub module name.
+For the metrics detail page, `event.dataset` is a required field. This field is a combination of `metricset.module`, which is the Metricbeat module name, and `metricset.name`, which is the sub module name.
 
 
 [float]


### PR DESCRIPTION
This PR fixes a few typos (thanks @gingerwizard) and adds a section about how `event.dataset` is a required field for the Metrics detail page.