### PR TITLE
Adds APM release highlights to Installation Upgrade Guide

### DIFF
--- a/docs/en/install-upgrade/highlights.asciidoc
+++ b/docs/en/install-upgrade/highlights.asciidoc
@@ -4,9 +4,25 @@
 Each release brings new features and product improvements. This section
 highlights notable new features and enhancements in {version}.
 
+** <<apm-highlights,APM>>
 ** <<beats-highlights,Beats>>
 ** <<elasticsearch-highlights,{es}>>
 ** <<kibana-higlights,{kib}>>
+
+[[apm-highlights]]
+=== APM highlights
+++++
+<titleabbrev>APM</titleabbrev>
+++++
+
+coming[8.0.0]
+
+This list summarizes the most important enhancements in APM.
+For the complete list, go to
+{apm-get-started-ref}/apm-release-notes.html[APM release highlights].
+
+//include::{apm-repo-dir}/apm-release-notes.asciidoc[tag=notable-highlights]
+
 
 [[beats-highlights]]
 === Beats highlights

--- a/docs/en/install-upgrade/highlights.asciidoc
+++ b/docs/en/install-upgrade/highlights.asciidoc
@@ -21,7 +21,7 @@ This list summarizes the most important enhancements in APM.
 For the complete list, go to
 {apm-get-started-ref}/apm-release-notes.html[APM release highlights].
 
-//include::{apm-repo-dir}/apm-release-notes.asciidoc[tag=notable-highlights]
+include::{apm-repo-dir}/apm-release-notes.asciidoc[tag=notable-v8-highlights]
 
 
 [[beats-highlights]]


### PR DESCRIPTION
Dependent on https://github.com/elastic/apm-server/pull/2292

This PR adds an APM section to the Installation and Upgrade Guide's Highlights page: https://www.elastic.co/guide/en/elastic-stack/master/elastic-stack-highlights.html

