### PR TITLE
[DOCS] Fix broken links for ES API docs move

### DIFF
--- a/docs/en/stack/data-frames/ecommerce-example.asciidoc
+++ b/docs/en/stack/data-frames/ecommerce-example.asciidoc
@@ -77,7 +77,7 @@ on the `order_id` field:
 image::images/ecommerce-pivot2.jpg["Adding multiple aggregations to a {dataframe} in {kib}"]
 
 TIP: If you're interested in a subset of the data, you can optionally include a
-{ref}/search-request-query.html[query] element. In this example, we've filtered
+{ref}/search-request-body.html#search-request-query[query] element. In this example, we've filtered
 the data so that we're only looking at orders with a `currency` of `EUR`.
 Alternatively, we could group the data by that field too. If you want to use
 more complex queries, you can create your {dataframe} from a


### PR DESCRIPTION
elastic/elasticsearch/pull/44238 moved several Elasticsearch APIs to a REST APIs section.

As a result of that move, some pages were converted to anchored sections. This will fix links to those pages once the above PR is re-applied.

I plan to merge this PR simultaneously with:
- elastic/elasticsearch/pull/44238
- elastic/elasticsearch/pull/44279
- elastic/kibana/pull/41001
- elastic/elasticsearch-hadoop/pull/1317