### PR TITLE
Typo in gke-on-prem-introduction

### DIFF
--- a/docs/en/gke-on-prem/gke-on-prem-introduction.asciidoc
+++ b/docs/en/gke-on-prem/gke-on-prem-introduction.asciidoc
@@ -11,7 +11,7 @@ your GKE On-Prem systems to give you greater observability into the services and
 applications that you provide to your end users.
 
 Whether you choose to deploy GKE On-Prem for security, compliance, or to benefit
-from using the best service regardless of where they run (in your data center of
+from using the best service regardless of where they run (in your data center or in
 Google Cloud), you should consider having your logs and metrics indexed, stored,
 analyzed, and visualized on premises. The {stack} supports on premises
 deployments using the {elasticgetstarted}[downloaded binaries] or using


### PR DESCRIPTION
typo correction:
was: in your data center of Google Cloud 
changed to: in your data center or in
Google Cloud