### PR TITLE
Adds OIDC guide to Stack Overview

### DIFF
--- a/docs/en/stack/security/authentication/index.asciidoc
+++ b/docs/en/stack/security/authentication/index.asciidoc
@@ -25,3 +25,6 @@ include::{xes-repo-dir}/security/authentication/user-cache.asciidoc[]
 
 :edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/authentication/saml-guide.asciidoc
 include::{xes-repo-dir}/security/authentication/saml-guide.asciidoc[]
+
+:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/authentication/oidc-guide.asciidoc
+include::{xes-repo-dir}/security/authentication/oidc-guide.asciidoc[]


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/41423

This PR adds the configuration information for the OpenID Connect realm in the Stack Overview.