### PR TITLE
Removes coming tags from Installation & Upgrade Guide

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -28,8 +28,6 @@ Upgrade Assistant provides information about which {dfeeds} need to be updated.
 <titleabbrev>APM</titleabbrev>
 ++++
 
-coming[7.2.0]
-
 This list summarizes the most important breaking changes in APM. 
 For the complete list, go to {apm-server-ref-70}/breaking-changes.html[APM Server 7.0 breaking changes].
 
@@ -40,8 +38,6 @@ For the complete list, go to {apm-server-ref-70}/breaking-changes.html[APM Serve
 ++++
 <titleabbrev>Beats</titleabbrev>
 ++++
-
-coming[7.2.0]
 
 This list summarizes the most important breaking changes in Beats. For the
 complete list, go to {beats-ref}/breaking-changes.html[Beats breaking changes].
@@ -56,8 +52,6 @@ include::{beats-repo-dir}/breaking-7.2.asciidoc[tag=notable-breaking-changes]
 <titleabbrev>{es}</titleabbrev>
 ++++
 
-coming[7.2.0]
-
 This list summarizes the most important breaking changes in {es} {version}. For
 the complete list, go to {ref}/breaking-changes.html[{es} breaking changes].
 
@@ -69,8 +63,6 @@ include::{es-repo-dir}/reference/migration/migrate_7_2.asciidoc[tag=notable-brea
 ++++
 <titleabbrev>{es} Hadoop</titleabbrev>
 ++++
-
-coming[7.2.0]
 
 This list summarizes the most important breaking changes in {es} Hadoop {version}.
 For the complete list, go to
@@ -85,8 +77,6 @@ include::{hadoop-repo-dir}/appendix/breaking.adoc[tag=notable-v7-breaking-change
 <titleabbrev>{kib}</titleabbrev>
 ++++
 
-coming[7.2.0]
-
 This list summarizes the most important breaking changes in {kib} {version}. For
 the complete list, go to {kibana-ref}/breaking-changes.html[{kib} breaking changes].
 
@@ -98,8 +88,6 @@ include::{kib-repo-dir}/migration/migrate_7_2.asciidoc[tag=notable-breaking-chan
 ++++
 <titleabbrev>{ls}</titleabbrev>
 ++++
-
-coming[7.2.0]
 
 This list summarizes the most important breaking changes in {ls} {version}. For
 the complete list, go to

--- a/docs/en/install-upgrade/highlights.asciidoc
+++ b/docs/en/install-upgrade/highlights.asciidoc
@@ -14,8 +14,6 @@ highlights notable new features and enhancements in {version}.
 <titleabbrev>Beats</titleabbrev>
 ++++
 
-coming[7.2.0]
-
 This list summarizes the most important enhancements in Beats.
 For the complete list, go to {beats-ref}/release-highlights.html[Beats release highlights].
 
@@ -27,8 +25,6 @@ include::{beats-repo-dir}/highlights-7.2.0.asciidoc[tag=notable-highlights]
 ++++
 <titleabbrev>{es}</titleabbrev>
 ++++
-
-coming[7.2.0]
 
 This list summarizes the most important enhancements in {es} {version}.
 For the complete list, go to {ref}/release-highlights.html[{es} release highlights].
@@ -45,8 +41,6 @@ include::{es-repo-dir}/reference/release-notes/highlights-7.2.0.asciidoc[tag=not
 ++++
 <titleabbrev>{kib}</titleabbrev>
 ++++
-
-coming[7.2.0]
 
 This list summarizes the most important enhancements in {kib} {version}.
 For the complete list, go to {kibana-ref}/release-highlights.html[{kib} release highlights].


### PR DESCRIPTION
This PR removes the coming[7.2.0] tags from the stack-docs repo.