### PR TITLE
[DOCS] Update anchors and links for Elasticserach API relocation.

### DIFF
--- a/docs/en/stack/data-frames/ecommerce-example.asciidoc
+++ b/docs/en/stack/data-frames/ecommerce-example.asciidoc
@@ -79,10 +79,10 @@ on the `order_id` field:
 image::images/ecommerce-pivot2.jpg["Adding multiple aggregations to a {dataframe-transform} in {kib}"]
 
 TIP: If you're interested in a subset of the data, you can optionally include a
-{ref}/search-request-query.html[query] element. In this example, we've filtered
-the data so that we're only looking at orders with a `currency` of `EUR`.
-Alternatively, we could group the data by that field too. If you want to use
-more complex queries, you can create your {dataframe} from a
+{ref}/search-request-body.html#request-body-search-query[query] element. In this
+example, we've filtered the data so that we're only looking at orders with a
+`currency` of `EUR`. Alternatively, we could group the data by that field too.
+If you want to use more complex queries, you can create your {dataframe} from a
 {kibana-ref}/save-open-search.html[saved search].
 
 If you prefer, you can use the


### PR DESCRIPTION
elastic/elasticsearch#44372 moved the navigation for several Elasticsearch APIs under the [REST APIs section](https://www.elastic.co/guide/en/elasticsearch/reference/master/rest-apis.html). That PR included [several redirects](https://github.com/elastic/elasticsearch/pull/44372/files#diff-427622c7e85f29d0b8f204c583e153f1) to avoid broken links.

This PR updates a link pointing to one of those redirected links. This saves users a step when visiting this link. It also rewraps the paragraph containing the link.

Will backport to 7.3