### PR TITLE
Updates Kibana breaking changes

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -81,11 +81,9 @@ include::{hadoop-repo-dir}/appendix/breaking.adoc[tag=notable-v7-breaking-change
 <titleabbrev>{kib}</titleabbrev>
 ++++
 
-This list summarizes the most important breaking changes in {kib} {version}. For
-the complete list, go to {kibana-ref}/breaking-changes.html[{kib} breaking changes].
+There are no breaking changes in 7.1.
 
-
-include::{kib-repo-dir}/migration/migrate_7_1.asciidoc[tag=notable-breaking-changes]
+//include::{kib-repo-dir}/migration/migrate_7_1.asciidoc[tag=notable-breaking-changes]
 
 
 [[logstash-breaking-changes]]


### PR DESCRIPTION
Related to https://github.com/elastic/kibana/pull/39818

This PR updates the Installation and Upgrade Guide such that it clearly states that there are no breaking changes for Kibana in 7.1.