### PR TITLE
[DOCS] Fix assumption that 6.7 is last 6.x release

### DIFF
--- a/docs/en/install-upgrade/upgrading-stack.asciidoc
+++ b/docs/en/install-upgrade/upgrading-stack.asciidoc
@@ -6,8 +6,8 @@ each of the products in your Elastic Stack. Beats and Logstash 7.n are
 compatible with {es} {version} to give you flexibility in scheduling
 the upgrade.
 
-{es} supports rolling upgrades between minor versions, from {es} 5.6 to 6.7,
-from 6.7 to 7.x, and from 7.n to {version}.
+{es} supports rolling upgrades between minor versions, from {es} 5.6 to 6.8,
+from 6.8 to 7.x, and from 7.n to {version}.
 
 IMPORTANT: 6.x and older indices are not compatible with {version}. You must
 remove or reindex them on your 7.x cluster before upgrading to {version}. The internal
@@ -26,14 +26,14 @@ By default, deprecation warnings are logged when the log level is set to `WARN`.
 . Review the <<elastic-stack-breaking-changes>> and upgrade your code to work
 with {version}.
 
-. Upgrade to 6.7 and use the {kibana-ref}/upgrade-assistant.html[{kib} Upgrade Assistant] to {ref}/docs-reindex.html[reindex]
+. Upgrade to 6.8 and use the {kibana-ref}/upgrade-assistant.html[{kib} Upgrade Assistant] to {ref}/docs-reindex.html[reindex]
 any indices that are not compatible with {version}.
 +
 [role="xpack"]
 .Upgrade Assistant
 ******
 The Upgrade Assistant and migration APIs are enabled with both the Basic and
-Trial licenses. You can install the default distribution of 6.7 to use the
+Trial licenses. You can install the default distribution of 6.8 to use the
 Upgrade Assistant to prepare to upgrade even if you are upgrading to the OSS
 distribution of {version}.
 ******
@@ -45,7 +45,7 @@ cluster configuration.
 [[upgrade-order-elastic-stack]]
 === Upgrade process
 
-When you've made the necessary changes and are ready to upgrade from 6.7 to
+When you've made the necessary changes and are ready to upgrade from 6.8 to
 {version}:
 
 . Test the upgrade in a dev environment *before* upgrading your
@@ -69,7 +69,7 @@ on the cluster during the upgrade process. For more information, see
 .. Beats: {beats-ref}/upgrading.html[upgrade instructions]
 .. APM Server: {apm-server-ref}/upgrading.html[upgrade instructions]
 
-NOTE: Logstash 6.7 and Beats 6.7 are compatible with all 7.x versions of
+NOTE: Logstash 6.8 and Beats 6.8 are compatible with all 7.x versions of
 {es}. This provides flexibility in when you schedule the upgrades
 for your Logstash instances and Beats agents, but we recommend upgrading as
 soon as possible to take advantage of performance improvements
@@ -89,11 +89,11 @@ Make sure all 5.x indices have been deleted before upgrading to {version}. {es}
 {version} will fail to start if any 5.x indices are present.
 
 If you are running a version prior to 6.0,
-https://www.elastic.co/guide/en/elastic-stack/6.7/upgrading-elastic-stack.html[upgrade to 6.7]
+https://www.elastic.co/guide/en/elastic-stack/6.8/upgrading-elastic-stack.html[upgrade to 6.8]
 and reindex your old indices or bring up a new {version} cluster and
 {ref}/reindex-upgrade-remote.html[reindex from remote].
 
-The recommended path is to upgrade to 6.7 before upgrading to {version}. This
+The recommended path is to upgrade to 6.8 before upgrading to {version}. This
 makes it easier to identify the changes you need to make to upgrade and enables
 you to perform a rolling upgrade with no downtime.
 
@@ -109,7 +109,7 @@ upgraded simultaneously.
 
 Although upgrading your Elastic Cloud clusters is easy, you still need to
 address breaking changes that affect your application. Minor version upgrades,
-upgrades from 6.7 to {version}, and all other cluster configuration
+upgrades from 6.8 to {version}, and all other cluster configuration
 changes can be performed with no downtime.
 
 To avoid downtime when a full cluster restart is required:


### PR DESCRIPTION
Relates to elastic/elasticsearch#42255