### PR TITLE
[DOCS] Add beats 7.1 release highlights

### DIFF
--- a/docs/en/install-upgrade/highlights.asciidoc
+++ b/docs/en/install-upgrade/highlights.asciidoc
@@ -17,8 +17,7 @@ highlights notable new features and enhancements in {version}.
 This list summarizes the most important enhancements in Beats.
 For the complete list, go to {beats-ref}/release-highlights.html[Beats release highlights].
 
-
-//include::{beats-repo-dir}/highlights-7.1.0.asciidoc[tag=notable-highlights]
+include::{beats-repo-dir}/highlights-7.1.0.asciidoc[tag=notable-highlights]
 
 [[elasticsearch-highlights]]
 === {es} highlights


### PR DESCRIPTION
Adds release highlights for 7.1. This PR needs to be merged at the same time as https://github.com/elastic/beats/pull/12376.