### PR TITLE
Removes 2.x references from Install Upgrade breaking changes

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -14,8 +14,8 @@ use and make the necessary changes so your code is compatible with {version}.
 [IMPORTANT]
 ===============================
 
-* If you're upgrading from 2.n, make sure you check the breaking changes from
-2.n to 5.n, as well as from 5.n to 6.n!
+* If you're upgrading from 5.n, make sure you check the breaking changes from
+5.n to 6.n, as well as from 6.n to 7.n!
 * If you are using {ml} {dfeeds} that contain discontinued search or query
 domain specific language (DSL), the upgrade will fail. In 5.6.5 and later, the
 Upgrade Assistant provides information about which {dfeeds} need to be updated.


### PR DESCRIPTION
This PR cleans up a reference to 2.x in the 7.0 Installation and Upgrade Guide.