### PR TITLE
[DOCS] Updates TLS tutorial for use with basic licenses and new cluster formation settings

### DIFF
--- a/docs/en/getting-started/get-started-stack.asciidoc
+++ b/docs/en/getting-started/get-started-stack.asciidoc
@@ -175,6 +175,13 @@ endif::[]
 For other operating systems, go to the
 https://www.elastic.co/downloads/elasticsearch[{es} download] page.
 
+TIP: The default {ref}/cluster.name.html[cluster.name] and
+{ref}/node.name.html[node.name] are `elasticsearch` and your hostname,
+respectively. If you plan to keep using this cluster or add more nodes, it is a
+good idea to change these default values to unique names. For details about
+changing these and other settings in the `elasticsearch.yml` file, see
+{ref}/settings.html[Configuring {es}].
+
 To learn more about installing, configuring, and running {es}, read the
 https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html[{es} Reference].
 

--- a/docs/en/stack/index.asciidoc
+++ b/docs/en/stack/index.asciidoc
@@ -14,6 +14,7 @@
 :kib-repo-dir:      {docdir}/../../../../kibana/docs
 :xes-repo-dir:      {docdir}/../../../../elasticsearch/x-pack/docs/en
 :es-repo-dir:       {docdir}/../../../../elasticsearch/docs/reference
+:stack-repo-dir:    {docdir}
 
 include::{asciidoc-dir}/../../shared/versions.asciidoc[]
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]

--- a/docs/en/stack/security/get-started-builtin-users.asciidoc
+++ b/docs/en/stack/security/get-started-builtin-users.asciidoc
@@ -1,6 +1,9 @@
+// tag::create-users[]
 There are <<built-in-users,built-in users>> that you can use for specific
 administrative purposes: `apm_system`, `beats_system`, `elastic`, `kibana`,
 `logstash_system`,  and `remote_monitoring_user`. 
+
+// end::create-users[]
 
 Before you can use them, you must set their passwords:
 
@@ -16,12 +19,15 @@ the following command from the {es} directory:
 See {ref}/starting-elasticsearch.html[Starting {es}].
 --
 
-. Set the built-in users' passwords. Run the following command from the {es} 
-directory:
+. Set the built-in users' passwords.
 +
 --
+// tag::create-users[]
+Run the following command from the {es} directory:
+
 ["source","sh",subs="attributes,callouts"]
 ----------------------------------------------------------------------
 ./bin/elasticsearch-setup-passwords interactive
 ----------------------------------------------------------------------
+// end::create-users[]
 --

--- a/docs/en/stack/security/get-started-kibana-users.asciidoc
+++ b/docs/en/stack/security/get-started-kibana-users.asciidoc
@@ -34,6 +34,7 @@ store them in a keystore instead. Run the following commands to create the {kib}
 keystore and add the secure settings:
 +
 --
+// tag::store-kibana-user[]
 ["source","sh",subs="attributes,callouts"]
 ----------------------------------------------------------------------
 ./bin/kibana-keystore create
@@ -44,6 +45,7 @@ keystore and add the secure settings:
 When prompted, specify the `kibana` built-in user and its password for these 
 setting values.  The settings are automatically applied when you start {kib}.   
 To learn more, see {kibana-ref}/secure-settings.html[Secure settings].
+// end::store-kibana-user[]
 --
 
 . Restart {kib}. For example, if you installed 

--- a/docs/en/stack/security/securing-communications/tutorial-tls-addnodes.asciidoc
+++ b/docs/en/stack/security/securing-communications/tutorial-tls-addnodes.asciidoc
@@ -36,6 +36,9 @@ You are prompted for information about each new node. Specify `node-2` and
 `node-3` for the instance names. For the purposes of this tutorial, specify the
 same IP address (`127.0.0.1,::1`) and DNS name (`localhost`) for each node.
 
+You are prompted to enter the password for your CA. You are also prompted to
+create a password for each certificate.
+
 By default, the command produces a zip file named `certificate-bundle.zip`,
 which contains the generated certificates and keys.
 --
@@ -94,8 +97,8 @@ same `cluster.name` value.
 
 --
 
-. If you set the `cluster.initial_master_nodes` on the first node, specify the
-same value on the second and third master-eligible nodes.
+. (Optional) Provide seed addresses to help your nodes discover other nodes with
+which to form a cluster.
 +
 --
 For example, add the following setting in the `ES_PATH_CONF/elasticsearch.yml`
@@ -103,15 +106,14 @@ file:
 
 [source,yaml]
 ----
-cluster.initial_master_nodes: ["node-1","node-2","node-3"]
+discovery.seed_hosts: ["localhost"]
 ----
 
-WARNING: If you set `cluster.initial_master_nodes` on multiple nodes, it must
-have the same value to ensure that only a single cluster forms during
-bootstrapping and to avoid the risk of data loss.
-
-For more information, see
-{ref}/modules-discovery-bootstrap-cluster.html[Bootstrapping a cluster].
+The default value for this setting is `127.0.0.1, [::1]`, therefore it isn't
+actually required in this tutorial. When you want to form a cluster with nodes
+on other hosts, however, you must use this setting to provide a list of
+master-eligible nodes to seed the discovery process. For more information, see
+{ref}/modules-discovery-hosts-providers.html[Discovery].
 --
 
 . On each node, enable TLS for transport communications. You must also configure
@@ -146,38 +148,6 @@ If you encounter errors, you can see some common problems and solutions in
 <<trb-security-ssl>>.
 --
 
-. Create passwords for the built-in users. 
-+
---
-include::{stack-repo-dir}/security/get-started-builtin-users.asciidoc[tag=create-users]
-
-NOTE: If you already created these users on the first node for other tutorials,
-you do not need to create them on the second and third node.
-
---
-
-. <<get-started-kibana-user,Add the built-in user to {kib}>>.
-+
---
-For example, run the following commands to create the {kib} keystore and add the
-`kibana` built-in user and its password in secure settings:
-
-include::{stack-repo-dir}/security/get-started-kibana-users.asciidoc[tag=store-kibana-user]
---
-
-. Start {kib}.
-+
---
-For example, if you installed {kib} with a `.tar.gz` package, run the following
-command from the {kib}  directory:
-["source","sh",subs="attributes,callouts"]
-----------------------------------------------------------------------
-./bin/kibana
-----------------------------------------------------------------------
-
-See {kibana-ref}/start-stop.html[Starting and stopping {kib}]. 
---
-
 . Verify that your cluster now contains three nodes.
 +
 --
@@ -209,13 +179,6 @@ Now that you have multiple nodes, your data can be distributed across the
 cluster in multiple primary and replica shards. For more information about the
 concepts of clusters, nodes, and shards, see
 {ref}/getting-started.html[Getting started with {es}].
-
-TIP: In these examples, we have not specified the `discovery.seed_hosts` setting,
-so it uses the default value which represents the loopback addresses for the
-system. When you want to form a cluster with nodes on other hosts, you must
-update that setting with a list of master-eligible nodes. See
-{ref}/modules-discovery-settings.html[Discovery and cluster formation settings]
-and {ref}/modules-discovery.html[Discovery and cluster formation].
 
 [float]
 [[encrypting-internode-nextsteps]]

--- a/docs/en/stack/security/securing-communications/tutorial-tls-addnodes.asciidoc
+++ b/docs/en/stack/security/securing-communications/tutorial-tls-addnodes.asciidoc
@@ -30,7 +30,7 @@ For example, run the following command:
 --multiple
 ----------------------------------------------------------------------
 // NOTCONSOLE
-<1> Use the certificate authority that you create in <<encrypting-communications-certificates>>.
+<1> Use the certificate authority that you created in <<encrypting-communications-certificates>>.
 
 You are prompted for information about each new node. Specify `node-2` and
 `node-3` for the instance names. For the purposes of this tutorial, specify the

--- a/docs/en/stack/security/securing-communications/tutorial-tls-addnodes.asciidoc
+++ b/docs/en/stack/security/securing-communications/tutorial-tls-addnodes.asciidoc
@@ -1,33 +1,7 @@
 [role="xpack"]
-[testenv="trial"]
+[testenv="basic"]
 [[encrypting-communications-hosts]]
 === Add nodes to your cluster
-
-Up to this point, we have used a cluster with a single {es} node to get up and
-running with the {stack}. An {es} _node_ is a single server that is part of your
-cluster and stores pieces of your data called _shards_. 
-
-You can add more nodes to your cluster and optionally designate specific purposes
-for each node. For example, you can allocate master nodes, data nodes, ingest
-nodes, machine learning nodes, and dedicated coordinating nodes. For details
-about each node type, see {ref}/modules-node.html[Nodes].
-
-In a single cluster, you can have as many nodes as you want but they must be
-able to communicate with each other. The communication between nodes in a
-cluster is handled by the {ref}/modules-transport.html[transport module]. To
-secure your cluster, you must ensure that the internode communications are
-encrypted.
-
-NOTE: In this tutorial, we add more nodes by installing more copies of {es} on
-the same machine. By default, {es} binds to loopback addresses for HTTP and
-transport communication. That is fine for the purposes of this tutorial and for
-downloading and experimenting with {es} in a test or development environment.
-When you are deploying a production environment, however, you are generally
-adding nodes on different machines so that your cluster is resilient to outages
-and avoids data loss.  In a production scenario, there are additional
-requirements that are not covered in this tutorial. See
-{ref}/bootstrap-checks.html#dev-vs-prod-mode[Development vs production mode] and
-{ref}/add-elasticsearch-nodes.html[Adding nodes to your cluster].
 
 Let's add two nodes to our cluster!
 
@@ -39,49 +13,66 @@ in a separate folder. You can simply repeat the steps that you used to install
 {stack-gs}/get-started-elastic-stack.html#install-elasticsearch[Getting started with the {stack}]
 tutorial.
 
-. Update the `ES_PATH_CONF/elasticsearch.yml` file on each node:
+. Generate certificates for the two new nodes.
 +
 --
-.. Enable the {es} {security-features}. 
-.. Ensure that the nodes share the same {ref}/cluster.name.html[`cluster.name`].
-.. Give each node a unique {ref}/node.name.html[`node.name`].
-.. Specify the minimum number of master-eligible nodes that must be available to
-form a cluster. By default, each node is eligible to be elected as the
-{ref}/modules-node.html#master-node[master node] and control the cluster. To
-avoid a _split brain_ scenario where multiple nodes elect themselves as the
-master, use the `discovery.zen.minimum_master_nodes` setting.
+For example, run the following command:
 
-By default, if you run multiple {es} nodes on the same machine, it
-automatically uses free ports in the range 9200-9300 for HTTP and 9300-9400 for
-transport. If you want to assign specific port numbers to each node, however,
-you can add {ref}/modules-transport.html[TCP transport settings]. You can then
-provide a list of these seed nodes,
-which is used to discover the nodes in your cluster.
+["source","sh",subs="attributes,callouts"]
+----------------------------------------------------------------------
+./bin/elasticsearch-certutil cert \
+--ca elastic-stack-ca.p12 \ <1>
+--multiple
+----------------------------------------------------------------------
+// NOTCONSOLE
+<1> Use the certificate authority that you create in <<encrypting-communications-certificates>>.
 
+You are prompted for information about each new node. Specify `node-2` and
+`node-3` for the instance names. For the purposes of this tutorial, specify the
+same IP address (`127.0.0.1,::1`) and DNS name (`localhost`) for each node.
+
+By default, the command produces a zip file named `certificate-bundle.zip`,
+which contains the generated certificates and keys.
+--
+
+. Decompress the `certificate-bundle.zip` file. For example:
++
+--
+["source","sh",subs="attributes,callouts"]
+----------------------------------------------------------------------
+unzip certificate-bundle.zip 
+
+Archive:  certificate-bundle.zip
+   creating: node-2/
+  inflating: node-2/node-2.p12       
+   creating: node-3/
+  inflating: node-3/node-3.p12   
+----------------------------------------------------------------------
+// NOTCONSOLE
+  
+The `certificate-bundle.zip` file contains a folder for each of your nodes. Each
+folder contains a single PKCS#12 keystore that includes a node certificate,
+node key, and CA certificate.
+--
+
+. Create a folder to contain certificates in the configuration directory of each
+{es} node. For example, create a `certs` folder in the `config` directory.
+
+. Copy the appropriate certificate to the configuration directory on each node.
+For example, copy the `node-2.p12` file into the `config/certs` directory on the
+second node and the `node-3.p12` into the `config/certs` directory on the third
+node.
+
+. Specify the name of the cluster and give each node a unique name.
++
+--
 For example, add the following settings to the `ES_PATH_CONF/elasticsearch.yml`
-file on the first node:
-
-[source,yaml]
-----
-xpack.security.enabled: true
-cluster.name: test-cluster
-node.name: node-1
-discovery.zen.minimum_master_nodes: 2
-transport.tcp.port: 9301
-discovery.zen.ping.unicast.hosts: ["localhost:9302", "localhost:9303"]
-----
-
-Add the following settings to the `ES_PATH_CONF/elasticsearch.yml`
 file on the second node:
 
 [source,yaml]
 ----
-xpack.security.enabled: true
 cluster.name: test-cluster
 node.name: node-2
-discovery.zen.minimum_master_nodes: 2
-transport.tcp.port: 9302
-discovery.zen.ping.unicast.hosts: ["localhost:9301", "localhost:9303"]
 ----
 
 Add the following settings to the `ES_PATH_CONF/elasticsearch.yml`
@@ -89,21 +80,50 @@ file on the third node:
 
 [source,yaml]
 ----
-xpack.security.enabled: true
 cluster.name: test-cluster
 node.name: node-3
-discovery.zen.minimum_master_nodes: 2
-transport.tcp.port: 9303
-discovery.zen.ping.unicast.hosts: ["localhost:9301", "localhost:9302"]
 ----
 
-TIP: In these examples, we have not specified the `transport.host`,
-`transport.bind_host`, or `transport.publish_host` settings, so they default to
-the `network.host` value. If you have not specified the `network.host` setting,
-it defaults to `_local_`, which represents the loopback addresses for the system. 
+NOTE: In order to join the same cluster as the first node, they must share the
+same `cluster.name` value.
 
-If you choose different cluster names, node names, host names, or ports, you
-must substitute the appropriate values in subsequent steps as well. 
+--
+
+. If you set the `cluster.initial_master_nodes` on the first node, specify the
+same value on the second and third master-eligible nodes.
++
+--
+For example, add the following setting in the `ES_PATH_CONF/elasticsearch.yml`
+file:
+
+[source,yaml]
+----
+cluster.initial_master_nodes: ["node-1","node-2","node-3"]
+----
+
+WARNING: If you set `cluster.initial_master_nodes` on multiple nodes, it must
+have the same value to ensure that only a single cluster forms during
+bootstrapping and to avoid the risk of data loss.
+
+For more information, see
+{ref}/modules-discovery-bootstrap-cluster.html[Bootstrapping a cluster].
+--
+
+. On each node, enable TLS for transport communications. You must also configure
+each node to identify itself using its signed certificate.
++
+--
+include::tutorial-tls-internode.asciidoc[tag=enable-tls]
+--
+
+. On each node, store the password for the PKCS#12 file in the {es} keystore.
++
+--
+include::tutorial-tls-internode.asciidoc[tag=secure-passwords]
+
+On the second node, supply the password that you created for the `node-2.p12`
+file. On the third node, supply the password that you created for the
+`node-3.p12` file.
 --
 
 . Start each {es} node. For example, if you installed {es} with a `.tar.gz`
@@ -117,13 +137,34 @@ package, run the following command from each {es} directory:
 
 See {ref}/starting-elasticsearch.html[Starting {es}].
 
+If you encounter errors, you can see some common problems and solutions in
+<<trb-security-ssl>>.
 --
 
-. (Optional) Restart {kib}. For example, if you installed 
-{kib} with a `.tar.gz` package, run the following command from the {kib} 
-directory:
+. Create passwords for the built-in users. 
 +
 --
+include::{stack-repo-dir}/security/get-started-builtin-users.asciidoc[tag=create-users]
+
+NOTE: If you already created these users on the first node for other tutorials,
+you do not need to create them on the second and third node.
+
+--
+
+. <<get-started-kibana-user,Add the built-in user to {kib}>>.
++
+--
+For example, run the following commands to create the {kib} keystore and add the
+`kibana` built-in user and its password in secure settings:
+
+include::{stack-repo-dir}/security/get-started-kibana-users.asciidoc[tag=store-kibana-user]
+--
+
+. Start {kib}.
++
+--
+For example, if you installed {kib} with a `.tar.gz` package, run the following
+command from the {kib}  directory:
 ["source","sh",subs="attributes,callouts"]
 ----------------------------------------------------------------------
 ./bin/kibana
@@ -132,10 +173,12 @@ directory:
 See {kibana-ref}/start-stop.html[Starting and stopping {kib}]. 
 --
 
-. Verify that your cluster now contains three nodes. For example, use the
-{ref}/cluster-health.html[cluster health API]:
+. Verify that your cluster now contains three nodes.
 +
 --
+For example, log into {kib} with the `elastic` built-in user. Go to
+*Dev Tools > Console* and run the {ref}/cluster-health.html[cluster health API]:
+
 [source,js]
 ----------------------------------
 GET _cluster/health
@@ -161,3 +204,21 @@ Now that you have multiple nodes, your data can be distributed across the
 cluster in multiple primary and replica shards. For more information about the
 concepts of clusters, nodes, and shards, see
 {ref}/getting-started.html[Getting started with {es}].
+
+TIP: In these examples, we have not specified the `discovery.seed_hosts` setting,
+so it uses the default value which represents the loopback addresses for the
+system. When you want to form a cluster with nodes on other hosts, you must
+update that setting with a list of master-eligible nodes. See
+{ref}/modules-discovery-settings.html[Discovery and cluster formation settings]
+and {ref}/modules-discovery.html[Discovery and cluster formation].
+
+[float]
+[[encrypting-internode-nextsteps]]
+=== What's next?
+
+Congratulations! You've encrypted communications between the nodes in your
+cluster and can pass the 
+{ref}/bootstrap-checks-xpack.html#bootstrap-checks-tls[TLS bootstrap check].
+
+If you want to encrypt communications between other products in the {stack}, see
+<<encrypting-communications>>.

--- a/docs/en/stack/security/securing-communications/tutorial-tls-addnodes.asciidoc
+++ b/docs/en/stack/security/securing-communications/tutorial-tls-addnodes.asciidoc
@@ -3,6 +3,11 @@
 [[encrypting-communications-hosts]]
 === Add nodes to your cluster
 
+You can add more nodes to your cluster and optionally designate specific
+purposes for each node. For example, you can allocate master nodes, data nodes,
+ingest nodes, machine learning nodes, and dedicated coordinating nodes. For
+details about each node type, see {ref}/modules-node.html[Nodes].
+
 Let's add two nodes to our cluster!
 
 . Install two additional copies of {es}. It's possible to run multiple {es}

--- a/docs/en/stack/security/securing-communications/tutorial-tls-certificates.asciidoc
+++ b/docs/en/stack/security/securing-communications/tutorial-tls-certificates.asciidoc
@@ -1,5 +1,5 @@
 [role="xpack"]
-[testenv="trial"]
+[testenv="basic"]
 [[encrypting-communications-certificates]]
 === Generate certificates
 
@@ -11,118 +11,68 @@ recommended approach is to trust a specific certificate authority (CA). Thus
 when nodes are added to your cluster they just need to use a certificate signed 
 by the same CA. 
 
-. Use the `elasticsearch-certutil` command to generate a CA and certificates and
-private keys for each node in your cluster. 
+. Generate a certificate authority for your cluster.
 +
 --
-You can let the tool prompt you for information about each node in your cluster,
-or you can supply that information in an input file. For example, create a
-`test-cluster.yml` file in one of your {es} nodes:
-
-[source,yaml]
-----
-instances:
-  - name: "node-1" <1>
-    dns: 
-      - "localhost"
-    ip:
-      - "127.0.0.1"
-      - "::1"
-  - name: "node-2"
-    dns:
-      - "localhost"
-    ip:
-      - "127.0.0.1"
-      - "::1"
-  - name: "node-3"
-    dns:
-      - "localhost"
-    ip:
-      - "127.0.0.1"
-      - "::1"
-----
-<1> If these `name` values match the values you specified for `node.name` in
-each `elasticsearch.yml` file, you can use a shortcut in a subsequent step. 
-
-TIP: In this tutorial, all three nodes exist on the same machine and share the
-same IP address and hostname. In general, clusters are more resilient when they
-contain nodes from multiple servers and this list would reflect that diversity.
-
-For information about all of the possible fields in this file, see 
-{ref}/certutil.html#certutil-silent[Using elasticsearch-certutil in silent mode].
-
-Then run the following command:
+Run the following command:
 
 ["source","sh",subs="attributes,callouts"]
 ----------------------------------------------------------------------
-./bin/elasticsearch-certutil cert --in test-cluster.yml --keep-ca-key
+./bin/elasticsearch-certutil ca
 ----------------------------------------------------------------------
 // NOTCONSOLE
 
-It prompts you for passwords to secure each output file. 
+You are prompted for an output filename and a password. In this tutorial, we'll
+use the default filename (`elastic-stack-ca.p12`).
 
-TIP: Ideally, you should use a different password for each file and store the
-files securely--especially the CA, since it holds the key to your cluster.
+The output file is a PKCS#12 keystore that contains the public certificate for
+your certificate authority and the private key that is used to sign the node
+certificates.
 
+TIP: We'll need to use this file again when we add nodes to the cluster, so
+remember its location and password. Ideally you should store the file securely,
+since it holds the key to your cluster.
+
+For more information about this command, see
+{ref}/certutil.html[elasticsearch-certutil].
 --
 
-. Decompress the `certificate-bundle.zip` file. For example:
+. Generate certificates and private keys for the first node in your cluster. 
 +
 --
+Run the following command:
+
 ["source","sh",subs="attributes,callouts"]
 ----------------------------------------------------------------------
-unzip certificate-bundle.zip 
-
-Archive:  certificate-bundle.zip
-   creating: ca/
-  inflating: ca/ca.p12               
-   creating: node-1/
-  inflating: node-1/node-1.p12       
-   creating: node-2/
-  inflating: node-2/node-2.p12       
-   creating: node-3/
-  inflating: node-3/node-3.p12  
+./bin/elasticsearch-certutil cert \
+--ca elastic-stack-ca.p12 \ <1>
+--name node-1 \ <2>
+--dns localhost \ <3>
+--ip 127.0.0.1,::1 <4>
 ----------------------------------------------------------------------
 // NOTCONSOLE
-  
-The `certificate-bundle.zip` file contains a folder for each of your nodes and a
-`ca` folder.
+<1> The `--ca` parameter contains the name of certificate authority that you
+generated for this cluster.
+<2> The `--name` parameter contains the name of the generated certificate.
+Ideally this value matches the node's `node.name` value in its
+`elasticsearch.yml` file.
+<3> The `--dns` parameter contains a comma-separated list of DNS names for the
+node.
+<4> The `--ip` parameter contains a comma-separated list of IP addresses for the
+node.
 
-The `ca` folder contains a `ca.p12` file, which is a PKCS#12 keystore. This file
-contains the public certificate for your certificate authority and the private
-key that is used to sign the node certificates.
+You are prompted for an output filename and a password. In this tutorial, we'll
+use the default filename, which in this case is `node-1.p12`.
 
-Each node folder contains a single PKCS#12 keystore that includes a node 
-certificate, node key, and CA certificate.
+The output file is a PKCS#12 keystore that includes a node certificate, node key,
+and CA certificate.
 --
 
-. Create a folder to contain certificates in the configuration
-directory on each {es} node. For example, create a `certs` folder in the `config`
-directory on each node.
+. Create a folder to contain certificates in the configuration directory of your
+{es} node. For example, create a `certs` folder in the `config` directory.
 
-. Copy the appropriate certificate to the configuration directory on each {es} 
-node. For example, copy the `node-1.p12` file into the `config/certs` directory
-on the first node. Copy the `node-2.p12` file to the second node and the
-`node-3.p12` to the third.
-
-If you later add more nodes, they just need to use a certificate signed by the
-same CA. For this reason, make sure you store your CA in a safe place and don't
-forget its password!
-
-For example: 
-["source","sh",subs="attributes,callouts"]
-----------------------------------------------------------------------
-./bin/elasticsearch-certutil cert --ca ca/ca.p12 \ <1>
---name <node-name> \ <2>
---dns <domain_name> \ <3>
---ip <ip_addresses> <4>
-----------------------------------------------------------------------
-// NOTCONSOLE
-<1> The certificate authority that you generated for this cluster.
-<2> The name of the generated certificate. Ideally this value matches the new
-node's `node.name` value in its `elasticsearch.yml` file.
-<3> A comma-separated list of DNS names for the new node.
-<4> A comma-separated list of IP addresses for the new node.
+. Copy the `node-1.p12` file into the `config/certs` directory
+on the first node.
 
 TIP: The {ref}/certutil.html[elasticsearch-certutil] command has a lot more
 options. For example, it can generate Privacy Enhanced Mail (PEM) formatted

--- a/docs/en/stack/security/securing-communications/tutorial-tls-certificates.asciidoc
+++ b/docs/en/stack/security/securing-communications/tutorial-tls-certificates.asciidoc
@@ -37,6 +37,9 @@ For more information about this command, see
 {ref}/certutil.html[elasticsearch-certutil].
 --
 
+. Create a folder to contain certificates in the configuration directory of your
+{es} node. For example, create a `certs` folder in the `config` directory.
+
 . Generate certificates and private keys for the first node in your cluster. 
 +
 --
@@ -46,33 +49,27 @@ Run the following command:
 ----------------------------------------------------------------------
 ./bin/elasticsearch-certutil cert \
 --ca elastic-stack-ca.p12 \ <1>
---name node-1 \ <2>
---dns localhost \ <3>
---ip 127.0.0.1,::1 <4>
+--dns localhost \ <2>
+--ip 127.0.0.1,::1 <3>
+--out config/certs/node-1.p12 <4>
 ----------------------------------------------------------------------
 // NOTCONSOLE
 <1> The `--ca` parameter contains the name of certificate authority that you
 generated for this cluster.
-<2> The `--name` parameter contains the name of the generated certificate.
-Ideally this value matches the node's `node.name` value in its
+<2> The `--dns` parameter contains a comma-separated list of DNS names for the
+node.
+<3> The `--ip` parameter contains a comma-separated list of IP addresses for the
+node.
+<4> The `--out` parameter contains the name and location of the generated
+certificate. Ideally the file name matches the `node.name` value in the
 `elasticsearch.yml` file.
-<3> The `--dns` parameter contains a comma-separated list of DNS names for the
-node.
-<4> The `--ip` parameter contains a comma-separated list of IP addresses for the
-node.
 
-You are prompted for an output filename and a password. In this tutorial, we'll
-use the default filename, which in this case is `node-1.p12`.
+You are prompted to enter the password for your CA. You are also prompted to
+create a password for the certificate.
 
 The output file is a PKCS#12 keystore that includes a node certificate, node key,
 and CA certificate.
 --
-
-. Create a folder to contain certificates in the configuration directory of your
-{es} node. For example, create a `certs` folder in the `config` directory.
-
-. Copy the `node-1.p12` file into the `config/certs` directory
-on the first node.
 
 TIP: The {ref}/certutil.html[elasticsearch-certutil] command has a lot more
 options. For example, it can generate Privacy Enhanced Mail (PEM) formatted

--- a/docs/en/stack/security/securing-communications/tutorial-tls-internode.asciidoc
+++ b/docs/en/stack/security/securing-communications/tutorial-tls-internode.asciidoc
@@ -149,7 +149,7 @@ command from the {es} directory:
 . Create passwords for the built-in users and . 
 +
 --
-NOTE: If you already created these users for other tutorials, you can skip this
+NOTE: If you already configured passwords for these users for other tutorials, you can skip this
 step.
 
 include::{stack-repo-dir}/security/get-started-builtin-users.asciidoc[tag=create-users]

--- a/docs/en/stack/security/securing-communications/tutorial-tls-internode.asciidoc
+++ b/docs/en/stack/security/securing-communications/tutorial-tls-internode.asciidoc
@@ -7,7 +7,8 @@ Now that we've generated a certificate authority and certificates, let's update
 the cluster to use these files.
 
 IMPORTANT: When you enable {es} {security-features}, unless you have a trial
-license, you must use Transport Layer Security (TLS) to encrypt internode communication. By following the steps in this tutorial tutorial, you learn how
+license, you must use Transport Layer Security (TLS) to encrypt internode
+communication. By following the steps in this tutorial tutorial, you learn how
 to meet the minimum requirements to pass the 
 {ref}/bootstrap-checks-xpack.html#bootstrap-checks-tls[TLS bootstrap check].
 
@@ -68,12 +69,16 @@ file:
 
 [source,yaml]
 ----
-cluster.initial_master_nodes: ["node-1","node-2","node-3"]
+cluster.initial_master_nodes: ["node-1"]
 ----
 
-NOTE: If you start an {es} node without configuring this setting or any other
+If you start an {es} node without configuring this setting or any other
 discovery settings, it will start up in development mode and auto-bootstrap
 itself into a new cluster.
+
+TIP: If you are starting a cluster with multiple master-eligible nodes for the
+first time, add all of those node names to the `cluster.initial_master_nodes`
+setting.
  
 See {ref}/modules-discovery-bootstrap-cluster.html[Bootstrapping a cluster] and
 {ref}/discovery-settings.html[Important discovery and cluster formation settings].
@@ -129,6 +134,44 @@ file. We are using this file for both the transport TLS keystore and truststore,
 therefore supply the same password for both of these settings.
 --
 
-. If you set the `cluster.initial_master_nodes` such that it bootstraps the
-cluster using three master-eligible nodes, you must create those other nodes.
-Otherwise, you can start {es} on the first node and add more nodes later.
+. {ref}/starting-elasticsearch.html[Start {es}].
++
+--
+For example, if you installed {es} with a `.tar.gz` package, run the following
+command from the {es} directory:
+
+["source","sh",subs="attributes,callouts"]
+----------------------------------------------------------------------
+./bin/elasticsearch
+----------------------------------------------------------------------
+--
+
+. Create passwords for the built-in users and . 
++
+--
+NOTE: If you already created these users for other tutorials, you can skip this
+step.
+
+include::{stack-repo-dir}/security/get-started-builtin-users.asciidoc[tag=create-users]
+
+After you create the `kibana` built-in user,
+<<get-started-kibana-user,configure {kib} to use it>>.
+
+For example, run the following commands to create the {kib} keystore and add the
+`kibana` built-in user and its password in secure settings:
+
+include::{stack-repo-dir}/security/get-started-kibana-users.asciidoc[tag=store-kibana-user]
+--
+
+. Start {kib}.
++
+--
+For example, if you installed {kib} with a `.tar.gz` package, run the following
+command from the {kib}  directory:
+["source","sh",subs="attributes,callouts"]
+----------------------------------------------------------------------
+./bin/kibana
+----------------------------------------------------------------------
+
+See {kibana-ref}/start-stop.html[Starting and stopping {kib}]. 
+--

--- a/docs/en/stack/security/securing-communications/tutorial-tls-internode.asciidoc
+++ b/docs/en/stack/security/securing-communications/tutorial-tls-internode.asciidoc
@@ -154,7 +154,7 @@ step.
 
 include::{stack-repo-dir}/security/get-started-builtin-users.asciidoc[tag=create-users]
 
-After you create the `kibana` built-in user,
+After you setup the password for the `kibana` built-in user,
 <<get-started-kibana-user,configure {kib} to use it>>.
 
 For example, run the following commands to create the {kib} keystore and add the

--- a/docs/en/stack/security/securing-communications/tutorial-tls-internode.asciidoc
+++ b/docs/en/stack/security/securing-communications/tutorial-tls-internode.asciidoc
@@ -3,43 +3,115 @@
 [[encrypting-internode]]
 === Encrypt internode communications  
 
-Now that you've generated a certificate authority and certificates for each node,
-you must update your cluster to use these files. 
+Now that we've generated a certificate authority and certificates, let's update
+the cluster to use these files.
 
-. Stop each {es} node. For example, if you installed {es} from an archive
-distribution, enter `Ctrl-C` on the command line. See 
-{ref}/stopping-elasticsearch.html[Stopping {es}].
+IMPORTANT: When you enable {es} {security-features}, unless you have a trial
+license, you must use Transport Layer Security (TLS) to encrypt internode communication. By following the steps in this tutorial tutorial, you learn how
+to meet the minimum requirements to pass the 
+{ref}/bootstrap-checks-xpack.html#bootstrap-checks-tls[TLS bootstrap check].
 
-. On each node, enable Transport Layer Security (TLS/SSL) for transport
-(internode) communications. You must also configure each node to identify itself
-using its signed certificate.
+. (Optional) Name the cluster.
 +
 --
-For example, add the following settings in each `ES_PATH_CONF/elasticsearch.yml`
+For example, add the {ref}/cluster.name.html[cluster.name] setting in the
+`ES_PATH_CONF/elasticsearch.yml` file:
+
+[source,yaml]
+----
+cluster.name: test-cluster
+----
+
+TIP: The `ES_PATH_CONF` environment variable contains the path for the {es} 
+configuration files. If you installed {es} using archive distributions (`zip` or 
+`tar.gz`), it defaults to `ES_HOME/config`. If you used package distributions 
+(Debian or RPM), it defaults to `/etc/elasticsearch`. For more information, see 
+{ref}/settings.html[Configuring {es}].
+
+The default cluster name is `elasticsearch`. You should choose a unique name,
+however, to ensure that your nodes join the right cluster.
+--
+
+. (Optional) Name the {es} node.
++
+--
+For example, add the {ref}/node.name.html[node.name] setting in the
+`ES_PATH_CONF/elasticsearch.yml` file:
+
+[source,yaml]
+----
+node.name: node-1
+----
+
+In this tutorial, the cluster will consist of three nodes that exist on the same
+machine and share the same (loopback) IP address and hostname. Therefore, we
+must give each node a unique name. 
+
+This step is also necessary if you want to use the `node.name` value to define
+the location of certificates in subsequent steps.
+--
+
+. Disable single-node discovery.
++
+--
+To enable {es} to form a multi-node cluster, use the default value for the
+`discovery.type` setting. If that setting exists in your
+`ES_PATH_CONF/elasticsearch.yml` file, remove it.
+--
+
+. (Optional) If you are starting the cluster for the first time, specify the
+initial set of master-eligible nodes.
++
+--
+For example, add the following setting in the `ES_PATH_CONF/elasticsearch.yml`
 file:
 
 [source,yaml]
 ----
+cluster.initial_master_nodes: ["node-1","node-2","node-3"]
+----
+
+NOTE: If you start an {es} node without configuring this setting or any other
+discovery settings, it will start up in development mode and auto-bootstrap
+itself into a new cluster.
+ 
+See {ref}/modules-discovery-bootstrap-cluster.html[Bootstrapping a cluster] and
+{ref}/discovery-settings.html[Important discovery and cluster formation settings].
+--
+
+. Enable Transport Layer Security (TLS/SSL) for transport (internode)
+communications. 
++
+--
+// tag::enable-tls[]
+For example, add the following settings in the `ES_PATH_CONF/elasticsearch.yml`
+file:
+
+[source,yaml]
+----
+xpack.security.enabled: true
 xpack.security.transport.ssl.enabled: true  
 xpack.security.transport.ssl.keystore.path: certs/${node.name}.p12 <1>
 xpack.security.transport.ssl.truststore.path: certs/${node.name}.p12
 ----
 <1> If the file name for your certificate does not match the `node.name` value,
-you must put the appropriate file name in each `elasticsearch.yml` file. 
+you must put the appropriate file name in the `elasticsearch.yml` file. 
+// end::enable-tls[]
 
 NOTE: The PKCS#12 keystore that is output by the `elasticsearch-certutil` can be
 used as both a keystore and a truststore. If you use other tools to manage and 
 generate your certificates, you might have different values for these settings,
 but that scenario is not covered in this tutorial.
 
-For more information about these settings, see
+For more information, see <<get-started-enable-security>> and 
 {ref}/security-settings.html#transport-tls-ssl-settings[Transport TLS settings].
 --
 
-. On each node, store the password for PKCS#12 file in the {es} keystore.
+. Store the password for the PKCS#12 file in the {es} keystore.
 +
 --
-For example, run the following commands on each node: 
+// tag::secure-passwords[]
+For example, run the following commands: 
 
 ["source","sh",subs="attributes,callouts"]
 ----------------------------------------------------------------------
@@ -50,61 +122,13 @@ For example, run the following commands on each node:
 <1> If the {es} keystore already exists, this command asks whether you want to
 overwrite it. You do not need to overwrite it; you can simply add settings to
 your existing {es} keystore.
+// end::secure-passwords[]
 
-You are prompted to supply the password value. As you saw in the previous step,
-we are using the same file for both the transport TLS keystore and truststore,
-therefore you supply the same password for both of these settings.
+You are prompted to supply the password that you created for the `node-1.p12`
+file. We are using this file for both the transport TLS keystore and truststore,
+therefore supply the same password for both of these settings.
 --
 
-. Start each {es} node. For example, if you installed {es} with a `.tar.gz`
-package, run the following command from each {es} directory:
-+
---
-["source","sh",subs="attributes,callouts"]
-----------------------------------------------------------------------
-./bin/elasticsearch
-----------------------------------------------------------------------
-
-See {ref}/starting-elasticsearch.html[Starting {es}].
---
-
-. (Optional) Restart {kib}. For example, if you installed 
-{kib} with a `.tar.gz` package, run the following command from the {kib} 
-directory:
-+
---
-["source","sh",subs="attributes,callouts"]
-----------------------------------------------------------------------
-./bin/kibana
-----------------------------------------------------------------------
-
-See {kibana-ref}/start-stop.html[Starting and stopping {kib}]. 
---
-
-. Verify that your cluster is healthy. For example, use the
-{ref}/cluster-health.html[cluster health API]:
-+
---
-[source,js]
-----------------------------------
-GET _cluster/health
-----------------------------------
-// CONSOLE 
-
-Confirm the `status` of your cluster is `green` in the response from this API.
-
-If you encounter errors, you can see some common problems and solutions in
-<<trb-security-ssl>>.  
---
-
-[float]
-[[encrypting-internode-nextsteps]]
-=== What's next?
-
-Congratulations! You've encrypted communications between the nodes in your
-cluster and can pass the 
-{ref}/bootstrap-checks-xpack.html#bootstrap-checks-tls[TLS bootstrap check].
-
-If you want to encrypt communications between other products in the {stack}, see
-<<encrypting-communications>>.
-
+. If you set the `cluster.initial_master_nodes` such that it bootstraps the
+cluster using three master-eligible nodes, you must create those other nodes.
+Otherwise, you can start {es} on the first node and add more nodes later.

--- a/docs/en/stack/security/securing-communications/tutorial-tls-internode.asciidoc
+++ b/docs/en/stack/security/securing-communications/tutorial-tls-internode.asciidoc
@@ -146,11 +146,11 @@ command from the {es} directory:
 ----------------------------------------------------------------------
 --
 
-. Create passwords for the built-in users and . 
+. Create passwords for the built-in users and configure {kib} to use them. 
 +
 --
-NOTE: If you already configured passwords for these users for other tutorials, you can skip this
-step.
+NOTE: If you already configured passwords for these users in other tutorials,
+you can skip this step.
 
 include::{stack-repo-dir}/security/get-started-builtin-users.asciidoc[tag=create-users]
 

--- a/docs/en/stack/security/securing-communications/tutorial-tls-intro.asciidoc
+++ b/docs/en/stack/security/securing-communications/tutorial-tls-intro.asciidoc
@@ -1,15 +1,33 @@
 [role="xpack"]
-[testenv="trial"]
+[testenv="basic"]
 [[encrypting-internode-communications]]
 == Tutorial: Encrypting communications
 
-When you enable {es} {security-features}, unless you have a trial license, you
-must use Transport Layer Security (TLS) to encrypt internode communication.
-In this tutorial, you learn how to meet the minimum requirements to pass the 
-{ref}/bootstrap-checks-xpack.html#bootstrap-checks-tls[TLS bootstrap check].
+In the {stack-gs}/get-started-elastic-stack.html[Getting started with the {stack}]
+and <<security-getting-started,Getting started with security>> tutorials, we
+used a cluster with a single {es} node to get up and running with the {stack}.
+An {es} _node_ is a single server that is part of your cluster and stores pieces
+of your data called _shards_. 
 
-NOTE: Single-node clusters that use a loopback interface do not have this
-requirement.
+You can add more nodes to your cluster and optionally designate specific
+purposes for each node. For example, you can allocate master nodes, data nodes,
+ingest nodes, machine learning nodes, and dedicated coordinating nodes. For
+details about each node type, see {ref}/modules-node.html[Nodes].
+
+You can have as many nodes as you want in a cluster but they must be able to communicate with each other. The communication between nodes in a cluster is
+handled by the {ref}/modules-transport.html[transport module]. To secure your
+cluster, you must ensure that the internode communications are encrypted.
+
+NOTE: In this tutorial, we add more nodes by installing more copies of {es} on
+the same machine. By default, {es} binds to loopback addresses for HTTP and
+transport communication. That is fine for the purposes of this tutorial and for
+downloading and experimenting with {es} in a test or development environment.
+When you are deploying a production environment, however, you are generally
+adding nodes on different machines so that your cluster is resilient to outages
+and avoids data loss. In a production scenario, there are additional
+requirements that are not covered in this tutorial. See
+{ref}/bootstrap-checks.html#dev-vs-prod-mode[Development vs production mode] and
+{ref}/add-elasticsearch-nodes.html[Adding nodes to your cluster].
 
 [float]
 [[encrypting-internode-prerequisites]]
@@ -20,11 +38,9 @@ Ideally, you should do this tutorial only after you complete the
 <<security-getting-started,Getting started with security>> tutorials. At a
 minimum, you must:
 
-. Install and configure {es} and {kib} in a cluster with a single {es} node, as
-described in
-{stack-gs}/get-started-elastic-stack.html[Getting started with the {stack}]. In
-particular, this tutorial provides instructions that work with the `zip` and
-`tar.gz` packages.
+. Install and configure {es} and {kib} in a cluster with a single {es} node. In
+particular, this tutorial provides instructions for adding nodes that work with
+the `zip` and `tar.gz` packages.
 
 . Verify that you are using a license that includes the encrypted communications
 {security-features}. To view your license in {kib}, go to *Management* and click
@@ -37,21 +53,6 @@ license at a minimum. For more information, see {subscriptions} and
 <<license-management>>.
 --
 
-. <<get-started-enable-security,Enable the {es} {security-features}>>.
-
-. <<get-started-built-in-users,Create passwords for built-in users>>.
-
-. <<get-started-kibana-user,Add the built-in user to {kib}>>.
-
-. Stop {kib}. The method for starting and stopping {kib} varies depending on 
-how you installed it. For example, if you installed {kib} from an archive 
-distribution (`.tar.gz` or `.zip`), stop it by entering `Ctrl-C` on the command 
-line. See {kibana-ref}/start-stop.html[Starting and stopping {kib}]. 
-
-. Stop {es}. For example, if you installed {es} from an archive distribution, 
-enter `Ctrl-C` on the command line. See 
-{ref}/stopping-elasticsearch.html[Stopping {es}].
-
-include::tutorial-tls-addnodes.asciidoc[]
 include::tutorial-tls-certificates.asciidoc[]
 include::tutorial-tls-internode.asciidoc[]
+include::tutorial-tls-addnodes.asciidoc[]

--- a/docs/en/stack/security/securing-communications/tutorial-tls-intro.asciidoc
+++ b/docs/en/stack/security/securing-communications/tutorial-tls-intro.asciidoc
@@ -6,15 +6,9 @@
 In the {stack-gs}/get-started-elastic-stack.html[Getting started with the {stack}]
 and <<security-getting-started,Getting started with security>> tutorials, we
 used a cluster with a single {es} node to get up and running with the {stack}.
-An {es} _node_ is a single server that is part of your cluster and stores pieces
-of your data called _shards_. 
 
-You can add more nodes to your cluster and optionally designate specific
-purposes for each node. For example, you can allocate master nodes, data nodes,
-ingest nodes, machine learning nodes, and dedicated coordinating nodes. For
-details about each node type, see {ref}/modules-node.html[Nodes].
-
-You can have as many nodes as you want in a cluster but they must be able to communicate with each other. The communication between nodes in a cluster is
+You can add as many nodes as you want in a cluster but they must be able to
+communicate with each other. The communication between nodes in a cluster is
 handled by the {ref}/modules-transport.html[transport module]. To secure your
 cluster, you must ensure that the internode communications are encrypted.
 
@@ -35,23 +29,18 @@ requirements that are not covered in this tutorial. See
 
 Ideally, you should do this tutorial only after you complete the 
 {stack-gs}/get-started-elastic-stack.html[Getting started with the {stack}] and
-<<security-getting-started,Getting started with security>> tutorials. At a
-minimum, you must:
+<<security-getting-started,Getting started with security>> tutorials.
 
-. Install and configure {es} and {kib} in a cluster with a single {es} node. In
-particular, this tutorial provides instructions for adding nodes that work with
-the `zip` and `tar.gz` packages.
+At a minimum, you must install and configure {es} and {kib} in a cluster with a
+single {es} node. In particular, this tutorial provides instructions for adding
+nodes that work with the `zip` and `tar.gz` packages.
 
-. Verify that you are using a license that includes the encrypted communications
-{security-features}. To view your license in {kib}, go to *Management* and click
-*License Management*. 
-+
---
-By default, when you install {stack} products, they apply basic licenses with no
-expiration dates. To complete this tutorial, you must have a basic or trial
-license at a minimum. For more information, see {subscriptions} and
+IMPORTANT: To complete this tutorial, you must install the default {es} and
+{kib} packages, which include the encrypted communications {security-features}.
+When you install these products, they apply basic licenses with no expiration
+dates. All of the subsequent steps in this tutorial assume that you are using a
+basic license. For more information, see {subscriptions} and
 <<license-management>>.
---
 
 include::tutorial-tls-certificates.asciidoc[]
 include::tutorial-tls-internode.asciidoc[]

--- a/docs/en/stack/security/securing-communications/tutorial-tls-intro.asciidoc
+++ b/docs/en/stack/security/securing-communications/tutorial-tls-intro.asciidoc
@@ -27,7 +27,7 @@ requirements that are not covered in this tutorial. See
 [[encrypting-internode-prerequisites]]
 === Before you begin
 
-Ideally, you should do this tutorial only after you complete the 
+Ideally, you should do this tutorial after you complete the 
 {stack-gs}/get-started-elastic-stack.html[Getting started with the {stack}] and
 <<security-getting-started,Getting started with security>> tutorials.
 


### PR DESCRIPTION
This PR updates the TLS tutorial (https://www.elastic.co/guide/en/elastic-stack-overview/master/encrypting-internode-communications.html) such that it:
1) No longer uses out-dated zen settings
2) Changes the order of the steps such that they work for nodes with basic licenses.
3) Re-uses some existing content via tagged sections so that we don't have to maintain the same information in multiple places. 