### PR TITLE
minor guide-improvements for mac

### DIFF
--- a/docs/en/getting-started/get-started-stack.asciidoc
+++ b/docs/en/getting-started/get-started-stack.asciidoc
@@ -758,7 +758,7 @@ sudo service logstash start
 
 ["source","sh",subs="attributes,callouts"]
 ----------------------------------------------------------------------
-cd logstash-7.1.1
+cd logstash-{logstash_version}
 ./bin/logstash -f config/demo-metrics-pipeline.conf
 ----------------------------------------------------------------------
 

--- a/docs/en/getting-started/get-started-stack.asciidoc
+++ b/docs/en/getting-started/get-started-stack.asciidoc
@@ -738,7 +738,7 @@ enriching, and transforming data.
 
 Use the command that works with your system. If you installed {ls} as a deb or
 rpm package, make sure the config file is in the `config` directory.
-On mac, this isn't required but considered best practice for reasons of consistency.
+On mac, that step isn't required but it is a best practice for reasons of consistency.
 
 *deb:*
 

--- a/docs/en/getting-started/get-started-stack.asciidoc
+++ b/docs/en/getting-started/get-started-stack.asciidoc
@@ -738,6 +738,7 @@ enriching, and transforming data.
 
 Use the command that works with your system. If you installed {ls} as a deb or
 rpm package, make sure the config file is in the `config` directory.
+On mac, this isn't required but considered best practice for reasons of consistency.
 
 *deb:*
 
@@ -757,7 +758,8 @@ sudo service logstash start
 
 ["source","sh",subs="attributes,callouts"]
 ----------------------------------------------------------------------
-./bin/logstash -f demo-metrics-pipeline.conf
+cd logstash-7.1.1
+./bin/logstash -f config/demo-metrics-pipeline.conf
 ----------------------------------------------------------------------
 
 *win:*


### PR DESCRIPTION
* recommend using config-dir as best practice on mac, because
 * implicitly suggesting .conf-files in the root-dir is a bad idea
 * clutters the users dir and provokes inconsistency across platforms
 * the config-dir is created on install anyway, so have people use it (or don't create it - clutter)

* add missing `cd logstash$version` in docs (`./` is referred to as that dir, but no cd was indicated previously - this is inconsistent with the docs otherwise comprehensive style)

* add `config/` to demo-arg for logstash -f with respect to the aforementioned recommendation