### PR TITLE
[DOCS] Reorganizes data frame examples

### DIFF
--- a/docs/en/stack/data-frames/dataframe-examples.asciidoc
+++ b/docs/en/stack/data-frames/dataframe-examples.asciidoc
@@ -14,11 +14,13 @@ insights from your data. All the examples use one of the
 step-by-step example, see 
 <<ecommerce-dataframes,Transforming your data with {dataframes}>>.
 
+* <<ecommerce-dataframes>>
 * <<example-best-customers>>
 * <<example-airline>>
 * <<example-clientips>>
 
-[float]
+include::ecommerce-example.asciidoc[]
+
 [[example-best-customers]]
 === Finding your best customers
 
@@ -105,7 +107,6 @@ enables us to analyze data at scale and gives more flexibility to explore and
 navigate data from a customer centric perspective. In some cases, it can even 
 make creating visualizations much simpler.
 
-[float]
 [[example-airline]]
 === Finding air carriers with the most delays
 
@@ -194,7 +195,7 @@ This {dataframe} makes it easier to answer questions such as:
 NOTE: This data is fictional and does not reflect actual delays 
 or flight stats for any of the featured destination or origin airports.
 
-[float]
+
 [[example-clientips]]
 === Finding suspicious client IPs by using scripted metrics
 

--- a/docs/en/stack/data-frames/ecommerce-example.asciidoc
+++ b/docs/en/stack/data-frames/ecommerce-example.asciidoc
@@ -1,10 +1,7 @@
 [role="xpack"]
 [testenv="basic"]
 [[ecommerce-dataframes]]
-== Transforming your data in {dataframes}
-++++
-<titleabbrev>Transforming your data</titleabbrev>
-++++
+=== Transforming the eCommerce sample data
 
 beta[]
 

--- a/docs/en/stack/data-frames/index.asciidoc
+++ b/docs/en/stack/data-frames/index.asciidoc
@@ -1,5 +1,4 @@
 include::dataframes.asciidoc[]
-include::ecommerce-example.asciidoc[]
 include::api-quickref.asciidoc[]
 include::dataframe-examples.asciidoc[]
 include::limitations.asciidoc[]


### PR DESCRIPTION
This PR reorganizes the data frame examples in the Stack Overview.  In particular, it moves the "Transforming your data" page under the "Examples" section and makes all of the example subsections into separate pages.