### PR TITLE
Fix confusion on the order parameter

### DIFF
--- a/docs/en/stack/security/authentication/realm-chains.asciidoc
+++ b/docs/en/stack/security/authentication/realm-chains.asciidoc
@@ -3,8 +3,9 @@
 === Realm chains
 
 <<realms,Realms>> live within a _realm chain_. It is essentially a prioritized list of
-configured realms (typically of various types). The order of the list determines
-the order in which the realms will be consulted. You should make sure each
+configured realms (typically of various types). The `order` setting determines
+the order in which the realms will be consulted. Lower orders will be consulted first.
+You should make sure each
 configured realm has a distinct `order` setting. In the event that two or more
 realms have the same `order`, they will be processed in `name` order.
 During the authentication process, {stack} {security-features} will consult and

--- a/docs/en/stack/security/authentication/realm-chains.asciidoc
+++ b/docs/en/stack/security/authentication/realm-chains.asciidoc
@@ -4,7 +4,7 @@
 
 <<realms,Realms>> live within a _realm chain_. It is essentially a prioritized list of
 configured realms (typically of various types). The `order` setting determines
-the order in which the realms will be consulted. Lower orders will be consulted first.
+Realms are consulted in ascending order (that is to say, the realm with the lowest `order` value is consulted first).
 You should make sure each
 configured realm has a distinct `order` setting. In the event that two or more
 realms have the same `order`, they will be processed in `name` order.

--- a/docs/en/stack/security/authentication/realm-chains.asciidoc
+++ b/docs/en/stack/security/authentication/realm-chains.asciidoc
@@ -3,7 +3,7 @@
 === Realm chains
 
 <<realms,Realms>> live within a _realm chain_. It is essentially a prioritized list of
-configured realms (typically of various types). The `order` setting determines
+configured realms (typically of various types).
 Realms are consulted in ascending order (that is to say, the realm with the lowest `order` value is consulted first).
 You should make sure each
 configured realm has a distinct `order` setting. In the event that two or more


### PR DESCRIPTION
This PR makes the following clearer.
- The order list does not matter. What matters is the `order` parameter.
- Also, it is not clear which order is consulted first.