### PR TITLE
Changes title and adds subtitle for gke-on-prem book

### DIFF
--- a/docs/en/gke-on-prem/index.asciidoc
+++ b/docs/en/gke-on-prem/index.asciidoc
@@ -18,7 +18,7 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :k8s-metadata-labels: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 
 [[gke-on-prem]]
-= Combining logs and metrics from Google Cloud's Anthos GKE On-Prem with traditional on premises systems in the Elastic Stack
+= Elastic Stack and Google Cloud Anthos : Combining logs and metrics from Google Cloud's Anthos GKE On-Prem with traditional on premises systems in the Elastic Stack
 
 include::gke-on-prem-introduction.asciidoc[]
 


### PR DESCRIPTION
Related to https://github.com/elastic/docs/pull/815

This PR shortens the title of the book and adds a sub-title, with the following results:

![image](https://user-images.githubusercontent.com/26471269/56062153-5cdf8580-5d20-11e9-9819-f35cad3453fe.png)

The shorter title is also used in the breadcrumbs on each page, for example:

![image](https://user-images.githubusercontent.com/26471269/56062270-b0ea6a00-5d20-11e9-867f-f8e6f773b7f0.png)
