### PR TITLE
[DOCS] Updates to the Getting started with security tutorial

### DIFF
--- a/docs/en/stack/security/get-started-enable-security.asciidoc
+++ b/docs/en/stack/security/get-started-enable-security.asciidoc
@@ -1,5 +1,5 @@
-When you use the trial license, the {es} {security-features} are disabled by
-default. To enable them:
+When you use the basic and trial licenses, the {es} {security-features} are
+disabled by default. To enable them:
 
 . Stop {kib}. The method for starting and stopping {kib} varies depending on 
 how you installed it. For example, if you installed {kib} from an archive 

--- a/docs/en/stack/security/get-started-security.asciidoc
+++ b/docs/en/stack/security/get-started-security.asciidoc
@@ -24,10 +24,16 @@ running.
 . Launch the {kib} web interface by pointing your browser to port 5601. For 
 example, http://127.0.0.1:5601[http://127.0.0.1:5601].
 
-TIP: By default, when you install {stack} products, they apply basic licenses
-with no expiration dates. To view your license in {kib}, go to **Management**
-and click **License Management**. For more information about Elastic license
-levels, see https://www.elastic.co/subscriptions.
+. Verify that you are using a license that includes the role-based access
+control (RBAC) and native authentication {security-features}. To view your
+license in {kib}, go to **Management** and click **License Management**. 
++
+--
+By default, when you install {stack} products, they apply basic licenses
+with no expiration dates. To complete this tutorial, you must have a basic or
+trial license at a minimum. For more information, see {subscriptions} and
+<<license-management>>.
+--
 
 [role="xpack"]
 [[get-started-enable-security]]

--- a/docs/en/stack/security/get-started-security.asciidoc
+++ b/docs/en/stack/security/get-started-security.asciidoc
@@ -24,11 +24,10 @@ running.
 . Launch the {kib} web interface by pointing your browser to port 5601. For 
 example, http://127.0.0.1:5601[http://127.0.0.1:5601].
 
-[role="xpack"]
-[[get-started-license]]
-=== Install a trial license
-
-include::{docdir}/get-started-trial.asciidoc[]
+TIP: By default, when you install {stack} products, they apply basic licenses
+with no expiration dates. To view your license in {kib}, go to **Management**
+and click **License Management**. For more information about Elastic license
+levels, see https://www.elastic.co/subscriptions.
 
 [role="xpack"]
 [[get-started-enable-security]]
@@ -141,10 +140,9 @@ Go to the *Management / Security / Roles* page to see them:
 [role="screenshot"]
 image::security/images/management-roles.jpg["Role management screenshot in Kibana"]
 
-Select a role to see more information about its privileges. For example, if you 
-select the `kibana_user` role, you will see that it grants `manage`, `read`, 
-`index`, and `delete` privileges on the `.kibana*` indices. To learn more about 
-these privileges, see <<privileges-list-indices>>. 
+Select a role to see more information about its privileges. For example, select
+the `kibana_system` role to see its list of cluster and index privileges. To
+learn more, see <<privileges-list-indices>>. 
 
 Let's assign the `kibana_user` role to your user. Go back to the 
 *Management / Security / Users* page and select your user. Add the `kibana_user` 
@@ -328,12 +326,9 @@ Congratulations! You've successfully set up authentication and authorization by
 using the native realm. You learned how to create user IDs and roles that 
 prevent unauthorized access to the {stack}. 
 
-Next, you'll want to try other features that are unlocked by your trial license, 
-such as {ml}. See <<ml-getting-started,Getting started with {ml}>>. 
-
-Later, when you're ready to increase the number of nodes in your cluster or set 
-up an production environment, you'll want to encrypt communications across the 
-{stack}. To learn how, read <<encrypting-communications>>. 
+Later, when you're ready to increase the number of nodes in your cluster, you'll
+want to encrypt communications across the {stack}. To learn how, read
+<<encrypting-communications>>. 
 
 For more detailed information about securing the {stack}, see:
 

--- a/docs/en/stack/security/securing-communications/tutorial-tls-intro.asciidoc
+++ b/docs/en/stack/security/securing-communications/tutorial-tls-intro.asciidoc
@@ -27,7 +27,7 @@ described in
 particular, this tutorial provides instructions that work with the `zip` and
 `tar.gz` packages.
 
-. <<get-started-license,Install a trial license>>.
+//. <<get-started-license,Install a trial license>>.
 
 . <<get-started-enable-security,Enable the {es} {security-features}>>.
 

--- a/docs/en/stack/security/securing-communications/tutorial-tls-intro.asciidoc
+++ b/docs/en/stack/security/securing-communications/tutorial-tls-intro.asciidoc
@@ -3,10 +3,9 @@
 [[encrypting-internode-communications]]
 == Tutorial: Encrypting communications
 
-In 6.0 and later releases, if you have a gold or higher license and the {es}
-{security-features} are enabled, you must use Transport Layer Security (TLS) to
-encrypt internode communication. In this tutorial, you learn how to meet the
-minimum requirements to pass the 
+When you enable {es} {security-features}, unless you have a trial license, you
+must use Transport Layer Security (TLS) to encrypt internode communication.
+In this tutorial, you learn how to meet the minimum requirements to pass the 
 {ref}/bootstrap-checks-xpack.html#bootstrap-checks-tls[TLS bootstrap check].
 
 NOTE: Single-node clusters that use a loopback interface do not have this
@@ -27,7 +26,16 @@ described in
 particular, this tutorial provides instructions that work with the `zip` and
 `tar.gz` packages.
 
-//. <<get-started-license,Install a trial license>>.
+. Verify that you are using a license that includes the encrypted communications
+{security-features}. To view your license in {kib}, go to *Management* and click
+*License Management*. 
++
+--
+By default, when you install {stack} products, they apply basic licenses with no
+expiration dates. To complete this tutorial, you must have a basic or trial
+license at a minimum. For more information, see {subscriptions} and
+<<license-management>>.
+--
 
 . <<get-started-enable-security,Enable the {es} {security-features}>>.
 


### PR DESCRIPTION
This PR updates the following tutorials in the Stack Overview: 
https://www.elastic.co/guide/en/elastic-stack-overview/master/security-getting-started.html
https://www.elastic.co/guide/en/elastic-stack-overview/master/encrypting-internode-communications.html

NOTE: It also changes the step related to looking at the privileges for the `kibana_user` role, since that information was no longer correct.