### PR TITLE
[DOCS] Remove scale attributes

### DIFF
--- a/docs/en/stack/monitoring/how-monitoring-works.asciidoc
+++ b/docs/en/stack/monitoring/how-monitoring-works.asciidoc
@@ -14,13 +14,13 @@ activities from impacting the performance of your production cluster. The
 following diagram illustrates a typical monitoring architecture with separate 
 production and monitoring clusters:
 
-image::monitoring/images/architecture10.png["A typical monitoring environment",width="100%"]
+image::monitoring/images/architecture10.png["A typical monitoring environment"]
 
 In 6.4 and later, you can use {metricbeat} to collect and ship data about 
 {kib}, rather than routing it through {es}. In 6.5 and later, you can also use 
 {metricbeat} to collect and ship data about {es}. For example:
 
-image::monitoring/images/architecture20.png[A typical monitoring environment that includes {metricbeat},scale=50]
+image::monitoring/images/architecture20.png[A typical monitoring environment that includes {metricbeat}]
 
 If you have at least a gold license, you can route data from multiple production
 clusters to a single monitoring cluster. For more information about the 


### PR DESCRIPTION
When we switch to Asciidoctor builds, the image scale attribute is no longer necessary and causes the image to be too small in https://github.com/elastic/stack-docs/edit/master/docs/en/stack/monitoring/how-monitoring-works.asciidoc:

![image](https://user-images.githubusercontent.com/26471269/55906284-bdd45580-5b88-11e9-8994-63122c63f84f.png)

This change should be deferred until after we've migrated the Stack Overview to Asciidoctor builds.