### PR TITLE
Add Kibana application privileges to the reserved role docs

### DIFF
--- a/docs/en/stack/security/authorization/built-in-roles.asciidoc
+++ b/docs/en/stack/security/authorization/built-in-roles.asciidoc
@@ -39,13 +39,13 @@ suitable for writing beats output to {es}.
 
 [[built-in-roles-data-frame-transforms-admin]] `data_frame_transforms_admin` ::
 Grants `manage_data_frame_transforms` cluster privileges, which enable you to
-manage data frame transforms. This role also includes the `reserved_ml` {kib}
-application privilege which makes the {kib} {ml} application visible.
+manage data frame transforms. This role also includes all
+{kibana-ref}/kibana-privileges.html[Kibana privileges] for the {ml-features}.
 
 [[built-in-roles-data-frame-transforms-user]] `data_frame_transforms_user` ::
 Grants `monitor_data_fram_transforms` cluster privileges, which enable you to
-use data frame transforms. This role also includes the `reserved_ml` {kib}
-application privilege which makes the {kib} {ml} application visible.
+use data frame transforms. This role also includes all
+{kibana-ref}/kibana-privileges.html[Kibana privileges] for the {ml-features}.
 
 [[built-in-roles-ingest-user]] `ingest_admin` ::
 Grants access to manage *all* index templates and *all* ingest pipeline configurations.
@@ -94,23 +94,22 @@ suitable for use within a Logstash pipeline.
 [[built-in-roles-ml-admin]] `machine_learning_admin`::
 Grants `manage_ml` cluster privileges, read access to `.ml-anomalies*`,
 `.ml-notifications*`, `.ml-state*`, `.ml-meta*` indices and write access to
-`.ml-annotations*` indices. This role also includes the `reserved_ml` {kib}
-application privilege which makes the {kib} {ml} application visible.
+`.ml-annotations*` indices. This role also includes all
+{kibana-ref}/kibana-privileges.html[Kibana privileges] for the {ml-features}.
 
 [[built-in-roles-ml-user]] `machine_learning_user`::
 Grants the minimum privileges required to view {ml} configuration,
 status, and work with results. This role grants `monitor_ml` cluster privileges,
 read access to the `.ml-notifications` and `.ml-anomalies*` indices
 (which store {ml} results), and write access to `.ml-annotations*` indices.
-This role also includes the `reserved_ml` {kib} application privilege which
-makes the {kib} {ml} application visible.
+This role also includes all {kibana-ref}/kibana-privileges.html[Kibana privileges] for the {ml-features}.
 
 [[built-in-roles-monitoring-user]] `monitoring_user`::
 Grants the minimum privileges required for any user of {monitoring} other than those
 required to use {kib}. This role grants access to the monitoring indices and grants
 privileges necessary for reading basic cluster information. This role also includes
-the `reserved_monitoring` {kib} application privilege which makes the {kib} monitoring
-application visible. Monitoring users should also be assigned the `kibana_user` role.
+all {kibana-ref}/kibana-privileges.html[Kibana privileges] for the {stack-monitor-features}.
+Monitoring users should also be assigned the `kibana_user` role.
 
 [[built-in-roles-remote-monitoring-agent]] `remote_monitoring_agent`::
 Grants the minimum privileges required to write data into the monitoring indices

--- a/docs/en/stack/security/authorization/built-in-roles.asciidoc
+++ b/docs/en/stack/security/authorization/built-in-roles.asciidoc
@@ -39,11 +39,13 @@ suitable for writing beats output to {es}.
 
 [[built-in-roles-data-frame-transforms-admin]] `data_frame_transforms_admin` ::
 Grants `manage_data_frame_transforms` cluster privileges, which enable you to
-manage data frames.
+manage data frame transforms. This role also includes the `reserved_ml` {kib}
+application privilege which makes the {kib} {ml} application visible.
 
 [[built-in-roles-data-frame-transforms-user]] `data_frame_transforms_user` ::
 Grants `monitor_data_fram_transforms` cluster privileges, which enable you to
-use data frames. 
+use data frame transforms. This role also includes the `reserved_ml` {kib}
+application privilege which makes the {kib} {ml} application visible.
 
 [[built-in-roles-ingest-user]] `ingest_admin` ::
 Grants access to manage *all* index templates and *all* ingest pipeline configurations.
@@ -92,19 +94,23 @@ suitable for use within a Logstash pipeline.
 [[built-in-roles-ml-admin]] `machine_learning_admin`::
 Grants `manage_ml` cluster privileges, read access to `.ml-anomalies*`,
 `.ml-notifications*`, `.ml-state*`, `.ml-meta*` indices and write access to
-`.ml-annotations*` indices.
+`.ml-annotations*` indices. This role also includes the `reserved_ml` {kib}
+application privilege which makes the {kib} {ml} application visible.
 
 [[built-in-roles-ml-user]] `machine_learning_user`::
 Grants the minimum privileges required to view {ml} configuration,
 status, and work with results. This role grants `monitor_ml` cluster privileges,
 read access to the `.ml-notifications` and `.ml-anomalies*` indices
 (which store {ml} results), and write access to `.ml-annotations*` indices.
+This role also includes the `reserved_ml` {kib} application privilege which
+makes the {kib} {ml} application visible.
 
 [[built-in-roles-monitoring-user]] `monitoring_user`::
 Grants the minimum privileges required for any user of {monitoring} other than those
 required to use {kib}. This role grants access to the monitoring indices and grants
-privileges necessary for reading basic cluster information. Monitoring users should
-also be assigned the `kibana_user` role.
+privileges necessary for reading basic cluster information. This role also includes
+the `reserved_monitoring` {kib} application privilege which makes the {kib} monitoring
+application visible. Monitoring users should also be assigned the `kibana_user` role.
 
 [[built-in-roles-remote-monitoring-agent]] `remote_monitoring_agent`::
 Grants the minimum privileges required to write data into the monitoring indices


### PR DESCRIPTION
Users who create roles that are similar to the reserved roles
need to know about these.

The privileges were added to the reserved roles in
elastic/elasticsearch#40651 and elastic/elasticsearch#42757