### PR TITLE
Removes the machine learning tutorial

### DIFF
--- a/docs/en/stack/ml/analyzing.asciidoc
+++ b/docs/en/stack/ml/analyzing.asciidoc
@@ -25,5 +25,5 @@ occur outside these bounds.
 [role="screenshot"]
 image::ml/images/ml-gs-job-analysis.jpg["Example screenshot from the Machine Learning Single Metric Viewer in Kibana"]
 
-For a more detailed walk-through of {ml-features}, see
-<<ml-getting-started>>.
+//For a more detailed walk-through of {ml-features}, see
+//<<ml-getting-started>>.

--- a/docs/en/stack/ml/index.asciidoc
+++ b/docs/en/stack/ml/index.asciidoc
@@ -8,7 +8,7 @@ Machine learning is tightly integrated with the {stack}. Data is pulled
 from {es} for analysis and anomaly results are displayed in {kib} dashboards.
 
 * <<ml-overview>>
-* <<ml-getting-started>>
+//* <<ml-getting-started>>
 * <<ml-configuring>>
 * <<stopping-ml>>
 * <<ml-troubleshooting, Troubleshooting Machine Learning>>
@@ -20,7 +20,7 @@ from {es} for analysis and anomaly results are displayed in {kib} dashboards.
 
 include::overview.asciidoc[]
 
-include::getting-started.asciidoc[]
+//include::getting-started.asciidoc[]
 
 include::{es-repo-dir}/ml/configuring.asciidoc[]
 

--- a/docs/en/stack/ml/jobs.asciidoc
+++ b/docs/en/stack/ml/jobs.asciidoc
@@ -26,8 +26,8 @@ In {kib}, there are wizards that help you create specific types of jobs, such
 as _single metric_, _multi-metric_, and _population_ jobs. A single metric job
 is just a job with a single detector and limited job properties. To have access
 to all of the job properties in {kib}, you must choose the _advanced_ job wizard.
-If you want to try creating single and multi-metrics jobs in {kib} with sample
-data, see <<ml-getting-started>>.
+//If you want to try creating single and multi-metrics jobs in {kib} with sample
+//data, see <<ml-getting-started>>.
 
 You can also optionally assign jobs to one or more _job groups_. You can use
 job groups to view the results from multiple jobs more easily and to expedite


### PR DESCRIPTION
Related to https://github.com/elastic/stack-docs/pull/225

The current machine learning tutorial (https://www.elastic.co/guide/en/elastic-stack-overview/master/ml-getting-started.html) is out-dated and is in the process of being replaced. 

This PR removes it from the documentation since it uses scripts that no longer works (i.e. they use mapping types).  The scripts could perhaps be fixed by removing the PUT mapping call and letting Elasticsearch infer the correct types and removing the type from the bulk update. Since we're overhauling the tutorial anyway, we'll just remove it for now instead.

NOTE: https://github.com/elastic/elasticsearch/pull/44251 and https://github.com/elastic/kibana/pull/40943 must be merged first.