### PR TITLE
Updates ML job terminology

### DIFF
--- a/docs/en/glossary/glossary.asciidoc
+++ b/docs/en/glossary/glossary.asciidoc
@@ -197,7 +197,7 @@ ifdef::xpack-terms[]
 
 [[glossary-ml-datafeed]] datafeed ::
 
-Machine learning jobs can analyze either a one-off batch of data or
+{anomaly-jobs-cap} can analyze either a one-off batch of data or
 continuously in real time. {dfeeds-cap} retrieve data from {es} for analysis.
 Alternatively you can post data from any source directly to a {ml} API.
 +
@@ -207,8 +207,8 @@ ifdef::xpack-terms[]
 
 [[glossary-ml-detector]] detector ::
 
-As part of the configuration information that is associated with a
-{ml} job, detectors define the type of analysis that needs to be done. They
+As part of the configuration information that is associated with an
+{anomaly-job}, detectors define the type of analysis that needs to be done. They
 also specify which fields to analyze. You can have more than one detector in a
 job, which is more efficient than running multiple jobs against the same data.
 +
@@ -406,7 +406,8 @@ ifdef::xpack-terms[]
 [[glossary-ml-job]] job ::
 
 Machine learning jobs contain the configuration information and metadata
-necessary to perform an analytics task.
+necessary to perform an analytics task. There are two types: {anomaly-jobs} and
+{dfanalytics-jobs}.
 +
 //Source: X-Pack
 endif::xpack-terms[]
@@ -425,8 +426,8 @@ machine learning node ::
 
 A {ml} node is a node that has `xpack.ml.enabled` and `node.ml` set to `true`,
 which is the default behavior. If you set `node.ml` to `false`, the node can
-service API requests but it cannot run jobs. If you want to use {ml-features},
-there must be at least one {ml} node in your cluster.
+service API requests but it cannot run {ml-jobs}. If you want to use
+{ml-features}, there must be at least one {ml} node in your cluster.
 +
 //Source: X-Pack
 endif::xpack-terms[]

--- a/docs/en/stack/ml/api-quickref.asciidoc
+++ b/docs/en/stack/ml/api-quickref.asciidoc
@@ -12,11 +12,11 @@ All {ml} endpoints have the following base:
 
 The main {ml} resources can be accessed with a variety of endpoints:
 
-* {ref}/ml-apis.html#ml-api-job-endpoint[+/anomaly_detectors/+]: Create and manage {ml} jobs
+* {ref}/ml-apis.html#ml-api-job-endpoint[+/anomaly_detectors/+]: Create and manage {anomaly-jobs}
 * {ref}/ml-apis.html#ml-api-calendar-endpoint[+/calendars/+]: Create and manage calendars and scheduled events
 * {ref}/ml-apis.html#ml-api-datafeed-endpoint[+/datafeeds/+]: Select data from {es} to be analyzed
 * {ref}/ml-apis.html#ml-api-filter-endpoint[+/filters/+]: Create and manage filters for custom rules
-* {ref}/ml-apis.html#ml-api-result-endpoint[+/results/+]: Access the results of a {ml} job
+* {ref}/ml-apis.html#ml-api-result-endpoint[+/results/+]: Access the results of an {anomaly-job}
 * {ref}/ml-apis.html#ml-api-snapshot-endpoint[+/model_snapshots/+]: Manage model snapshots
 
 For a full list, see {ref}/ml-apis.html[Machine learning APIs].


### PR DESCRIPTION
Related to https://github.com/elastic/stack-docs/issues/237

This PR updates occurrences of machine learning job terminology with the appropriate shared attribute from https://github.com/elastic/docs/blob/master/shared/attributes.asciidoc, such that it's clear whether anomaly detection jobs or data frame analytics jobs (or both types of machine learning jobs) are discussed.