### PR TITLE
[DOCS] Remove 'install a trial license' page from 'Tutorial: Getting started with security'

### DIFF
--- a/docs/en/stack/redirects.asciidoc
+++ b/docs/en/stack/redirects.asciidoc
@@ -32,3 +32,10 @@ See <<elasticsearch-security>>.
 === Security files
 
 See {ref}/security-files.html[Security files].
+
+[role="exclude",id="get-started-license"]
+=== Install a trial license
+
+A trial license is no longer needed to use security features.
+
+See https://www.elastic.co/subscriptions[https://www.elastic.co/subscriptions].

--- a/docs/en/stack/security/get-started-security.asciidoc
+++ b/docs/en/stack/security/get-started-security.asciidoc
@@ -25,12 +25,6 @@ running.
 example, http://127.0.0.1:5601[http://127.0.0.1:5601].
 
 [role="xpack"]
-[[get-started-license]]
-=== Install a trial license
-
-include::{docdir}/get-started-trial.asciidoc[]
-
-[role="xpack"]
 [[get-started-enable-security]]
 === Enable {es} {security-features}
 

--- a/docs/en/stack/security/securing-communications/tutorial-tls-intro.asciidoc
+++ b/docs/en/stack/security/securing-communications/tutorial-tls-intro.asciidoc
@@ -27,8 +27,6 @@ described in
 particular, this tutorial provides instructions that work with the `zip` and
 `tar.gz` packages.
 
-. <<get-started-license,Install a trial license>>.
-
 . <<get-started-enable-security,Enable the {es} {security-features}>>.
 
 . <<get-started-built-in-users,Create passwords for built-in users>>.


### PR DESCRIPTION
Removes the [Install a Trial LIcense](https://www.elastic.co/guide/en/elastic-stack-overview/master/get-started-license.html) page from the 'Getting started with security' tutorial in the Stack Overview docs.

Also adds a redirect for the previous anchor.

Plan to backport to 7.x, 7.1, and 6.8

## Note
This is not an exhaustive removal of all security-related license references. Those will be handled with other PRs.
