### PR TITLE
Adds Kibana highlights and breaking changes

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -90,7 +90,7 @@ coming[7.3.0]
 This list summarizes the most important breaking changes in {kib} {version}. For
 the complete list, go to {kibana-ref}/breaking-changes.html[{kib} breaking changes].
 
-//include::{kib-repo-dir}/migration/migrate_7_2.asciidoc[tag=notable-breaking-changes]
+include::{kib-repo-dir}/migration/migrate_7_3.asciidoc[tag=notable-breaking-changes]
 
 [[logstash-breaking-changes]]
 === {ls} breaking changes

--- a/docs/en/install-upgrade/highlights.asciidoc
+++ b/docs/en/install-upgrade/highlights.asciidoc
@@ -70,10 +70,8 @@ coming[7.3.0]
 This list summarizes the most important enhancements in {kib} {version}.
 For the complete list, go to {kibana-ref}/release-highlights.html[{kib} release highlights].
 
-////
 :leveloffset: +1
 
 include::{kib-repo-dir}/release-notes/highlights-7.3.0.asciidoc[tag=notable-highlights]
 
 :leveloffset: -1
-////


### PR DESCRIPTION
This PR updates uncomments the inclusions on the following pages in the Installation and Upgrade Guide:
https://www.elastic.co/guide/en/elastic-stack/7.3/kibana-higlights.html
https://www.elastic.co/guide/en/elastic-stack/7.3/kibana-breaking-changes.html
... since that content now exists in the Kibana User Guide https://www.elastic.co/guide/en/kibana/7.3/index.html