### PR TITLE
[DOCS] Fix broken Cloud link for 5.1

### DIFF
--- a/docs/en/install-upgrade/upgrading-stack.asciidoc
+++ b/docs/en/install-upgrade/upgrading-stack.asciidoc
@@ -143,5 +143,5 @@ To avoid downtime on production clusters due to major version upgrades:
 
 . Delete the old cluster to stop incurring additional costs. You are billed extra only for the time that the additional cluster was running. Billing for usage is by the hour.
 
-To learn more about the upgrade process on Elastic Cloud, see {cloudref}/ec-upgrade-cluster.html[
+To learn more about the upgrade process on Elastic Cloud, see {cloudref}/ec-upgrade-deployment.html[
 Upgrade Versions] and {cloudref}/ec-configure.html[Configuring Elastic Cloud].


### PR DESCRIPTION
Updated the `ec-upgrade-cluster.html` link to `ec-upgrade-deployment.html`.