### PR TITLE
Updates links to Kibana breaking changes and highlights

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -90,7 +90,7 @@ coming[7.2.0]
 This list summarizes the most important breaking changes in {kib} {version}. For
 the complete list, go to {kibana-ref}/breaking-changes.html[{kib} breaking changes].
 
-//include::{kib-repo-dir}/migration/migrate_7_1.asciidoc[tag=notable-breaking-changes]
+include::{kib-repo-dir}/migration/migrate_7_2.asciidoc[tag=notable-breaking-changes]
 
 [[logstash-breaking-changes]]
 === {ls} breaking changes

--- a/docs/en/install-upgrade/highlights.asciidoc
+++ b/docs/en/install-upgrade/highlights.asciidoc
@@ -37,10 +37,8 @@ coming[7.2.0]
 This list summarizes the most important enhancements in {kib} {version}.
 For the complete list, go to {kibana-ref}/release-highlights.html[{kib} release highlights].
 
-////
 :leveloffset: +1
 
-include::{kib-repo-dir}/release-notes/highlights-7.1.0.asciidoc[tag=notable-highlights]
+include::{kib-repo-dir}/release-notes/highlights-7.2.0.asciidoc[tag=notable-highlights]
 
 :leveloffset: -1
-////


### PR DESCRIPTION
Depends on https://github.com/elastic/kibana/pull/35989

This PR updates the Installation and Upgrade Guide for 7.x such that it references the appropriate files from the Kibana Guide.