### PR TITLE
[DOCS] Updates links to Kibana and Elasticsearch breaking changes

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -31,6 +31,8 @@ Upgrade Assistant provides information about which {dfeeds} need to be updated.
 This list summarizes the most important breaking changes in APM. 
 For the complete list, go to {apm-get-started-ref}/apm-breaking-changes.html[APM breaking changes].
 
+coming[7.1.0]
+
 include::{apm-repo-dir}/apm-breaking-changes.asciidoc[tag=notable-v7-breaking-changes]
 
 [[beats-breaking-changes]]
@@ -41,6 +43,8 @@ include::{apm-repo-dir}/apm-breaking-changes.asciidoc[tag=notable-v7-breaking-ch
 
 This list summarizes the most important breaking changes in Beats.
 For the complete list, go to {beats-ref}/breaking-changes.html[Beats breaking changes].
+
+coming[7.1.0]
 
 include::{beats-repo-dir}/breaking.asciidoc[tag=notable-breaking-changes]
 
@@ -55,51 +59,9 @@ include::{beats-repo-dir}/breaking.asciidoc[tag=notable-breaking-changes]
 This list summarizes the most important breaking changes in {es} {version}. For
 the complete list, go to {ref}/breaking-changes.html[{es} breaking changes].
 
-include::{es-repo-dir}/reference/migration/migrate_7_0.asciidoc[tag=notable-breaking-changes]
+coming[7.1.0]
 
-include::{es-repo-dir}/reference/migration/migrate_7_0/aggregations.asciidoc[tag=notable-breaking-changes]
-
-include::{es-repo-dir}/reference/migration/migrate_7_0/analysis.asciidoc[tag=notable-breaking-changes]
-
-include::{es-repo-dir}/reference/migration/migrate_7_0/api.asciidoc[tag=notable-breaking-changes]
-
-include::{es-repo-dir}/reference/migration/migrate_7_0/cluster.asciidoc[tag=notable-breaking-changes]
-
-include::{es-repo-dir}/reference/migration/migrate_7_0/discovery.asciidoc[tag=notable-breaking-changes]
-
-include::{es-repo-dir}/reference/migration/migrate_7_0/indices.asciidoc[tag=notable-breaking-changes]
-
-include::{es-repo-dir}/reference/migration/migrate_7_0/ingest.asciidoc[tag=notable-breaking-changes]
-
-include::{es-repo-dir}/reference/migration/migrate_7_0/java_time.asciidoc[tag=notable-breaking-changes]
-
-include::{es-repo-dir}/reference/migration/migrate_7_0/java.asciidoc[tag=notable-breaking-changes]
-
-include::{es-repo-dir}/reference/migration/migrate_7_0/logging.asciidoc[tag=notable-breaking-changes]
-
-include::{es-repo-dir}/reference/migration/migrate_7_0/low_level_restclient.asciidoc[tag=notable-breaking-changes]
-
-include::{es-repo-dir}/reference/migration/migrate_7_0/mappings.asciidoc[tag=notable-breaking-changes]
-
-include::{es-repo-dir}/reference/migration/migrate_7_0/ml.asciidoc[tag=notable-breaking-changes]
-
-include::{es-repo-dir}/reference/migration/migrate_7_0/node.asciidoc[tag=notable-breaking-changes]
-
-include::{es-repo-dir}/reference/migration/migrate_7_0/packaging.asciidoc[tag=notable-breaking-changes]
-
-include::{es-repo-dir}/reference/migration/migrate_7_0/plugins.asciidoc[tag=notable-breaking-changes]
-
-include::{es-repo-dir}/reference/migration/migrate_7_0/restclient.asciidoc[tag=notable-breaking-changes]
-
-include::{es-repo-dir}/reference/migration/migrate_7_0/scripting.asciidoc[tag=notable-breaking-changes]
-
-include::{es-repo-dir}/reference/migration/migrate_7_0/search.asciidoc[tag=notable-breaking-changes]
-
-include::{es-repo-dir}/reference/migration/migrate_7_0/settings.asciidoc[tag=notable-breaking-changes]
-
-include::{es-repo-dir}/reference/migration/migrate_7_0/snapshotstats.asciidoc[tag=notable-breaking-changes]
-
-include::{es-repo-dir}/reference/migration/migrate_7_0/suggesters.asciidoc[tag=notable-breaking-changes]
+include::{es-repo-dir}/reference/migration/migrate_7_1.asciidoc[tag=notable-breaking-changes]
 
 [[elasticsearch-hadoop-breaking-changes]]
 === {es} Hadoop breaking changes
@@ -111,6 +73,8 @@ include::{es-repo-dir}/reference/migration/migrate_7_0/suggesters.asciidoc[tag=n
 This list summarizes the most important breaking changes in {es} Hadoop {version}.
 For the complete list, go to
 {hadoop-ref}/breaking-changes.html[Elasticsearch Hadoop breaking changes].
+
+coming[7.1.0]
 
 include::{hadoop-repo-dir}/appendix/breaking.adoc[tag=notable-v7-breaking-changes]
 
@@ -124,7 +88,9 @@ include::{hadoop-repo-dir}/appendix/breaking.adoc[tag=notable-v7-breaking-change
 This list summarizes the most important breaking changes in {kib} {version}. For
 the complete list, go to {kibana-ref}/breaking-changes.html[{kib} breaking changes].
 
-include::{kib-repo-dir}/migration/migrate_7_0.asciidoc[tag=notable-breaking-changes]
+coming[7.1.0]
+
+include::{kib-repo-dir}/migration/migrate_7_1.asciidoc[tag=notable-breaking-changes]
 
 
 [[logstash-breaking-changes]]
@@ -137,6 +103,8 @@ include::{kib-repo-dir}/migration/migrate_7_0.asciidoc[tag=notable-breaking-chan
 This list summarizes the most important breaking changes in {ls} {version}. For
 the complete list, go to
 {logstash-ref}/breaking-changes.html[Logstash breaking changes].
+
+coming[7.1.0]
 
 include::{ls-repo-dir}/static/breaking-changes.asciidoc[tag=notable-breaking-changes]
 

--- a/docs/en/install-upgrade/highlights.asciidoc
+++ b/docs/en/install-upgrade/highlights.asciidoc
@@ -17,7 +17,9 @@ highlights notable new features and enhancements in {version}.
 This list summarizes the most important enhancements in Beats.
 For the complete list, go to {beats-ref}/release-highlights.html[Beats release highlights].
 
-include::{beats-repo-dir}/highlights-7.0.0.asciidoc[tag=notable-highlights]
+coming[7.1.0]
+
+//include::{beats-repo-dir}/highlights-7.1.0.asciidoc[tag=notable-highlights]
 
 [[elasticsearch-highlights]]
 === {es} highlights
@@ -29,9 +31,11 @@ include::{beats-repo-dir}/highlights-7.0.0.asciidoc[tag=notable-highlights]
 This list summarizes the most important enhancements in {es} {version}.
 For the complete list, go to {ref}/release-highlights.html[{es} release highlights].
 
+coming[7.1.0]
+
 :leveloffset: +1
 
-include::{es-repo-dir}/reference/release-notes/highlights-7.0.0.asciidoc[tag=notable-highlights]
+include::{es-repo-dir}/reference/release-notes/highlights-7.1.0.asciidoc[tag=notable-highlights]
 
 :leveloffset: -1
 
@@ -45,8 +49,10 @@ include::{es-repo-dir}/reference/release-notes/highlights-7.0.0.asciidoc[tag=not
 This list summarizes the most important enhancements in {kib} {version}.
 For the complete list, go to {kibana-ref}/release-highlights.html[{kib} release highlights].
 
+coming[7.1.0]
+
 :leveloffset: +1
 
-include::{kib-repo-dir}/release-notes/highlights-7.0.0.asciidoc[tag=notable-highlights]
+include::{kib-repo-dir}/release-notes/highlights-7.1.0.asciidoc[tag=notable-highlights]
 
 :leveloffset: -1


### PR DESCRIPTION
Depends on https://github.com/elastic/kibana/pull/35994 and https://github.com/elastic/elasticsearch/pull/41773

This PR updates the Installation and Upgrade Guide for 7.1 such that it references the appropriate files from the elasticsearch and kibana repos.