### PR TITLE
[7.0] Removes edit_url attributes (#414)

### DIFF
--- a/docs/en/stack/index.asciidoc
+++ b/docs/en/stack/index.asciidoc
@@ -20,29 +20,20 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
 include::introduction.asciidoc[]
 
-:edit_url: https://github.com/elastic/stack-docs/edit/{branch}/docs/en/stack/security/index.asciidoc
 include::security/index.asciidoc[]
 
-:edit_url:
 include::monitoring/index.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/watcher/index.asciidoc
 include::{xes-repo-dir}/watcher/index.asciidoc[]
 
-:edit_url: https://github.com/elastic/stack-docs/edit/{branch}/docs/en/stack/ml/index.asciidoc
 include::ml/index.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/docs/reference/ccr/index.asciidoc
 include::{es-repo-dir}/ccr/index.asciidoc[]
 
-:edit_url:
 include::troubleshooting.asciidoc[]
 
-:edit_url:
 include::limitations.asciidoc[]
 
-:edit_url:
 include::license.asciidoc[]
 
-:edit_url:
 include::redirects.asciidoc[]

--- a/docs/en/stack/limitations.asciidoc
+++ b/docs/en/stack/limitations.asciidoc
@@ -20,11 +20,9 @@ https://www.elastic.co/blog/elastic-stack-6-0-0-alpha1-released[Elastic Stack 6.
 * <<ml-limitations>>
 
 --
-:edit_url: https://github.com/elastic/stack-docs/edit/{branch}/docs/en/stack/security/limitations.asciidoc
+
 include::security/limitations.asciidoc[]
 
-:edit_url: https://github.com/elastic/stack-docs/edit/{branch}/docs/en/stack/watcher/limitations.asciidoc
 include::watcher/limitations.asciidoc[]
 
-:edit_url: https://github.com/elastic/stack-docs/edit/{branch}/docs/en/stack/ml/limitations.asciidoc
 include::ml/limitations.asciidoc[]

--- a/docs/en/stack/ml/getting-started.asciidoc
+++ b/docs/en/stack/ml/getting-started.asciidoc
@@ -72,20 +72,14 @@ _machine learning nodes_ or limit which nodes run resource-intensive
 activity related to jobs, see 
 {ref}/modules-node.html#ml-node[{ml} node settings]. 
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/ml/getting-started-data.asciidoc
 include::getting-started-data.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/ml/getting-started-wizards.asciidoc
 include::getting-started-wizards.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/ml/getting-started-single.asciidoc
 include::getting-started-single.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/ml/getting-started-multi.asciidoc
 include::getting-started-multi.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/ml/getting-started-forecast.asciidoc
 include::getting-started-forecast.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/ml/getting-started-next.asciidoc
 include::getting-started-next.asciidoc[]

--- a/docs/en/stack/ml/index.asciidoc
+++ b/docs/en/stack/ml/index.asciidoc
@@ -18,22 +18,16 @@ from {es} for analysis and anomaly results are displayed in {kib} dashboards.
 
 --
 
-:edit_url: https://github.com/elastic/stack-docs/edit/{branch}/docs/en/stack/ml/overview.asciidoc
 include::overview.asciidoc[]
 
-:edit_url: https://github.com/elastic/stack-docs/edit/{branch}/docs/en/stack/ml/getting-started.asciidoc
 include::getting-started.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/docs/reference/ml/configuring.asciidoc
 include::{es-repo-dir}/ml/configuring.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/docs/reference/ml/stopping-ml.asciidoc
 include::{es-repo-dir}/ml/stopping-ml.asciidoc[]
 
-:edit_url: https://github.com/elastic/stack-docs/edit/{branch}/docs/en/stack/ml/api-quickref.asciidoc
 include::api-quickref.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/docs/reference/ml/functions.asciidoc
 include::{es-repo-dir}/ml/functions.asciidoc[]
 
 

--- a/docs/en/stack/ml/overview.asciidoc
+++ b/docs/en/stack/ml/overview.asciidoc
@@ -2,7 +2,6 @@
 [[ml-overview]]
 == Overview
 
-:edit_url: https://github.com/elastic/stack-docs/edit/{branch}/docs/en/stack/ml/
 include::analyzing.asciidoc[]
 include::forecasting.asciidoc[]
 include::jobs.asciidoc[]

--- a/docs/en/stack/security/authentication/index.asciidoc
+++ b/docs/en/stack/security/authentication/index.asciidoc
@@ -1,5 +1,4 @@
 
-:edit_url: https://github.com/elastic/stack-docs/edit/{branch}/docs/en/stack/security/authentication
 include::overview.asciidoc[]
 include::built-in-users.asciidoc[]
 include::internal-users.asciidoc[]
@@ -14,14 +13,10 @@ include::pki-realm.asciidoc[]
 include::saml-realm.asciidoc[]
 include::kerberos-realm.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/authentication/custom-realm.asciidoc
 include::{xes-repo-dir}/security/authentication/custom-realm.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/authentication/anonymous-access.asciidoc
 include::{xes-repo-dir}/security/authentication/anonymous-access.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/authentication/user-cache.asciidoc
 include::{xes-repo-dir}/security/authentication/user-cache.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/authentication/saml-guide.asciidoc
 include::{xes-repo-dir}/security/authentication/saml-guide.asciidoc[]

--- a/docs/en/stack/security/authorization/index.asciidoc
+++ b/docs/en/stack/security/authorization/index.asciidoc
@@ -1,33 +1,22 @@
 
-:edit_url: https://github.com/elastic/stack-docs/edit/{branch}/docs/en/stack/security/authorization/overview.asciidoc
 include::overview.asciidoc[]
 
-:edit_url: https://github.com/elastic/stack-docs/edit/{branch}/docs/en/stack/security/authorization/built-in-roles.asciidoc
 include::built-in-roles.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/authorization/managing-roles.asciidoc
 include::{xes-repo-dir}/security/authorization/managing-roles.asciidoc[]
 
-:edit_url: https://github.com/elastic/stack-docs/edit/{branch}/docs/en/stack/security/authorization/privileges.asciidoc
 include::privileges.asciidoc[]
 
-:edit_url: https://github.com/elastic/stack-docs/edit/{branch}/docs/en/stack/security/authorization/document-level-security.asciidoc
 include::document-level-security.asciidoc[]
 
-:edit_url: https://github.com/elastic/stack-docs/edit/{branch}/docs/en/stack/security/authorization/field-level-security.asciidoc
 include::field-level-security.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/authorization/alias-privileges.asciidoc
 include::{xes-repo-dir}/security/authorization/alias-privileges.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/authorization/mapping-roles.asciidoc
 include::{xes-repo-dir}/security/authorization/mapping-roles.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/authorization/field-and-document-access-control.asciidoc
 include::{xes-repo-dir}/security/authorization/field-and-document-access-control.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/authorization/run-as-privilege.asciidoc
 include::{xes-repo-dir}/security/authorization/run-as-privilege.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/authorization/custom-roles-provider.asciidoc
 include::{xes-repo-dir}/security/authorization/custom-authorization.asciidoc[]

--- a/docs/en/stack/security/index.asciidoc
+++ b/docs/en/stack/security/index.asciidoc
@@ -90,29 +90,20 @@ Head over to our {security-forum}[Security Discussion Forum]
 to share your experience, questions, and suggestions.
 --
 
-:edit_url: https://github.com/elastic/stack-docs/edit/{branch}/docs/en/stack/security/how-security-works.asciidoc
 include::how-security-works.asciidoc[]
 
-:edit_url: https://github.com/elastic/stack-docs/edit/{branch}/docs/en/stack/security/authentication/index.asciidoc
 include::authentication/index.asciidoc[]
 
-:edit_url: https://github.com/elastic/stack-docs/edit/{branch}/docs/en/stack/security/authorization/index.asciidoc
 include::authorization/index.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/auditing.asciidoc
 include::{xes-repo-dir}/security/auditing/index.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/securing-communications.asciidoc
 include::{xes-repo-dir}/security/securing-communications.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/using-ip-filtering.asciidoc
 include::{xes-repo-dir}/security/using-ip-filtering.asciidoc[]
 
-:edit_url: https://github.com/elastic/elasticsearch/edit/{branch}/x-pack/docs/en/security/ccs-clients-integrations.asciidoc
 include::{xes-repo-dir}/security/ccs-clients-integrations.asciidoc[]
 
-:edit_url: https://github.com/elastic/stack-docs/edit/{branch}/docs/en/stack/security/get-started-security.asciidoc
 include::get-started-security.asciidoc[]
 
-:edit_url: https://github.com/elastic/stack-docs/edit/{branch}/docs/en/stack/security/securing-communications/tutorial-tls-internode.asciidoc
 include::securing-communications/tutorial-tls-intro.asciidoc[]

--- a/docs/en/stack/troubleshooting.asciidoc
+++ b/docs/en/stack/troubleshooting.asciidoc
@@ -35,14 +35,10 @@ GET /_xpack
 --------------------------------------------------
 // CONSOLE
 
-:edit_url: https://github.com/elastic/stack-docs/edit/{branch}/docs/en/stack/security/troubleshooting.asciidoc
 include::security/troubleshooting.asciidoc[]
 
-:edit_url: https://github.com/elastic/stack-docs/edit/{branch}/docs/en/stack/watcher/troubleshooting.asciidoc
 include::watcher/troubleshooting.asciidoc[]
 
-:edit_url: https://github.com/elastic/stack-docs/edit/{branch}/docs/en/stack/monitoring/troubleshooting.asciidoc
 include::monitoring/troubleshooting.asciidoc[]
 
-:edit_url: https://github.com/elastic/stack-docs/edit/{branch}/docs/en/stack/ml/troubleshooting.asciidoc
 include::ml/troubleshooting.asciidoc[]


### PR DESCRIPTION
Related to #413

This PR removes unnecessary edit_url attributes from the 7.0 branch