### PR TITLE
Fix broken link to Cloud docs

### DIFF
--- a/docs/en/install-upgrade/upgrading-stack.asciidoc
+++ b/docs/en/install-upgrade/upgrading-stack.asciidoc
@@ -125,7 +125,7 @@ only for the time that the new cluster runs in parallel with your old cluster.
 Usage is billed on an hourly basis.
 
 To learn more about the upgrade process on Elastic Cloud, see
-{cloud}/ec-upgrade-cluster.html[Upgrade versions].
+{cloud}/ec-upgrade-deployment.html[Upgrade versions].
 
 NOTE: Elastic Cloud only supports upgrades to released versions. Preview
 releases and master snapshots are not supported.


### PR DESCRIPTION
Looks like `{cloud}/ec-upgrade-cluster.html` might need to be `{cloud}/ec-upgrade-deployment.html`.