### PR TITLE
[DOCS] Adds configuration information for ESMS

### DIFF
--- a/docs/en/stack/monitoring/esms.asciidoc
+++ b/docs/en/stack/monitoring/esms.asciidoc
@@ -183,14 +183,7 @@ To use {metricbeat}:
 . Disable the default collection of {kib} monitoring metrics. +
 +
 --
-Add the following setting in the {kib} configuration file (`kibana.yml`): 
-
-[source,yaml]
-----------------------------------
-xpack.monitoring.kibana.collection.enabled: false
-----------------------------------
-
-Leave the `xpack.monitoring.enabled` set to its default value (`true`). 
+include::{kib-repo-dir}/monitoring/monitoring-metricbeat.asciidoc[tag=disable-kibana-collection]
 
 For more information, see 
 {kibana-ref}/monitoring-settings-kb.html[Monitoring settings in {kib}].
@@ -204,70 +197,27 @@ each node in the production cluster.
 . {metricbeat-ref}/metricbeat-installation.html[Install {metricbeat}] on the 
 same server as {kib}.
 
-. Enable the {kib} module in {metricbeat}. +
+. Enable the {kib} {xpack} module in {metricbeat}. +
 +
 --
-For example, to enable the default configuration in the `modules.d` directory, 
-run the following command:
-
-["source","sh",subs="attributes,callouts"]
-----------------------------------------------------------------------
-metricbeat modules enable kibana
-----------------------------------------------------------------------
-
-For more information, see 
-{metricbeat-ref}/configuration-metricbeat.html[Specify which modules to run] and 
-{metricbeat-ref}/metricbeat-module-kibana.html[{kib} module]. 
+include::{kib-repo-dir}/monitoring/monitoring-metricbeat.asciidoc[tag=enable-kibana-module]
 --
 
-. Configure the {kib} module in {metricbeat}. +
+. Configure the {kib} {xpack} module in {metricbeat}. +
 +
 --
-You must specify the following settings in the `modules.d/kibana.yml` file:
-
-[source,yaml]
-----------------------------------
-- module: kibana
-  metricsets:
-    - stats
-  period: 10s
-  hosts: ["KIBANA_URL"] <1>
-  xpack.enabled: true <2>
-----------------------------------
-<1> This setting identifies the host and port number that you use to access
-{kib}. For example, `http://localhost:5601`.
-<2> This setting ensures that {kib} can read the monitoring data successfully. 
-That is to say, it's stored in the same location and format as monitoring data 
-that is sent by {ref}/es-monitoring-exporters.html[exporters].  
+include::{kib-repo-dir}/monitoring/monitoring-metricbeat.asciidoc[tag=configure-kibana-module]
 --
 
 . If the {stack} {security-features} are enabled, you must also provide a user 
 ID and password so that {metricbeat} can collect metrics successfully. 
 
-.. Create a user on the production cluster that has the 
-`remote_monitoring_collector` {stack-ov}/built-in-roles.html[built-in role]. 
-Alternatively, use the `remote_monitoring_user` 
-{stack-ov}/built-in-users.html[built-in user].
-
-.. Add the `username` and `password` settings to the {kib} module configuration 
-file.
-+
---
-For example, add the following settings in the `modules.d/kibana.yml` file:
-
-[source,yaml]
-----------------------------------
-- module: kibana
-  ...
-  username: remote_monitoring_user
-  password: YOUR_PASSWORD
-----------------------------------
---
+include::{kib-repo-dir}/monitoring/monitoring-metricbeat.asciidoc[tag=remote-monitoring-user]
 
 . If you configured {kib} to use
 {kibana-ref}/configuring-tls.html[encrypted communications], you must access it
 via HTTPS. For example, use a `hosts` setting like 
-`https://localhost:5601` in the `modules.d/kibana.yml` file. 
+`https://localhost:5601` in the `modules.d/kibana-xpack.yml` file. 
 
 . Identify where to send the {kib} monitoring data and supply the necessary
 security information. If you have not already done so, add the following
@@ -294,9 +244,10 @@ settings in the {metricbeat} configuration file (`metricbeat.yml`):
 +
 --
 Open {kib} in your web browser. Use the {kib} URL and the administrator user ID
-that was provided to you by the Elastic support team. If it doesn't already
-exist, add an {kibana-ref}/index-patterns.html[index pattern] and
-{kibana-ref}/discover.html[explore] your monitoring data.
+that was provided to you by the Elastic support team.
+{kibana-ref}/kibana-page.html[View the {kib} metrics] on the *Monitoring* page.
+
+If you do not see your metrics yet, see <<monitoring-troubleshooting>>.
 --
 ////
 To use HTTP exporters:

--- a/docs/en/stack/monitoring/esms.asciidoc
+++ b/docs/en/stack/monitoring/esms.asciidoc
@@ -51,51 +51,21 @@ For more information about these settings, see
 {ref}/monitoring-settings.html[Monitoring settings in {es}].
 --
 
-. {metricbeat-ref}/metricbeat-installation.html[Install {metricbeat}].
+. {metricbeat-ref}/metricbeat-installation.html[Install {metricbeat}] on each
+node.
 
-. Enable the {es} module in {metricbeat}.
+. Enable the {es} {xpack} module in {metricbeat} on each node. +
 +
 --
-For example, to enable the default configuration in the `modules.d` directory, 
-run the following command:
-
-["source","sh",subs="attributes,callouts"]
-----------------------------------------------------------------------
-metricbeat modules enable elasticsearch-xpack
-----------------------------------------------------------------------
-
-For more information, see 
-{metricbeat-ref}/configuration-metricbeat.html[Specify which modules to run] and 
-{metricbeat-ref}/metricbeat-module-elasticsearch.html[{es} module]. 
+include::{es-repo-dir}/monitoring/configuring-metricbeat.asciidoc[tag=enable-es-module]
 --
 
-. By default, the module collects {es} monitoring metrics from `http://localhost:9200`.
-If your local {es} node has a different address, you must specify it via the
-`hosts` setting in the `modules.d/elasticsearch-xpack.yml` file. If your cluster
-uses {ref}/configuring-tls.html[encrypted communications], you must access it
-via HTTPS. For example, use a `hosts` setting like `https://localhost:9200`.
-
-. If {es} {security-features} are enabled in your production cluster,
-{metricbeat} must use a valid user ID and password to collect metrics
-successfully. 
+. Configure the {es} {xpack} module in {metricbeat} on each node. +
 +
 --
-Create a user on the production cluster that has the
-{stack-ov}/built-in-roles.html[`remote_monitoring_collector` built-in role]. 
-Alternatively, use the
-{stack-ov}/built-in-users.html[`remote_monitoring_user` built-in user].
+include::{es-repo-dir}/monitoring/configuring-metricbeat.asciidoc[tag=configure-es-module]
 
-Add the `username` and `password` settings to the {es} module configuration
-file. For example, add the following settings in the
-`modules.d/elasticsearch-xpack.yml` file:
-
-[source,yaml]
-----------------------------------
-- module: elasticsearch
-  ...
-  username: remote_monitoring_user
-  password: YOUR_PASSWORD
-----------------------------------
+include::{es-repo-dir}/monitoring/configuring-metricbeat.asciidoc[tag=remote-monitoring-user]
 --
 
 . Identify where to send the {es} monitoring data and supply the necessary
@@ -123,50 +93,13 @@ Elastic support team.
 +
 --
 Open {kib} in your web browser. Use the {kib} URL and the administrator user ID
-that was provided to you by the Elastic support team. Add an
-{kibana-ref}/index-patterns.html[index pattern] and
-{kibana-ref}/discover.html[explore] your monitoring data.
---
-////
-To use collectors and exporters:
+that was provided to you by the Elastic support team.
+{kibana-ref}/elasticsearch-metrics.html[View the {es} metrics] on the
+*Monitoring* page.
 
-. Copy the certificates that you obtained from the Elastic support team to the
-{es} configuration directory (`ES_PATH_CONF`) on each node. These certificates
-enable your production cluster to verify the identity of the ESMS and
-communicate securely.
-
-. Configure the following settings on each node in the production cluster:
-+
+If you do not see your metrics yet, see
+<<monitoring-troubleshooting,Troubleshooting {monitor-features}>>.
 --
-[source,js]
-----------------------------------
-PUT _cluster/settings
-{
-  "persistent": {
-    "xpack.monitoring.enabled": true,
-    "xpack.monitoring.collection.enabled": true,
-    "xpack.monitoring.elasticsearch.collection.enabled": true,
-    "xpack.monitoring.exporters.cloud_monitoring.type": "http",
-    "xpack.monitoring.exporters.cloud_monitoring.host": "MONITORING_ELASTICSEARCH_URL", <1>
-    "xpack.monitoring.exporters.cloud_monitoring.auth.username": "cloud_monitoring_agent", <2>
-    "xpack.monitoring.exporters.cloud_monitoring.auth.password": "MONITORING_AGENT_PASSWORD" <3>
-    "xpack.monitoring.exporters.cloud_monitoring.ssl.certificate_authorities": "ES_PATH_CONF/ca.crt" <4>
-  }
-}
-----------------------------------
-// CONSOLE
-<1> Replace `MONITORING_ELASTICSEARCH_URL` with the appropriate URL from the ESMS.
-<2> The Elastic support team creates this user in ESMS and grants it the
-{stack-ov}/built-in-roles.html[`remote_monitoring_agent` built-in role]. 
-<3> Replace `MONITORING_AGENT_PASSWORD` with the value provided to you by the
-Elastic support team.
-<4> Replace the path and file name with the appropriate information for the file
-provided by the Elastic support team.
-
-Alternatively, you can put those settings in the `elasticsearch.yml` file on
-each node. This method, however, requires you to restart each node.
---
-////
 
 [discrete]
 [[esms-kibana]]
@@ -207,19 +140,9 @@ include::{kib-repo-dir}/monitoring/monitoring-metricbeat.asciidoc[tag=enable-kib
 +
 --
 include::{kib-repo-dir}/monitoring/monitoring-metricbeat.asciidoc[tag=configure-kibana-module]
---
 
-. If the {stack} {security-features} are enabled, you must also provide a user
-ID and password so that {metricbeat} can collect metrics successfully. 
-+
---
 include::{kib-repo-dir}/monitoring/monitoring-metricbeat.asciidoc[tag=remote-monitoring-user]
 --
-
-. If you configured {kib} to use
-{kibana-ref}/configuring-tls.html[encrypted communications], you must access it
-via HTTPS. For example, use a `hosts` setting like 
-`https://localhost:5601` in the `modules.d/kibana-xpack.yml` file. 
 
 . Identify where to send the {kib} monitoring data and supply the necessary
 security information. Add the following settings in the {metricbeat}
@@ -249,30 +172,6 @@ Open {kib} in your web browser. Use the {kib} URL and the administrator user ID
 that was provided to you by the Elastic support team.
 {kibana-ref}/kibana-page.html[View the {kib} metrics] on the *Monitoring* page.
 
-If you do not see your metrics yet, see <<monitoring-troubleshooting>>.
+If you do not see your metrics yet, see
+<<monitoring-troubleshooting,Troubleshooting {monitor-features}>>.
 --
-////
-To use HTTP exporters:
-TBD
-
-
-[discrete]
-[[esms-logstash]]
-=== Collecting monitoring data about {ls}
-
-. (Optional)
-{logstash-ref}/configuring-logstash.html[Configure {ls} to collect data and send it to the monitoring cluster]. 
-+
---
-NOTE: You must configure HTTP exporters in the production cluster to route this 
-data to ESMS. It cannot be accomplished by using {metricbeat}. 
-
---
-
-[[esms-view]]
-=== Viewing monitoring data
-
-You can view the monitoring data by logging into {kib} on ESMS. The {kib} URL is
-provided by the Elastic support team. For more information about the monitoring
-interface in {kib}, see {kibana-ref}/xpack-monitoring.html[Monitoring]. 
-////

--- a/docs/en/stack/monitoring/esms.asciidoc
+++ b/docs/en/stack/monitoring/esms.asciidoc
@@ -1,29 +1,30 @@
 [role="xpack"]
 [[esms]]
-== {stack} Monitoring Service
+== {esms}
 
-The {stack} Monitoring Service (ESMS) is a monitoring cluster on Cloud that
-Elastic provides to self-managed commercial customers. If you send your
-monitoring data to the ESMS, it can also be used by Elastic support to provide
-better and faster incident resolution. 
+The {esms} ({esms-init}) is a monitoring cluster on {ecloud}. Elastic provides
+and maintains {esms-init} for self-managed commercial customers. If you send
+your monitoring data to {esms-init}, it can also be used by Elastic support to
+provide better and faster incident resolution.
 
-NOTE: You must obtain your ESMS cluster URLs and credentials from the Elastic
-support team.
+NOTE: You must obtain your {esms-init} cluster URLs and credentials from the
+Elastic support team.
 
 [discrete]
 [[esms-elasticsearch]]
 === Collecting monitoring data about {es}
 
 There are two methods for collecting and sending data about the health of your
-production cluster to ESMS: {metricbeat} or collectors and exporters.
+production cluster to {esms-init}: {metricbeat} or collectors and exporters.
 
-TIP: If you want to monitor {ls}, you must use collectors and exporters to
-route data from the production cluster to ESMS. Otherwise, it is simplest to use
-{metricbeat}. 
+TIP: If you want to monitor {ls}, you must use collectors and exporters to route
+data from the production cluster to {esms-init}. Otherwise, it is simplest to
+use {metricbeat}. 
 
 To use {metricbeat}:
 
-. If your production cluster is stopped, {ref}/starting-elasticsearch.html[start it].
+. If your production cluster is stopped,
+{ref}/starting-elasticsearch.html[start it].
 
 . Configure the following settings on each node in the production cluster:
 +
@@ -69,7 +70,6 @@ For more information, see
 {metricbeat-ref}/metricbeat-module-system.html[System module].
 --
 
-
 . Enable the {es} {xpack} module in {metricbeat} on each node. +
 +
 --
@@ -96,8 +96,8 @@ output.elasticsearch:
   username: cloud_monitoring_agent <2>
   password: MONITORING_AGENT_PASSWORD <3>
 ----------------------------------
-<1> Replace `MONITORING_ELASTICSEARCH_URL` with the appropriate URL from the ESMS.
-<2> The Elastic support team creates this user in ESMS and grants it the
+<1> Replace `MONITORING_ELASTICSEARCH_URL` with the appropriate URL for {esms-init}.
+<2> The Elastic support team creates this user in {esms-init} and grants it the
 {stack-ov}/built-in-roles.html[`remote_monitoring_agent` built-in role]. 
 <3> Replace `MONITORING_AGENT_PASSWORD` with the value provided to you by the
 Elastic support team.
@@ -105,7 +105,7 @@ Elastic support team.
 
 . {metricbeat-ref}/metricbeat-starting.html[Start {metricbeat}].
 
-. Verify that your monitoring data exists in ESMS.
+. Verify that your monitoring data exists in {esms-init}.
 +
 --
 Open {kib} in your web browser. Use the {kib} URL and the administrator user ID
@@ -121,9 +121,9 @@ If you do not see your metrics yet, see
 [[esms-kibana]]
 === Collecting monitoring data about {kib}
 
-There are two methods for sending monitoring data about {kib} to ESMS. You can
-send it directly to ESMS by using {metricbeat} or you can route it through
-exporters on the production cluster.
+There are two methods for sending monitoring data about {kib} to {esms-init}.
+You can send it directly to {esms-init} by using {metricbeat} or you can route
+it through exporters on the production cluster.
 
 TIP: It is simplest to use {metricbeat}. 
 
@@ -187,8 +187,8 @@ configuration file (`metricbeat.yml`):
     username: cloud_monitoring_agent <2>
     password: MONITORING_AGENT_PASSWORD <3>
 ----------------------------------
-<1> Replace `MONITORING_ELASTICSEARCH_URL` with the appropriate URL from the ESMS.
-<2> The Elastic support team creates this user in ESMS and grants it the
+<1> Replace `MONITORING_ELASTICSEARCH_URL` with the appropriate URL for {esms-init}.
+<2> The Elastic support team creates this user in {esms-init} and grants it the
 {stack-ov}/built-in-roles.html[`remote_monitoring_agent` built-in role]. 
 <3> Replace `MONITORING_AGENT_PASSWORD` with the value provided to you by the
   Elastic support team.
@@ -196,7 +196,7 @@ configuration file (`metricbeat.yml`):
 
 . {metricbeat-ref}/metricbeat-starting.html[Start {metricbeat}]. 
 
-. Verify that your monitoring data exists in ESMS.
+. Verify that your monitoring data exists in {esms-init}.
 +
 --
 Open {kib} in your web browser. Use the {kib} URL and the administrator user ID

--- a/docs/en/stack/monitoring/esms.asciidoc
+++ b/docs/en/stack/monitoring/esms.asciidoc
@@ -41,21 +41,6 @@ include::{es-repo-dir}/monitoring/configuring-metricbeat.asciidoc[tag=disable-de
 . {metricbeat-ref}/metricbeat-installation.html[Install {metricbeat}] on each
 node.
 
-. Optional: Disable the system module in {metricbeat}. +
-+
---
-Run the following command:
-
-["source","sh",subs="attributes,callouts"]
-----------------------------------------------------------------------
-metricbeat modules disable system
-----------------------------------------------------------------------
-
-For more information, see 
-{metricbeat-ref}/configuration-metricbeat.html[Specify which modules to run] and
-{metricbeat-ref}/metricbeat-module-system.html[System module].
---
-
 . Enable the {es} {xpack} module in {metricbeat} on each node. +
 +
 --
@@ -68,6 +53,12 @@ include::{es-repo-dir}/monitoring/configuring-metricbeat.asciidoc[tag=enable-es-
 include::{es-repo-dir}/monitoring/configuring-metricbeat.asciidoc[tag=configure-es-module]
 
 include::{es-repo-dir}/monitoring/configuring-metricbeat.asciidoc[tag=remote-monitoring-user]
+--
+
+. Optional: Disable the system module in {metricbeat}. +
++
+--
+include::{es-repo-dir}/monitoring/configuring-metricbeat.asciidoc[tag=disable-system-module]
 --
 
 . Identify where to send the {es} monitoring data and supply the necessary
@@ -132,21 +123,6 @@ each node in the production cluster.
 . {metricbeat-ref}/metricbeat-installation.html[Install {metricbeat}] on the 
 same server as {kib}.
 
-. Optional: Disable the system module in {metricbeat}. +
-+
---
-Run the following command:
-
-["source","sh",subs="attributes,callouts"]
-----------------------------------------------------------------------
-metricbeat modules disable system
-----------------------------------------------------------------------
-
-For more information, see 
-{metricbeat-ref}/configuration-metricbeat.html[Specify which modules to run] and
-{metricbeat-ref}/metricbeat-module-system.html[System module].
---
-
 . Enable the {kib} {xpack} module in {metricbeat}. +
 +
 --
@@ -159,6 +135,12 @@ include::{kib-repo-dir}/monitoring/monitoring-metricbeat.asciidoc[tag=enable-kib
 include::{kib-repo-dir}/monitoring/monitoring-metricbeat.asciidoc[tag=configure-kibana-module]
 
 include::{kib-repo-dir}/monitoring/monitoring-metricbeat.asciidoc[tag=remote-monitoring-user]
+--
+
+. Optional: Disable the system module in {metricbeat}. +
++
+--
+include::{kib-repo-dir}/monitoring/monitoring-metricbeat.asciidoc[tag=disable-system-module]
 --
 
 . Identify where to send the {kib} monitoring data and supply the necessary

--- a/docs/en/stack/monitoring/esms.asciidoc
+++ b/docs/en/stack/monitoring/esms.asciidoc
@@ -2,21 +2,28 @@
 [[esms]]
 == {stack} Monitoring Service
 
-The {stack} Monitoring Service (ESMS) is an additional service that deploys
-a monitoring cluster running {es} and {kib}. 
+The {stack} Monitoring Service (ESMS) is a monitoring cluster on Cloud that
+Elastic provides to self-managed commercial customers. If you send your
+monitoring data to the ESMS, it can also be used by Elastic support to provide
+better and faster incident resolution. 
 
-In 6.4 and later, you can use {metricbeat} to ship monitoring data about 
-{kib} to ESMS. In 6.5 and later, you can do the same for {es}.
+NOTE: You must obtain your ESMS cluster URLs and credentials from the Elastic
+support team.
 
-To store monitoring data in ESMS:
+[discrete]
+[[esms-elasticsearch]]
+=== Collecting monitoring data about {es}
 
-. Obtain your ESMS cluster URLs and credentials from the Elastic support team.
+There are two methods for collecting and sending data about the health of your
+production cluster to ESMS: {metricbeat} or collectors and exporters.
 
-. Configure your production cluster to collect data and send it to the 
-monitoring cluster.
-** {ref}/configuring-metricbeat.html[Use {metricbeat}]. This option 
-is available in 6.5 and later versions.
-... Configure the following settings on each node in the production cluster:
+TIP: If you want to monitor {ls}, you must use collectors and exporters to
+route data from the production cluster to ESMS. Otherwise, it is simplest to use
+{metricbeat}. 
+
+To use {metricbeat}:
+
+. Configure the following settings on each node in the production cluster:
 +
 --
 [source,js]
@@ -35,8 +42,10 @@ PUT _cluster/settings
 Alternatively, you can put those settings in the `elasticsearch.yml` file on
 each node. This method, however, requires you to restart each node.
 --
-... {metricbeat-ref}/metricbeat-installation.html[Install {metricbeat}].
-... Enable the {es} module in {metricbeat}.
+
+. {metricbeat-ref}/metricbeat-installation.html[Install {metricbeat}].
+
+. Enable the {es} module in {metricbeat}.
 +
 --
 For example, to enable the default configuration in the `modules.d` directory, 
@@ -51,12 +60,14 @@ For more information, see
 {metricbeat-ref}/configuration-metricbeat.html[Specify which modules to run] and 
 {metricbeat-ref}/metricbeat-module-elasticsearch.html[{es} module]. 
 --
-... By default, the module collects {es} monitoring metrics from `http://localhost:9200`.
+
+. By default, the module collects {es} monitoring metrics from `http://localhost:9200`.
 If your local {es} node has a different address, you must specify it via the
 `hosts` setting in the `modules.d/elasticsearch-xpack.yml` file. If your cluster
 uses {ref}/configuring-tls.html[encrypted communications], you must access it
 via HTTPS. For example, use a `hosts` setting like `https://localhost:9200`.
-... If {es} {security-features} are enabled in your production cluster,
+
+. If {es} {security-features} are enabled in your production cluster,
 {metricbeat} must use a valid user ID and password to collect metrics
 successfully. 
 +
@@ -67,7 +78,8 @@ Alternatively, use the
 {stack-ov}/built-in-users.html[`remote_monitoring_user` built-in user].
 
 Add the `username` and `password` settings to the {es} module configuration
-file. For example, add the following settings in the `modules.d/elasticsearch-xpack.yml` file:
+file. For example, add the following settings in the
+`modules.d/elasticsearch-xpack.yml` file:
 
 [source,yaml]
 ----------------------------------
@@ -77,7 +89,8 @@ file. For example, add the following settings in the `modules.d/elasticsearch-xp
   password: YOUR_PASSWORD
 ----------------------------------
 --
-... Identify where to send the {es} monitoring data and supply the necessary
+
+. Identify where to send the {es} monitoring data and supply the necessary
 security information. Add the following settings in the {metricbeat}
 configuration file (`metricbeat.yml`):
 +
@@ -93,13 +106,19 @@ output.elasticsearch:
 <2> Replace `MONITORING_AGENT_PASSWORD` with the value provided to you by the
 Elastic support team.
 --
-... {ref}/starting-elasticsearch.html[Start {es}].
-... {metricbeat-ref}/metricbeat-starting.html[Start {metricbeat}].
-** {ref}/configuring-monitoring.html[Use HTTP exporters]. For example:
-... Copy the certificates that you obtained from the Elastic support team to the
+
+. {ref}/starting-elasticsearch.html[Start {es}].
+
+. {metricbeat-ref}/metricbeat-starting.html[Start {metricbeat}].
+
+To use collectors and exporters:
+
+. Copy the certificates that you obtained from the Elastic support team to the
 {es} configuration directory (`ES_PATH_CONF`) on each node. These certificates
-enable your production cluster to verify the identity of the ESMS and communicate securely.
-... Configure the following settings on each node in the production cluster:
+enable your production cluster to verify the identity of the ESMS and
+communicate securely.
+
+. Configure the following settings on each node in the production cluster:
 +
 --
 [source,js]
@@ -120,13 +139,143 @@ PUT _cluster/settings
 ----------------------------------
 // CONSOLE
 <1> Replace `MONITORING_ELASTICSEARCH_URL` with the appropriate URL from the ESMS.
-<2> Replace `MONITORING_AGENT_PASSWORD` with the value provided to you by the Elastic support team.
+<2> Replace `MONITORING_AGENT_PASSWORD` with the value provided to you by the
+Elastic support team.
 <3> Replace the path and file name with the appropriate information for the file
 provided by the Elastic support team.
 
 Alternatively, you can put those settings in the `elasticsearch.yml` file on
 each node. This method, however, requires you to restart each node.
 --
+
+[discrete]
+[[esms-kibana]]
+=== Collecting monitoring data about {kib}
+
+There are two methods for sending monitoring data about {kib} to ESMS. You can
+send it directly to ESMS by using {metricbeat} or you can route it through
+exporters on the production cluster.
+
+TIP: It is simplest to use {metricbeat}. 
+
+To use {metricbeat}:
+
+. Disable the default collection of {kib} monitoring metrics. +
++
+--
+Add the following setting in the {kib} configuration file (`kibana.yml`): 
+
+[source,yaml]
+----------------------------------
+xpack.monitoring.kibana.collection.enabled: false
+----------------------------------
+
+Leave the `xpack.monitoring.enabled` set to its default value (`true`). 
+
+For more information, see 
+{kibana-ref}/monitoring-settings-kb.html[Monitoring settings in {kib}].
+--
+
+. {kibana-ref}/start-stop.html[Start {kib}].
+
+. Ensure that the `xpack.monitoring.collection.enabled` setting to `true` on 
+each node in the production cluster.
+
+. {metricbeat-ref}/metricbeat-installation.html[Install {metricbeat}] on the 
+same server as {kib}.
+
+. Enable the {kib} module in {metricbeat}. +
++
+--
+For example, to enable the default configuration in the `modules.d` directory, 
+run the following command:
+
+["source","sh",subs="attributes,callouts"]
+----------------------------------------------------------------------
+metricbeat modules enable kibana
+----------------------------------------------------------------------
+
+For more information, see 
+{metricbeat-ref}/configuration-metricbeat.html[Specify which modules to run] and 
+{metricbeat-ref}/metricbeat-module-kibana.html[{kib} module]. 
+--
+
+. Configure the {kib} module in {metricbeat}. +
++
+--
+You must specify the following settings in the `modules.d/kibana.yml` file:
+
+[source,yaml]
+----------------------------------
+- module: kibana
+  metricsets:
+    - stats
+  period: 10s
+  hosts: ["http://localhost:5601"] <1>
+  xpack.enabled: true <2>
+----------------------------------
+<1> This setting identifies the host and port number that are used to access {kib}. 
+<2> This setting ensures that {kib} can read the monitoring data successfully. 
+That is to say, it's stored in the same location and format as monitoring data 
+that is sent by {ref}/es-monitoring-exporters.html[exporters].  
+--
+
+. If the {stack} {security-features} are enabled, you must also provide a user 
+ID and password so that {metricbeat} can collect metrics successfully. 
+
+.. Create a user on the production cluster that has the 
+`remote_monitoring_collector` {stack-ov}/built-in-roles.html[built-in role]. 
+Alternatively, use the `remote_monitoring_user` 
+{stack-ov}/built-in-users.html[built-in user].
+
+.. Add the `username` and `password` settings to the {kib} module configuration 
+file.
++
+--
+For example, add the following settings in the `modules.d/kibana.yml` file:
+
+[source,yaml]
+----------------------------------
+- module: kibana
+  ...
+  username: remote_monitoring_user
+  password: YOUR_PASSWORD
+----------------------------------
+--
+
+. If you configured {kib} to use
+{kibana-ref}/configuring-tls.html[encrypted communications], you must access it
+via HTTPS. For example, use a `hosts` setting like 
+`https://localhost:5601` in the `modules.d/kibana.yml` file. 
+
+. Identify where to send the {kib} monitoring data and supply the necessary
+security information. Add the following settings in the {metricbeat} 
+configuration file (`metricbeat.yml`):
++
+--
+[source,yaml]
+----------------------------------
+  output.elasticsearch:
+    hosts: ["MONITORING_ELASTICSEARCH_URL"] <1>
+    username: cloud_monitoring_agent
+    password: MONITORING_AGENT_PASSWORD <2>
+----------------------------------
+<1> Replace `MONITORING_ELASTICSEARCH_URL` with the appropriate URL from the ESMS.
+<2> Replace `MONITORING_AGENT_PASSWORD` with the value provided to you by the
+  Elastic support team.
+--
+
+. {metricbeat-ref}/metricbeat-starting.html[Start {metricbeat}]. 
+
+////
+To use HTTP exporters:
+TBD
+
+
+[discrete]
+[[esms-logstash]]
+=== Collecting monitoring data about {ls}
+
 . (Optional)
 {logstash-ref}/configuring-logstash.html[Configure {ls} to collect data and send it to the monitoring cluster]. 
 +
@@ -136,10 +285,10 @@ data to ESMS. It cannot be accomplished by using {metricbeat}.
 
 --
 
-. (Optional) Configure {kib} to collect data and send it to the monitoring cluster:
-** {kibana-ref}/monitoring-metricbeat.html[Use {metricbeat}]. This 
-option is available in 6.4 and later versions. 
-** {kibana-ref}/monitoring-kibana.html[Use HTTP exporters].
+[[esms-view]]
+=== Viewing monitoring data
 
-. View the monitoring data by logging into {kib} on ESMS. For more information,
-see {kibana-ref}/xpack-monitoring.html[Monitoring]. 
+You can view the monitoring data by logging into {kib} on ESMS. The {kib} URL is
+provided by the Elastic support team. For more information about the monitoring
+interface in {kib}, see {kibana-ref}/xpack-monitoring.html[Monitoring]. 
+////

--- a/docs/en/stack/monitoring/esms.asciidoc
+++ b/docs/en/stack/monitoring/esms.asciidoc
@@ -54,6 +54,22 @@ For more information about these settings, see
 . {metricbeat-ref}/metricbeat-installation.html[Install {metricbeat}] on each
 node.
 
+. Optional: Disable the system module in {metricbeat}. +
++
+--
+Run the following command:
+
+["source","sh",subs="attributes,callouts"]
+----------------------------------------------------------------------
+metricbeat modules disable system
+----------------------------------------------------------------------
+
+For more information, see 
+{metricbeat-ref}/configuration-metricbeat.html[Specify which modules to run] and
+{metricbeat-ref}/metricbeat-module-system.html[System module].
+--
+
+
 . Enable the {es} {xpack} module in {metricbeat} on each node. +
 +
 --
@@ -129,6 +145,21 @@ each node in the production cluster.
 
 . {metricbeat-ref}/metricbeat-installation.html[Install {metricbeat}] on the 
 same server as {kib}.
+
+. Optional: Disable the system module in {metricbeat}. +
++
+--
+Run the following command:
+
+["source","sh",subs="attributes,callouts"]
+----------------------------------------------------------------------
+metricbeat modules disable system
+----------------------------------------------------------------------
+
+For more information, see 
+{metricbeat-ref}/configuration-metricbeat.html[Specify which modules to run] and
+{metricbeat-ref}/metricbeat-module-system.html[System module].
+--
 
 . Enable the {kib} {xpack} module in {metricbeat}. +
 +

--- a/docs/en/stack/monitoring/esms.asciidoc
+++ b/docs/en/stack/monitoring/esms.asciidoc
@@ -23,6 +23,8 @@ route data from the production cluster to ESMS. Otherwise, it is simplest to use
 
 To use {metricbeat}:
 
+. If your production cluster is stopped, {ref}/starting-elasticsearch.html[start it].
+
 . Configure the following settings on each node in the production cluster:
 +
 --
@@ -31,7 +33,6 @@ To use {metricbeat}:
 PUT _cluster/settings
 {
   "persistent": {
-    "xpack.monitoring.enabled": true,
     "xpack.monitoring.collection.enabled": true,
     "xpack.monitoring.elasticsearch.collection.enabled": false
   }
@@ -41,6 +42,13 @@ PUT _cluster/settings
 
 Alternatively, you can put those settings in the `elasticsearch.yml` file on
 each node. This method, however, requires you to restart each node.
+
+The `xpack.monitoring.enabled` setting must also have a value of `true`, which
+is its default value. If you have set it to `false` in the `elasticsearch.yml`
+file on any node, you must change or remove it.
+
+For more information about these settings, see
+{ref}/monitoring-settings.html[Monitoring settings in {es}].
 --
 
 . {metricbeat-ref}/metricbeat-installation.html[Install {metricbeat}].
@@ -99,18 +107,19 @@ configuration file (`metricbeat.yml`):
 ----------------------------------
 output.elasticsearch:
   hosts: ["MONITORING_ELASTICSEARCH_URL"] <1>
-  username: cloud_monitoring_agent
-  password: MONITORING_AGENT_PASSWORD <2>
+  username: cloud_monitoring_agent <2>
+  password: MONITORING_AGENT_PASSWORD <3>
 ----------------------------------
 <1> Replace `MONITORING_ELASTICSEARCH_URL` with the appropriate URL from the ESMS.
-<2> Replace `MONITORING_AGENT_PASSWORD` with the value provided to you by the
+<2> The Elastic support team creates this user in ESMS and grants it the
+{stack-ov}/built-in-roles.html[`remote_monitoring_agent` built-in role]. 
+<3> Replace `MONITORING_AGENT_PASSWORD` with the value provided to you by the
 Elastic support team.
 --
 
-. {ref}/starting-elasticsearch.html[Start {es}].
-
 . {metricbeat-ref}/metricbeat-starting.html[Start {metricbeat}].
 
+////
 To use collectors and exporters:
 
 . Copy the certificates that you obtained from the Elastic support team to the
@@ -131,23 +140,26 @@ PUT _cluster/settings
     "xpack.monitoring.elasticsearch.collection.enabled": true,
     "xpack.monitoring.exporters.cloud_monitoring.type": "http",
     "xpack.monitoring.exporters.cloud_monitoring.host": "MONITORING_ELASTICSEARCH_URL", <1>
-    "xpack.monitoring.exporters.cloud_monitoring.auth.username": "cloud_monitoring_agent",
-    "xpack.monitoring.exporters.cloud_monitoring.auth.password": "MONITORING_AGENT_PASSWORD" <2>
-    "xpack.monitoring.exporters.cloud_monitoring.ssl.certificate_authorities": "ES_PATH_CONF/ca.crt" <3>
+    "xpack.monitoring.exporters.cloud_monitoring.auth.username": "cloud_monitoring_agent", <2>
+    "xpack.monitoring.exporters.cloud_monitoring.auth.password": "MONITORING_AGENT_PASSWORD" <3>
+    "xpack.monitoring.exporters.cloud_monitoring.ssl.certificate_authorities": "ES_PATH_CONF/ca.crt" <4>
   }
 }
 ----------------------------------
 // CONSOLE
 <1> Replace `MONITORING_ELASTICSEARCH_URL` with the appropriate URL from the ESMS.
-<2> Replace `MONITORING_AGENT_PASSWORD` with the value provided to you by the
+<2> The Elastic support team creates this user in ESMS and grants it the
+{stack-ov}/built-in-roles.html[`remote_monitoring_agent` built-in role]. 
+<3> Replace `MONITORING_AGENT_PASSWORD` with the value provided to you by the
 Elastic support team.
-<3> Replace the path and file name with the appropriate information for the file
+<4> Replace the path and file name with the appropriate information for the file
 provided by the Elastic support team.
 
 Alternatively, you can put those settings in the `elasticsearch.yml` file on
 each node. This method, however, requires you to restart each node.
 --
-
+////
+////
 [discrete]
 [[esms-kibana]]
 === Collecting monitoring data about {kib}
@@ -257,16 +269,19 @@ configuration file (`metricbeat.yml`):
 ----------------------------------
   output.elasticsearch:
     hosts: ["MONITORING_ELASTICSEARCH_URL"] <1>
-    username: cloud_monitoring_agent
-    password: MONITORING_AGENT_PASSWORD <2>
+    username: cloud_monitoring_agent <2>
+    password: MONITORING_AGENT_PASSWORD <3>
 ----------------------------------
 <1> Replace `MONITORING_ELASTICSEARCH_URL` with the appropriate URL from the ESMS.
-<2> Replace `MONITORING_AGENT_PASSWORD` with the value provided to you by the
+<2> The Elastic support team creates this user in ESMS and grants it the
+{stack-ov}/built-in-roles.html[`remote_monitoring_agent` built-in role]. 
+<3> Replace `MONITORING_AGENT_PASSWORD` with the value provided to you by the
   Elastic support team.
 --
 
 . {metricbeat-ref}/metricbeat-starting.html[Start {metricbeat}]. 
 
+////
 ////
 To use HTTP exporters:
 TBD

--- a/docs/en/stack/monitoring/esms.asciidoc
+++ b/docs/en/stack/monitoring/esms.asciidoc
@@ -191,7 +191,7 @@ For more information, see
 
 . {kibana-ref}/start-stop.html[Start {kib}].
 
-. Ensure that the `xpack.monitoring.collection.enabled` setting to `true` on 
+. Ensure that the `xpack.monitoring.collection.enabled` setting is `true` on 
 each node in the production cluster.
 
 . {metricbeat-ref}/metricbeat-installation.html[Install {metricbeat}] on the 
@@ -209,10 +209,12 @@ include::{kib-repo-dir}/monitoring/monitoring-metricbeat.asciidoc[tag=enable-kib
 include::{kib-repo-dir}/monitoring/monitoring-metricbeat.asciidoc[tag=configure-kibana-module]
 --
 
-. If the {stack} {security-features} are enabled, you must also provide a user 
+. If the {stack} {security-features} are enabled, you must also provide a user
 ID and password so that {metricbeat} can collect metrics successfully. 
-
++
+--
 include::{kib-repo-dir}/monitoring/monitoring-metricbeat.asciidoc[tag=remote-monitoring-user]
+--
 
 . If you configured {kib} to use
 {kibana-ref}/configuring-tls.html[encrypted communications], you must access it
@@ -220,8 +222,8 @@ via HTTPS. For example, use a `hosts` setting like
 `https://localhost:5601` in the `modules.d/kibana-xpack.yml` file. 
 
 . Identify where to send the {kib} monitoring data and supply the necessary
-security information. If you have not already done so, add the following
-settings in the {metricbeat} configuration file (`metricbeat.yml`):
+security information. Add the following settings in the {metricbeat}
+configuration file (`metricbeat.yml`):
 +
 --
 [source,yaml]

--- a/docs/en/stack/monitoring/esms.asciidoc
+++ b/docs/en/stack/monitoring/esms.asciidoc
@@ -13,13 +13,10 @@ To store monitoring data in ESMS:
 . Obtain your ESMS cluster URLs and credentials from the Elastic support team.
 
 . Configure your production cluster to collect data and send it to the 
-monitoring cluster. 
-
+monitoring cluster.
 ** {ref}/configuring-metricbeat.html[Use {metricbeat}]. This option 
-is available in 6.5 and later versions. 
-
-** {ref}/configuring-monitoring.html[Use HTTP exporters]. For example, on
-each node in the production cluster, configure the following settings:
+is available in 6.5 and later versions.
+... Configure the following settings on each node in the production cluster:
 +
 --
 [source,js]
@@ -27,21 +24,122 @@ each node in the production cluster, configure the following settings:
 PUT _cluster/settings
 {
   "persistent": {
-    "xpack.monitoring.collection.enabled": true
+    "xpack.monitoring.enabled": true,
+    "xpack.monitoring.collection.enabled": true,
+    "xpack.monitoring.elasticsearch.collection.enabled": false
+  }
+}
+----------------------------------
+// CONSOLE
+
+Alternatively, you can put those settings in the `elasticsearch.yml` file on
+each node. This method, however, requires you to restart each node.
+--
+... {metricbeat-ref}/metricbeat-installation.html[Install {metricbeat}].
+... Enable the {es} module in {metricbeat}.
++
+--
+For example, to enable the default configuration in the `modules.d` directory, 
+run the following command:
+
+["source","sh",subs="attributes,callouts"]
+----------------------------------------------------------------------
+metricbeat modules enable elasticsearch-xpack
+----------------------------------------------------------------------
+
+For more information, see 
+{metricbeat-ref}/configuration-metricbeat.html[Specify which modules to run] and 
+{metricbeat-ref}/metricbeat-module-elasticsearch.html[{es} module]. 
+--
+... By default, the module collects {es} monitoring metrics from `http://localhost:9200`.
+If your local {es} node has a different address, you must specify it via the
+`hosts` setting in the `modules.d/elasticsearch-xpack.yml` file. If your cluster
+uses {ref}/configuring-tls.html[encrypted communications], you must access it
+via HTTPS. For example, use a `hosts` setting like `https://localhost:9200`.
+... If {es} {security-features} are enabled in your production cluster,
+{metricbeat} must use a valid user ID and password to collect metrics
+successfully. 
++
+--
+Create a user on the production cluster that has the
+{stack-ov}/built-in-roles.html[`remote_monitoring_collector` built-in role]. 
+Alternatively, use the
+{stack-ov}/built-in-users.html[`remote_monitoring_user` built-in user].
+
+Add the `username` and `password` settings to the {es} module configuration
+file. For example, add the following settings in the `modules.d/elasticsearch-xpack.yml` file:
+
+[source,yaml]
+----------------------------------
+- module: elasticsearch
+  ...
+  username: remote_monitoring_user
+  password: YOUR_PASSWORD
+----------------------------------
+--
+... Identify where to send the {es} monitoring data and supply the necessary
+security information. Add the following settings in the {metricbeat}
+configuration file (`metricbeat.yml`):
++
+--
+[source,yaml]
+----------------------------------
+output.elasticsearch:
+  hosts: ["MONITORING_ELASTICSEARCH_URL"] <1>
+  username: cloud_monitoring_agent
+  password: MONITORING_AGENT_PASSWORD <2>
+----------------------------------
+<1> Replace `MONITORING_ELASTICSEARCH_URL` with the appropriate URL from the ESMS.
+<2> Replace `MONITORING_AGENT_PASSWORD` with the value provided to you by the
+Elastic support team.
+--
+... {ref}/starting-elasticsearch.html[Start {es}].
+... {metricbeat-ref}/metricbeat-starting.html[Start {metricbeat}].
+** {ref}/configuring-monitoring.html[Use HTTP exporters]. For example:
+... Copy the certificates that you obtained from the Elastic support team to the
+{es} configuration directory (`ES_PATH_CONF`) on each node. These certificates
+enable your production cluster to verify the identity of the ESMS and communicate securely.
+... Configure the following settings on each node in the production cluster:
++
+--
+[source,js]
+----------------------------------
+PUT _cluster/settings
+{
+  "persistent": {
+    "xpack.monitoring.enabled": true,
+    "xpack.monitoring.collection.enabled": true,
+    "xpack.monitoring.elasticsearch.collection.enabled": true,
     "xpack.monitoring.exporters.cloud_monitoring.type": "http",
     "xpack.monitoring.exporters.cloud_monitoring.host": "MONITORING_ELASTICSEARCH_URL", <1>
     "xpack.monitoring.exporters.cloud_monitoring.auth.username": "cloud_monitoring_agent",
     "xpack.monitoring.exporters.cloud_monitoring.auth.password": "MONITORING_AGENT_PASSWORD" <2>
+    "xpack.monitoring.exporters.cloud_monitoring.ssl.certificate_authorities": "ES_PATH_CONF/ca.crt" <3>
   }
 }
 ----------------------------------
 // CONSOLE
 <1> Replace `MONITORING_ELASTICSEARCH_URL` with the appropriate URL from the ESMS.
 <2> Replace `MONITORING_AGENT_PASSWORD` with the value provided to you by the Elastic support team.
+<3> Replace the path and file name with the appropriate information for the file
+provided by the Elastic support team.
 
 Alternatively, you can put those settings in the `elasticsearch.yml` file on
 each node. This method, however, requires you to restart each node.
 --
+. (Optional)
+{logstash-ref}/configuring-logstash.html[Configure {ls} to collect data and send it to the monitoring cluster]. 
++
+--
+NOTE: You must configure HTTP exporters in the production cluster to route this 
+data to ESMS. It cannot be accomplished by using {metricbeat}. 
+
+--
+
+. (Optional) Configure {kib} to collect data and send it to the monitoring cluster:
+** {kibana-ref}/monitoring-metricbeat.html[Use {metricbeat}]. This 
+option is available in 6.4 and later versions. 
+** {kibana-ref}/monitoring-kibana.html[Use HTTP exporters].
 
 . View the monitoring data by logging into {kib} on ESMS. For more information,
 see {kibana-ref}/xpack-monitoring.html[Monitoring]. 

--- a/docs/en/stack/monitoring/esms.asciidoc
+++ b/docs/en/stack/monitoring/esms.asciidoc
@@ -23,33 +23,19 @@ use {metricbeat}.
 
 To use {metricbeat}:
 
-. If your production cluster is stopped,
-{ref}/starting-elasticsearch.html[start it].
-
-. Configure the following settings on each node in the production cluster:
+. Enable the collection of monitoring data on your cluster.
 +
 --
-[source,js]
-----------------------------------
-PUT _cluster/settings
-{
-  "persistent": {
-    "xpack.monitoring.collection.enabled": true,
-    "xpack.monitoring.elasticsearch.collection.enabled": false
-  }
-}
-----------------------------------
-// CONSOLE
-
-Alternatively, you can put those settings in the `elasticsearch.yml` file on
-each node. This method, however, requires you to restart each node.
-
-The `xpack.monitoring.enabled` setting must also have a value of `true`, which
-is its default value. If you have set it to `false` in the `elasticsearch.yml`
-file on any node, you must change or remove it.
+include::{es-repo-dir}/monitoring/configuring-metricbeat.asciidoc[tag=enable-collection]
 
 For more information about these settings, see
 {ref}/monitoring-settings.html[Monitoring settings in {es}].
+--
+
+. Disable the default collection of {es} monitoring metrics.
++
+--
+include::{es-repo-dir}/monitoring/configuring-metricbeat.asciidoc[tag=disable-default-collection]
 --
 
 . {metricbeat-ref}/metricbeat-installation.html[Install {metricbeat}] on each

--- a/docs/en/stack/monitoring/esms.asciidoc
+++ b/docs/en/stack/monitoring/esms.asciidoc
@@ -119,6 +119,14 @@ Elastic support team.
 
 . {metricbeat-ref}/metricbeat-starting.html[Start {metricbeat}].
 
+. Verify that your monitoring data exists in ESMS.
++
+--
+Open {kib} in your web browser. Use the {kib} URL and the administrator user ID
+that was provided to you by the Elastic support team. Add an
+{kibana-ref}/index-patterns.html[index pattern] and
+{kibana-ref}/discover.html[explore] your monitoring data.
+--
 ////
 To use collectors and exporters:
 
@@ -159,7 +167,7 @@ Alternatively, you can put those settings in the `elasticsearch.yml` file on
 each node. This method, however, requires you to restart each node.
 --
 ////
-////
+
 [discrete]
 [[esms-kibana]]
 === Collecting monitoring data about {kib}
@@ -223,10 +231,11 @@ You must specify the following settings in the `modules.d/kibana.yml` file:
   metricsets:
     - stats
   period: 10s
-  hosts: ["http://localhost:5601"] <1>
+  hosts: ["KIBANA_URL"] <1>
   xpack.enabled: true <2>
 ----------------------------------
-<1> This setting identifies the host and port number that are used to access {kib}. 
+<1> This setting identifies the host and port number that you use to access
+{kib}. For example, `http://localhost:5601`.
 <2> This setting ensures that {kib} can read the monitoring data successfully. 
 That is to say, it's stored in the same location and format as monitoring data 
 that is sent by {ref}/es-monitoring-exporters.html[exporters].  
@@ -261,8 +270,8 @@ via HTTPS. For example, use a `hosts` setting like
 `https://localhost:5601` in the `modules.d/kibana.yml` file. 
 
 . Identify where to send the {kib} monitoring data and supply the necessary
-security information. Add the following settings in the {metricbeat} 
-configuration file (`metricbeat.yml`):
+security information. If you have not already done so, add the following
+settings in the {metricbeat} configuration file (`metricbeat.yml`):
 +
 --
 [source,yaml]
@@ -281,7 +290,14 @@ configuration file (`metricbeat.yml`):
 
 . {metricbeat-ref}/metricbeat-starting.html[Start {metricbeat}]. 
 
-////
+. Verify that your monitoring data exists in ESMS.
++
+--
+Open {kib} in your web browser. Use the {kib} URL and the administrator user ID
+that was provided to you by the Elastic support team. If it doesn't already
+exist, add an {kibana-ref}/index-patterns.html[index pattern] and
+{kibana-ref}/discover.html[explore] your monitoring data.
+--
 ////
 To use HTTP exporters:
 TBD

--- a/docs/en/stack/monitoring/esms.asciidoc
+++ b/docs/en/stack/monitoring/esms.asciidoc
@@ -1,0 +1,47 @@
+[role="xpack"]
+[[esms]]
+== {stack} Monitoring Service
+
+The {stack} Monitoring Service (ESMS) is an additional service that deploys
+a monitoring cluster running {es} and {kib}. 
+
+In 6.4 and later, you can use {metricbeat} to ship monitoring data about 
+{kib} to ESMS. In 6.5 and later, you can do the same for {es}.
+
+To store monitoring data in ESMS:
+
+. Obtain your ESMS cluster URLs and credentials from the Elastic support team.
+
+. Configure your production cluster to collect data and send it to the 
+monitoring cluster. 
+
+** {ref}/configuring-metricbeat.html[Use {metricbeat}]. This option 
+is available in 6.5 and later versions. 
+
+** {ref}/configuring-monitoring.html[Use HTTP exporters]. For example, on
+each node in the production cluster, configure the following settings:
++
+--
+[source,js]
+----------------------------------
+PUT _cluster/settings
+{
+  "persistent": {
+    "xpack.monitoring.collection.enabled": true
+    "xpack.monitoring.exporters.cloud_monitoring.type": "http",
+    "xpack.monitoring.exporters.cloud_monitoring.host": "MONITORING_ELASTICSEARCH_URL", <1>
+    "xpack.monitoring.exporters.cloud_monitoring.auth.username": "cloud_monitoring_agent",
+    "xpack.monitoring.exporters.cloud_monitoring.auth.password": "MONITORING_AGENT_PASSWORD" <2>
+  }
+}
+----------------------------------
+// CONSOLE
+<1> Replace `MONITORING_ELASTICSEARCH_URL` with the appropriate URL from the ESMS.
+<2> Replace `MONITORING_AGENT_PASSWORD` with the value provided to you by the Elastic support team.
+
+Alternatively, you can put those settings in the `elasticsearch.yml` file on
+each node. This method, however, requires you to restart each node.
+--
+
+. View the monitoring data by logging into {kib} on ESMS. For more information,
+see {kibana-ref}/xpack-monitoring.html[Monitoring]. 

--- a/docs/en/stack/monitoring/index.asciidoc
+++ b/docs/en/stack/monitoring/index.asciidoc
@@ -1,3 +1,4 @@
 include::intro.asciidoc[]
 include::how-monitoring-works.asciidoc[]
 include::production.asciidoc[]
+include::esms.asciidoc[]

--- a/docs/en/stack/monitoring/production.asciidoc
+++ b/docs/en/stack/monitoring/production.asciidoc
@@ -5,7 +5,8 @@
 By default, monitoring agents store data in the cluster where they're running.
 In production, you should
 send data to a separate _monitoring cluster_ so that historical monitoring
-data is available even when the nodes you are monitoring are not. 
+data is available even when the nodes you are monitoring are not. If you are
+sending your data to the ESMS, see <<esms>>.
 
 In 6.4 and later, you can use {metricbeat} to ship monitoring data about 
 {kib} to a separate monitoring cluster. In 6.5 and later, you can do the same 

--- a/docs/en/stack/monitoring/troubleshooting.asciidoc
+++ b/docs/en/stack/monitoring/troubleshooting.asciidoc
@@ -4,5 +4,17 @@
 <titleabbrev>Monitoring</titleabbrev>
 ++++
 
-See
+See also
 {logstash-ref}/monitoring-troubleshooting.html[Troubleshooting monitoring in Logstash].
+
+*Symptoms*:
+There is no information about your cluster on the *Monitoring* page in {kib}.
+
+*Resolution*:
+Check whether the appropriate indices exist on the monitoring cluster. For
+example, use the {ref}/cat-indices.html[cat indices] command to verify that
+there is a `.monitoring-kibana*` index for your {kib} monitoring data and a
+`.monitoring-es*` index for your {es} monitoring data. If you are collecting
+monitoring data by using {metricbeat} the indices have `-mb` in their names. If
+the indices do not exist, review your configuration: <<xpack-monitoring>>.
+


### PR DESCRIPTION
This PR adds information similar to https://www.elastic.co/guide/en/elastic-stack-overview/master/monitoring-production.html, but instead of sending the monitoring data to a monitoring cluster, it is sent to the Elasticsearch Stack Monitoring Service.

Initially this page contains instructions for using Metricbeat to monitor Kibana and Elasticsearch.  It will be expanded to describe using collectors and exporters and monitoring Logstash.

This PR depends on tagged regions that are implemented in https://github.com/elastic/kibana/pull/37123,  https://github.com/elastic/elasticsearch/pull/42547, https://github.com/elastic/elasticsearch/pull/42601,  and https://github.com/elastic/kibana/pull/37198 to permit content-reuse. It also uses attributes implemented in https://github.com/elastic/docs/pull/902