### PR TITLE
[DOCS] Update ML limitation

### DIFF
--- a/docs/en/stack/ml/limitations.asciidoc
+++ b/docs/en/stack/ml/limitations.asciidoc
@@ -115,7 +115,7 @@ analyzed.
 
 
 [float]
-=== Using time-based index patterns
+=== Time-based index patterns in {kib}
 //See x-pack-elasticsearch/#1910
 
 If you try to create a {ml} analysis job that uses time-based index patterns

--- a/docs/en/stack/ml/limitations.asciidoc
+++ b/docs/en/stack/ml/limitations.asciidoc
@@ -113,16 +113,6 @@ If you are send pre-aggregated data to a job for analysis, you must ensure
 that the `size` is configured correctly. Otherwise, some data might not be
 analyzed.
 
-
-[float]
-=== Time-based index patterns in {kib}
-//See x-pack-elasticsearch/#1910
-
-If you try to create a {ml} analysis job that uses time-based index patterns
-like `[logstash-]YYYY.MM.DD` in the single metric or multi-metric job creation
-wizards in {kib}, errors occur. You must use wildcards in the index pattern.
-For example, create an index pattern like `logstash-2019.*`.
-
 [float]
 === Fields named "by", "count", or "over" cannot be used to split data
 //See x-pack-elasticsearch/#858

--- a/docs/en/stack/ml/limitations.asciidoc
+++ b/docs/en/stack/ml/limitations.asciidoc
@@ -115,13 +115,13 @@ analyzed.
 
 
 [float]
-=== Time-based index patterns are not supported
+=== Using time-based index patterns
 //See x-pack-elasticsearch/#1910
 
-It is not possible to create a {ml} analysis job that uses time-based
-index patterns, for example `[logstash-]YYYY.MM.DD`.
-This applies to the single metric or multi metric job creation wizards in {kib}.
-
+If you try to create a {ml} analysis job that uses time-based index patterns
+like `[logstash-]YYYY.MM.DD` in the single metric or multi-metric job creation
+wizards in {kib}, errors occur. You must use wildcards in the index pattern.
+For example, create an index pattern like `logstash-2019.*`.
 
 [float]
 === Fields named "by", "count", or "over" cannot be used to split data


### PR DESCRIPTION
This PR updates the following limitation, since it is no longer accurate:

https://www.elastic.co/guide/en/elastic-stack-overview/master/ml-limitations.html#_time_based_index_patterns_are_not_supported