### PR TITLE
[7.1][Docs] Backport: Change path to beats breaking changes file (#331)

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -43,8 +43,7 @@ include::{apm-repo-dir}/apm-breaking-changes.asciidoc[tag=notable-v7-breaking-ch
 This list summarizes the most important breaking changes in Beats.
 For the complete list, go to {beats-ref}/breaking-changes.html[Beats breaking changes].
 
-
-include::{beats-repo-dir}/breaking.asciidoc[tag=notable-breaking-changes]
+include::{beats-repo-dir}/breaking-7.0.asciidoc[tag=notable-breaking-changes]
 
 
 [[elasticsearch-breaking-changes]]

--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -43,7 +43,8 @@ include::{apm-repo-dir}/apm-breaking-changes.asciidoc[tag=notable-v7-breaking-ch
 This list summarizes the most important breaking changes in Beats.
 For the complete list, go to {beats-ref}/breaking-changes.html[Beats breaking changes].
 
-include::{beats-repo-dir}/breaking-7.0.asciidoc[tag=notable-breaking-changes]
+
+include::{beats-repo-dir}/breaking-7.1.asciidoc[tag=notable-breaking-changes]
 
 
 [[elasticsearch-breaking-changes]]


### PR DESCRIPTION
Backports #331 to the 7.1 branch. Must be merged at the same time as https://github.com/elastic/beats/pull/12322