### PR TITLE
[DOCS] Updates license details in security tutorials

### DIFF
--- a/docs/en/stack/security/get-started-enable-security.asciidoc
+++ b/docs/en/stack/security/get-started-enable-security.asciidoc
@@ -33,8 +33,3 @@ Therefore, it is a good idea to explicitly add this setting to avoid confusion
 about whether {security-features} are enabled.  
 
 --
-
-When you enable {es} {security-features}, basic authentication is enabled by
-default. To communicate with the cluster, you must specify a username and
-password. Unless you <<anonymous-access,enable anonymous access>>, all requests
-that don't include a user name and password are rejected.

--- a/docs/en/stack/security/get-started-security.asciidoc
+++ b/docs/en/stack/security/get-started-security.asciidoc
@@ -15,9 +15,11 @@ roles in {es}, {kib}, {ls}, and {metricbeat}.
 +
 --
 IMPORTANT: To complete this tutorial, you must install the default {es} and
-{kib} packages, which include role-based access control (RBAC) and native authentication {security-features}. When you install these products, they apply
+{kib} packages, which include role-based access control (RBAC) and native
+authentication {security-features}. When you install these products, they apply
 basic licenses with no expiration dates. All of the subsequent steps in this
-tutorial assume that you are using a basic license. For more information, see {subscriptions} and <<license-management>>.
+tutorial assume that you are using a basic license. For more information, see
+{subscriptions} and <<license-management>>.
 
 --
 
@@ -36,12 +38,30 @@ example, http://127.0.0.1:5601[http://127.0.0.1:5601].
 [[get-started-enable-security]]
 === Enable {es} {security-features}
 
-include::get-started-enable-security.asciidoc[]
+include::get-started-enable-security.asciidoc[] 
 
-NOTE: This tutorial involves a single node cluster, but if you had multiple 
+. Enable single-node discovery in the `ES_PATH_CONF/elasticsearch.yml` file. 
++
+-- 
+This tutorial involves a single node cluster, but if you had multiple 
 nodes, you would enable {es} {security-features} on every node in the cluster
 and configure Transport Layer Security (TLS) for internode-communication, which
-is beyond the scope of this tutorial. 
+is beyond the scope of this tutorial. By enabling single-node discovery, we are
+postponing the configuration of TLS. For example, add the following setting:
+
+[source,yaml]
+----
+discovery.type: single-node
+----
+
+For more information, see
+{ref}/bootstrap-checks.html#single-node-discovery[Single-node discovery].
+--
+
+When you enable {es} {security-features}, basic authentication is enabled by
+default. To communicate with the cluster, you must specify a username and
+password. Unless you <<anonymous-access,enable anonymous access>>, all requests
+that don't include a user name and password are rejected.
 
 [role="xpack"]
 [[get-started-built-in-users]]

--- a/docs/en/stack/security/get-started-security.asciidoc
+++ b/docs/en/stack/security/get-started-security.asciidoc
@@ -11,7 +11,15 @@ roles in {es}, {kib}, {ls}, and {metricbeat}.
 === Before you begin
 
 . Install and configure {es}, {kib}, {ls}, and {metricbeat} as described in 
-{stack-gs}/get-started-elastic-stack.html[Getting started with the {stack}]. 
+{stack-gs}/get-started-elastic-stack.html[Getting started with the {stack}].
++
+--
+IMPORTANT: To complete this tutorial, you must install the default {es} and
+{kib} packages, which include role-based access control (RBAC) and native authentication {security-features}. When you install these products, they apply
+basic licenses with no expiration dates. All of the subsequent steps in this
+tutorial assume that you are using a basic license. For more information, see {subscriptions} and <<license-management>>.
+
+--
 
 . Stop {ls}. The method for starting and stopping {ls} varies depending on whether 
 you are running it from the command line or running it as a service. For example, 
@@ -23,17 +31,6 @@ running.
 
 . Launch the {kib} web interface by pointing your browser to port 5601. For 
 example, http://127.0.0.1:5601[http://127.0.0.1:5601].
-
-. Verify that you are using a license that includes the role-based access
-control (RBAC) and native authentication {security-features}. To view your
-license in {kib}, go to **Management** and click **License Management**. 
-+
---
-By default, when you install {stack} products, they apply basic licenses
-with no expiration dates. To complete this tutorial, you must have a basic or
-trial license at a minimum. For more information, see {subscriptions} and
-<<license-management>>.
---
 
 [role="xpack"]
 [[get-started-enable-security]]

--- a/docs/en/stack/security/get-started-security.asciidoc
+++ b/docs/en/stack/security/get-started-security.asciidoc
@@ -1,5 +1,5 @@
 [role="xpack"]
-[testenv="trial"]
+[testenv="basic"]
 [[security-getting-started]]
 == Tutorial: Getting started with security
 

--- a/docs/en/stack/security/securing-communications/tutorial-tls-intro.asciidoc
+++ b/docs/en/stack/security/securing-communications/tutorial-tls-intro.asciidoc
@@ -25,16 +25,15 @@ described in
 {stack-gs}/get-started-elastic-stack.html[Getting started with the {stack}]. In
 particular, this tutorial provides instructions that work with the `zip` and
 `tar.gz` packages.
-
-. Verify that you are using a license that includes the encrypted communications
-{security-features}. To view your license in {kib}, go to *Management* and click
-*License Management*. 
 +
 --
-By default, when you install {stack} products, they apply basic licenses with no
-expiration dates. To complete this tutorial, you must have a basic or trial
-license at a minimum. For more information, see {subscriptions} and
+IMPORTANT: To complete this tutorial, you must install the default {es} and
+{kib} packages, which include the encrypted communications {security-features}.
+When you install these products, they apply basic licenses with no expiration
+dates. All of the subsequent steps in this tutorial assume that you are using a
+basic license. For more information, see {subscriptions} and
 <<license-management>>.
+
 --
 
 . <<get-started-enable-security,Enable the {es} {security-features}>>.

--- a/docs/en/stack/security/securing-communications/tutorial-tls-intro.asciidoc
+++ b/docs/en/stack/security/securing-communications/tutorial-tls-intro.asciidoc
@@ -25,15 +25,16 @@ described in
 {stack-gs}/get-started-elastic-stack.html[Getting started with the {stack}]. In
 particular, this tutorial provides instructions that work with the `zip` and
 `tar.gz` packages.
+
+. Verify that you are using a license that includes the encrypted communications
+{security-features}. To view your license in {kib}, go to *Management* and click
+*License Management*. 
 +
 --
-IMPORTANT: To complete this tutorial, you must install the default {es} and
-{kib} packages, which include the encrypted communications {security-features}.
-When you install these products, they apply basic licenses with no expiration
-dates. All of the subsequent steps in this tutorial assume that you are using a
-basic license. For more information, see {subscriptions} and
+By default, when you install {stack} products, they apply basic licenses with no
+expiration dates. To complete this tutorial, you must have a basic or trial
+license at a minimum. For more information, see {subscriptions} and
 <<license-management>>.
-
 --
 
 . <<get-started-enable-security,Enable the {es} {security-features}>>.


### PR DESCRIPTION
This PR addresses comments such as https://github.com/elastic/stack-docs/pull/329#discussion_r285728857 by stating that the two security tutorials (https://www.elastic.co/guide/en/elastic-stack-overview/master/security-getting-started.html and https://www.elastic.co/guide/en/elastic-stack-overview/master/encrypting-internode-communications.html) require the use of the basic license. 

It also adds a step to enable single-node discovery so that TLS setup is postponed from the first tutorial.