### PR TITLE
Adds data frame analytics placeholder to Stack Overview

### DIFF
--- a/docs/en/stack/data-frames/dataframes.asciidoc
+++ b/docs/en/stack/data-frames/dataframes.asciidoc
@@ -1,6 +1,6 @@
 [role="xpack"]
 [[ml-dataframes]]
-= {dataframes-cap}
+= {dataframe-transforms-cap}
 
 [partintro]
 --

--- a/docs/en/stack/index.asciidoc
+++ b/docs/en/stack/index.asciidoc
@@ -27,9 +27,11 @@ include::monitoring/index.asciidoc[]
 
 include::{xes-repo-dir}/watcher/index.asciidoc[]
 
+include::data-frames/index.asciidoc[]
+
 include::ml/index.asciidoc[]
 
-include::data-frames/index.asciidoc[]
+include::ml/df-analytics/index.asciidoc[]
 
 include::{es-repo-dir}/ccr/index.asciidoc[]
 

--- a/docs/en/stack/ml/df-analytics/api-quickref.asciidoc
+++ b/docs/en/stack/ml/df-analytics/api-quickref.asciidoc
@@ -1,0 +1,22 @@
+[role="xpack"]
+[[ml-dfanalytics-apis]]
+== API quick reference
+
+With the exception of the evaluation API, all {dfanalytics} endpoints have the
+following base:
+
+[source,js]
+----
+/_ml/data_frame/analytics
+----
+// NOTCONSOLE
+
+
+* {ref}/put-dfanalytics.html[Create {dfanalytics-jobs}]
+* {ref}/delete-dfanalytics.html[Delete {dfanalytics-jobs}]
+* {ref}/get-dfanalytics.html[Get {dfanalytics-jobs} info]
+* {ref}/get-dfanalytics-stats.html[Get {dfanalytics-jobs} statistics]
+* {ref}/start-dfanalytics.html[Start {dfanalytics-jobs}]
+* {ref}/stop-dfanalytics.html[Stop {dfanalytics-jobs}]
+* {ref}/evaluate-dfanalytics.html[Evaluate {dfanalytics}]
+

--- a/docs/en/stack/ml/df-analytics/index.asciidoc
+++ b/docs/en/stack/ml/df-analytics/index.asciidoc
@@ -11,25 +11,4 @@ annotate it with the results.
 
 --
 
-[role="xpack"]
-[[ml-dfanalytics-apis]]
-== API quick reference
-
-With the exception of the evaluation API, all {dfanalytics} endpoints have the
-following base:
-
-[source,js]
-----
-/_ml/data_frame/analytics
-----
-// NOTCONSOLE
-
-
-* {ref}/put-dfanalytics.html[Create {dfanalytics-jobs}]
-* {ref}/delete-dfanalytics.html[Delete {dfanalytics-jobs}]
-* {ref}/get-dfanalytics.html[Get {dfanalytics-jobs} info]
-* {ref}/get-dfanalytics-stats.html[Get {dfanalytics-jobs} statistics]
-* {ref}/start-dfanalytics.html[Start {dfanalytics-jobs}]
-* {ref}/stop-dfanalytics.html[stop {dfanalytics-jobs}]
-* {ref}/evaluate-dfanalytics.html[Evaluate {dfanalytics}]
-
+include::api-quickref.asciidoc[]

--- a/docs/en/stack/ml/df-analytics/index.asciidoc
+++ b/docs/en/stack/ml/df-analytics/index.asciidoc
@@ -1,0 +1,35 @@
+[role="xpack"]
+[[ml-dfanalytics]]
+= {ml-cap} {dfanalytics}
+
+[partintro]
+--
+{dfanalytics-cap} enable you to perform different analyses of your data and 
+annotate it with the results.
+
+* <<ml-dfanalytics-apis>>
+
+--
+
+[role="xpack"]
+[[ml-dfanalytics-apis]]
+== API quick reference
+
+With the exception of the evaluation API, all {dfanalytics} endpoints have the
+following base:
+
+[source,js]
+----
+/_ml/data_frame/analytics
+----
+// NOTCONSOLE
+
+
+* {ref}/put-dfanalytics.html[Create {dfanalytics-jobs}]
+* {ref}/delete-dfanalytics.html[Delete {dfanalytics-jobs}]
+* {ref}/get-dfanalytics.html[Get {dfanalytics-jobs} info]
+* {ref}/get-dfanalytics-stats.html[Get {dfanalytics-jobs} statistics]
+* {ref}/start-dfanalytics.html[Start {dfanalytics-jobs}]
+* {ref}/stop-dfanalytics.html[stop {dfanalytics-jobs}]
+* {ref}/evaluate-dfanalytics.html[Evaluate {dfanalytics}]
+

--- a/docs/en/stack/ml/index.asciidoc
+++ b/docs/en/stack/ml/index.asciidoc
@@ -1,6 +1,6 @@
 [role="xpack"]
 [[xpack-ml]]
-= Machine learning in the {stack}
+= {ml-cap} anomaly detection
 
 [partintro]
 --


### PR DESCRIPTION
This PR adds a "Machine learning data frame analytics" section to the Stack Overview and an API quick reference page within that section. 

It also rename the "Data frames" section to "Data frame transforms" and renames the "Machine learning in the Elastic Stack" to "Machine learning anomaly detection". 