### PR TITLE
fixed branding mentioned in issue 320

### DIFF
--- a/docs/en/gke-on-prem/index.asciidoc
+++ b/docs/en/gke-on-prem/index.asciidoc
@@ -18,7 +18,7 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :k8s-metadata-labels: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 
 [[gke-on-prem]]
-= Elastic Stack and Google Cloud Anthos : Combining logs and metrics from Google Cloud's Anthos GKE On-Prem with traditional on premises systems in the Elastic Stack
+= Elastic Stack and Google Cloud's Anthos : Combining logs and metrics from Google Cloud's Anthos GKE On-Prem with traditional on premises systems in the Elastic Stack
 
 include::gke-on-prem-introduction.asciidoc[]
 


### PR DESCRIPTION
I had shortened the title of this doc and removed the possessive `'s` in `Google Cloud's Anthos`.  Google's naming guideline asks for `'s`.