### PR TITLE
Updates shared version attributes file

### DIFF
--- a/docs/en/getting-started/index.asciidoc
+++ b/docs/en/getting-started/index.asciidoc
@@ -14,7 +14,7 @@
 :kib-repo-dir:      {docdir}/../../../../kibana/docs
 :xes-repo-dir:      {docdir}/../../../../elasticsearch/x-pack/docs/en
 
-include::{asciidoc-dir}/../../shared/versions72.asciidoc[]
+include::{asciidoc-dir}/../../shared/versions73.asciidoc[]
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
 include::get-started-stack.asciidoc[]

--- a/docs/en/infraops/index.asciidoc
+++ b/docs/en/infraops/index.asciidoc
@@ -5,7 +5,7 @@
 
 = Infrastructure Monitoring Guide
 
-include::{asciidoc-dir}/../../shared/versions72.asciidoc[]
+include::{asciidoc-dir}/../../shared/versions73.asciidoc[]
 
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 

--- a/docs/en/secops/index.asciidoc
+++ b/docs/en/secops/index.asciidoc
@@ -5,7 +5,7 @@
 
 = Security Monitoring Guide
 
-include::{asciidoc-dir}/../../shared/versions72.asciidoc[]
+include::{asciidoc-dir}/../../shared/versions73.asciidoc[]
 
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 

--- a/docs/en/stack/index.asciidoc
+++ b/docs/en/stack/index.asciidoc
@@ -15,7 +15,7 @@
 :xes-repo-dir:      {docdir}/../../../../elasticsearch/x-pack/docs/en
 :es-repo-dir:       {docdir}/../../../../elasticsearch/docs/reference
 
-include::{asciidoc-dir}/../../shared/versions72.asciidoc[]
+include::{asciidoc-dir}/../../shared/versions73.asciidoc[]
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
 include::introduction.asciidoc[]


### PR DESCRIPTION
Related to https://github.com/elastic/docs/pull/894

This PR updates the books in the stack-docs repo to use the new shared file: https://github.com/elastic/docs/blob/master/shared/versions73.asciidoc