### PR TITLE
[7.2] Adds APM release highlights to Installation Upgrade Guide

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -29,9 +29,9 @@ Upgrade Assistant provides information about which {dfeeds} need to be updated.
 ++++
 
 This list summarizes the most important breaking changes in APM. 
-For the complete list, go to {apm-server-ref-70}/breaking-changes.html[APM Server 7.0 breaking changes].
+For the complete list, go to {apm-server-ref}/breaking-changes.html[APM Server breaking changes].
 
-//include::{apm-repo-dir}/apm-breaking-changes.asciidoc[tag=notable-v7-breaking-changes]
+include::{apm-repo-dir}/apm-breaking-changes.asciidoc[tag=notable-v7-breaking-changes]
 
 [[beats-breaking-changes]]
 === Beats breaking changes

--- a/docs/en/install-upgrade/highlights.asciidoc
+++ b/docs/en/install-upgrade/highlights.asciidoc
@@ -4,9 +4,25 @@
 Each release brings new features and product improvements. This section
 highlights notable new features and enhancements in {version}.
 
+** <<apm-highlights,APM>>
 ** <<beats-highlights,Beats>>
 ** <<elasticsearch-highlights,{es}>>
 ** <<kibana-higlights,{kib}>>
+
+[[apm-highlights]]
+=== APM highlights
+++++
+<titleabbrev>APM</titleabbrev>
+++++
+
+coming[8.0.0]
+
+This list summarizes the most important enhancements in APM.
+For the complete list, go to
+{apm-get-started-ref}/apm-release-notes.html[APM release highlights].
+
+include::{apm-repo-dir}/apm-release-notes.asciidoc[tag=notable-v8-highlights]
+
 
 [[beats-highlights]]
 === {beats} highlights

--- a/docs/en/install-upgrade/highlights.asciidoc
+++ b/docs/en/install-upgrade/highlights.asciidoc
@@ -15,13 +15,11 @@ highlights notable new features and enhancements in {version}.
 <titleabbrev>APM</titleabbrev>
 ++++
 
-coming[7.2.0]
-
 This list summarizes the most important enhancements in APM.
 For the complete list, go to
 {apm-get-started-ref}/apm-release-notes.html[APM release highlights].
 
-//include::{apm-repo-dir}/apm-release-notes.asciidoc[tag=notable-v72-highlights]
+include::{apm-repo-dir}/apm-release-notes.asciidoc[tag=notable-v72-highlights]
 
 
 [[beats-highlights]]

--- a/docs/en/install-upgrade/highlights.asciidoc
+++ b/docs/en/install-upgrade/highlights.asciidoc
@@ -15,13 +15,13 @@ highlights notable new features and enhancements in {version}.
 <titleabbrev>APM</titleabbrev>
 ++++
 
-coming[8.0.0]
+coming[7.2.0]
 
 This list summarizes the most important enhancements in APM.
 For the complete list, go to
 {apm-get-started-ref}/apm-release-notes.html[APM release highlights].
 
-include::{apm-repo-dir}/apm-release-notes.asciidoc[tag=notable-v8-highlights]
+//include::{apm-repo-dir}/apm-release-notes.asciidoc[tag=notable-v72-highlights]
 
 
 [[beats-highlights]]


### PR DESCRIPTION
This PR backports https://github.com/elastic/stack-docs/pull/375 to 7.2

It is related to https://github.com/elastic/apm-server/pull/2298