### PR TITLE
Updates version attributes

### DIFF
--- a/docs/en/getting-started/index.asciidoc
+++ b/docs/en/getting-started/index.asciidoc
@@ -14,7 +14,7 @@
 :kib-repo-dir:      {docdir}/../../../../kibana/docs
 :xes-repo-dir:      {docdir}/../../../../elasticsearch/x-pack/docs/en
 
-include::{asciidoc-dir}/../../shared/versions73.asciidoc[]
+include::{asciidoc-dir}/../../shared/versions74.asciidoc[]
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
 include::get-started-stack.asciidoc[]

--- a/docs/en/infraops/index.asciidoc
+++ b/docs/en/infraops/index.asciidoc
@@ -5,7 +5,7 @@
 
 = Infrastructure Monitoring Guide
 
-include::{asciidoc-dir}/../../shared/versions73.asciidoc[]
+include::{asciidoc-dir}/../../shared/versions74.asciidoc[]
 
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 

--- a/docs/en/stack/index.asciidoc
+++ b/docs/en/stack/index.asciidoc
@@ -16,7 +16,7 @@
 :es-repo-dir:       {docdir}/../../../../elasticsearch/docs/reference
 :stack-repo-dir:    {docdir}
 
-include::{asciidoc-dir}/../../shared/versions73.asciidoc[]
+include::{asciidoc-dir}/../../shared/versions74.asciidoc[]
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
 include::introduction.asciidoc[]


### PR DESCRIPTION
Related to https://github.com/elastic/docs/pull/962

This PR updates the version attributes for various books in the stack-docs repo so that they're set appropriately for the 7.x branch.