### PR TITLE
Fixes link in gke-on-prem-architecture

### DIFF
--- a/docs/en/gke-on-prem/gke-on-prem-architecture.asciidoc
+++ b/docs/en/gke-on-prem/gke-on-prem-architecture.asciidoc
@@ -54,7 +54,8 @@ image:images/loadbalancer.png[]
 
 Depending on your deployment of GKE On-Prem in your datacenter, you may have to
 consider the network topology when exposing services to your network. The sample
-application referenced in "Example Application", below, exposes a port to the
-external network. The manifest file specifies an IP address that is provisioned
-on the on-premises load balancer. Your configuration will likely be different,
-but make sure to take this into consideration when setting up your environment.
+application referenced in <<gke-on-prem-example,Example Application>> exposes a
+port to the external network. The manifest file specifies an IP address that is
+provisioned on the on-premises load balancer. Your configuration will likely be
+different, but make sure to take this into consideration when setting up your
+environment.


### PR DESCRIPTION
This PR changes the following text in https://www.elastic.co/guide/en/elastic-stack-gke/current/architecture.html:

 > The sample application referenced in "Example Application", below, exposes a port to the external network.

It adds a link to https://www.elastic.co/guide/en/elastic-stack-gke/current/gke-on-prem-deploy.html#gke-on-prem-example so that it's clearer what is meant by "below".