### PR TITLE
[DOCS] Adds pivoting to Stack Overview

### DIFF
--- a/docs/en/stack/data-frames/dataframes.asciidoc
+++ b/docs/en/stack/data-frames/dataframes.asciidoc
@@ -61,5 +61,3 @@ IMPORTANT: Creating a {dataframe} leaves your source index intact. A new index w
 be created dedicated to the {dataframe}.
 
 --
-
-include::api-quickref.asciidoc[]

--- a/docs/en/stack/data-frames/index.asciidoc
+++ b/docs/en/stack/data-frames/index.asciidoc
@@ -1,3 +1,3 @@
 include::dataframes.asciidoc[]
-include::{es-repo-dir}/data-frames/pivoting.asciidoc[]
+//include::{es-repo-dir}/data-frames/pivoting.asciidoc[]
 include::api-quickref.asciidoc[]

--- a/docs/en/stack/data-frames/index.asciidoc
+++ b/docs/en/stack/data-frames/index.asciidoc
@@ -1,0 +1,3 @@
+include::dataframes.asciidoc[]
+include::{es-repo-dir}/data-frames/pivoting.asciidoc[]
+include::api-quickref.asciidoc[]

--- a/docs/en/stack/index.asciidoc
+++ b/docs/en/stack/index.asciidoc
@@ -32,7 +32,7 @@ include::{xes-repo-dir}/watcher/index.asciidoc[]
 :edit_url: https://github.com/elastic/stack-docs/edit/{branch}/docs/en/stack/ml/index.asciidoc
 include::ml/index.asciidoc[]
 
-include::data-frames/dataframes.asciidoc[]
+include::data-frames/index.asciidoc[]
 
 :edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/docs/reference/ccr/index.asciidoc
 include::{es-repo-dir}/ccr/index.asciidoc[]


### PR DESCRIPTION
This PR adds a page to the Stack Overview related to creating a data frame transform that pivots your data.

It also adds a link to the data frame APIs in the Elasticsearch Reference.

https://github.com/elastic/elasticsearch/pull/42971 must be merged before the pivoting page can be uncommented.