### PR TITLE
[DOCS] Fixes broken link to java-clients

### DIFF
--- a/docs/en/stack/security/get-started-security.asciidoc
+++ b/docs/en/stack/security/get-started-security.asciidoc
@@ -353,7 +353,5 @@ Logstash and {es}.
 * <<beats,Configuring security in the Beats>>. Configure authentication 
 credentials and encrypt connections to {es}. 
 
-* <<java-clients,Configuring the Java transport client to use encrypted communications>>.
-
 * {hadoop-ref}/security.html[Configuring {es} for Apache Hadoop to use secured transport]. 
 


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/42202

This PR and https://github.com/elastic/elasticsearch/pull/42459 fix the following build errors:
12:04:56 INFO:build_docs:/tmp/docsbuild/target_repo/html/en/elastic-stack-overview/master/index.xml:5905: element xref: validity error : IDREF attribute linkend references an unknown ID "java-clients"