### PR TITLE
Adds ILM breaking changes

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -64,6 +64,7 @@ the complete list, go to {ref}/breaking-changes.html[{es} breaking changes].
 include::{es-repo-dir}/reference/migration/migrate_8_0.asciidoc[tag=notable-breaking-changes]
 include::{es-repo-dir}/reference/migration/migrate_8_0/analysis.asciidoc[tag=notable-breaking-changes]
 include::{es-repo-dir}/reference/migration/migrate_8_0/discovery.asciidoc[tag=notable-breaking-changes]
+include::{es-repo-dir}/reference/migration/migrate_8_0/ilm.asciidoc[tag=notable-breaking-changes]
 include::{es-repo-dir}/reference/migration/migrate_8_0/java.asciidoc[tag=notable-breaking-changes]
 include::{es-repo-dir}/reference/migration/migrate_8_0/mappings.asciidoc[tag=notable-breaking-changes]
 include::{es-repo-dir}/reference/migration/migrate_8_0/packaging.asciidoc[tag=notable-breaking-changes]


### PR DESCRIPTION
Depends on https://github.com/elastic/elasticsearch/pull/41095

This PR re-uses the tagged region in the Elasticsearch Reference for breaking changes in index lifecycle management (ILM).