### PR TITLE
[DOCS] Fix broken Cloud link for 6.0

### DIFF
--- a/docs/en/install-upgrade/upgrading-stack.asciidoc
+++ b/docs/en/install-upgrade/upgrading-stack.asciidoc
@@ -254,7 +254,7 @@ only for the time that the new cluster runs in parallel with your old cluster.
 Usage is billed on an hourly basis.
 
 To learn more about the upgrade process on Elastic Cloud, see 
-{cloud}/ec-upgrade-cluster.html[Upgrade versions].
+{cloud}/ec-upgrade-deployment.html[Upgrade versions].
 
 NOTE: Elastic Cloud only supports upgrades to released versions. Preview
 releases and master snapshots are not supported.


### PR DESCRIPTION
Updated the `ec-upgrade-cluster.html` link to `ec-upgrade-deployment.html`.