### PR TITLE
Adds info about when to use data frames

### DIFF
--- a/docs/en/stack/data-frames/checkpoints.asciidoc
+++ b/docs/en/stack/data-frames/checkpoints.asciidoc
@@ -1,8 +1,8 @@
 [role="xpack"]
 [[ml-transform-checkpoints]]
-=== {dataframe-transform-cap} checkpoints
+== How {dataframe-transform} checkpoints work
 ++++
-<titleabbrev>Checkpoints</titleabbrev>
+<titleabbrev>How checkpoints work</titleabbrev>
 ++++
 
 beta[]
@@ -55,4 +55,34 @@ TIP: If the cluster experiences unsuitable performance degradation due to the
 source query to the {dataframe-transform} to reduce the scope of data it
 processes. Also consider whether the cluster has sufficient resources in place
 to support both the composite aggregation search and the indexing of its
-results. 
+results.
+
+[discrete]
+[[ml-transform-checkpoint-errors]]
+==== Error handling
+
+Failures in {dataframe-transforms} tend to be related to searching or indexing.
+To increase the resiliency of {dataframe-transforms}, the cursor positions of
+the aggregated search and the changed entities search are tracked in memory and
+persisted periodically.
+
+Checkpoint failures can be categorized as follows:
+
+* Temporary failures: The checkpoint is retried. If 10 consecutive failures
+occur, the {dataframe-transform} has a failed status. For example, this
+situation might occur when there are shard failures and queries return only
+partial results.
+* Irrecoverable failures: The {dataframe-transform} immediately fails. For
+example, this situation occurs when the source index is not found.
+* Adjustment failures: The {dataframe-transform} retries with adjusted settings.
+For example, if a parent circuit breaker memory errors occur during the
+composite aggregation, the transform receives partial results. The aggregated
+search is retried with a smaller number of buckets. This retry is performed at
+the interval defined in the transform's `frequency` property. If the search
+is retried to the point where it reaches a minimal number of buckets, an
+irrecoverable failure occurs.
+
+//TBD: Where is the minimal number of buckets specified?
+
+In general, the design of {dataframe-transforms} favors data consistency over
+continuous running.

--- a/docs/en/stack/data-frames/checkpoints.asciidoc
+++ b/docs/en/stack/data-frames/checkpoints.asciidoc
@@ -82,7 +82,8 @@ the interval defined in the transform's `frequency` property. If the search
 is retried to the point where it reaches a minimal number of buckets, an
 irrecoverable failure occurs.
 
-//TBD: Where is the minimal number of buckets specified?
-
-In general, the design of {dataframe-transforms} favors data consistency over
-continuous running.
+If the node running the {dataframe-transforms} fails, the transform restarts
+from the most recent persisted cursor position. This recovery process might
+repeat some of the work the transform had already done, but it ensures data
+consistency. In general, the design of {dataframe-transforms} favors data
+consistency over continuous running.

--- a/docs/en/stack/data-frames/checkpoints.asciidoc
+++ b/docs/en/stack/data-frames/checkpoints.asciidoc
@@ -85,5 +85,4 @@ irrecoverable failure occurs.
 If the node running the {dataframe-transforms} fails, the transform restarts
 from the most recent persisted cursor position. This recovery process might
 repeat some of the work the transform had already done, but it ensures data
-consistency. In general, the design of {dataframe-transforms} favors data
-consistency over continuous running.
+consistency.

--- a/docs/en/stack/data-frames/index.asciidoc
+++ b/docs/en/stack/data-frames/index.asciidoc
@@ -1,3 +1,7 @@
+<<<<<<< HEAD
+=======
+include::dataframes.asciidoc[]
+>>>>>>> [DOCS] Adds data frame transform overview
 include::overview.asciidoc[]
 include::api-quickref.asciidoc[]
 include::dataframe-examples.asciidoc[]

--- a/docs/en/stack/data-frames/index.asciidoc
+++ b/docs/en/stack/data-frames/index.asciidoc
@@ -1,7 +1,74 @@
-<<<<<<< HEAD
-=======
-include::dataframes.asciidoc[]
->>>>>>> [DOCS] Adds data frame transform overview
+[role="xpack"]
+[[ml-dataframes]]
+= {dataframe-transforms-cap}
+
+[partintro]
+--
+
+beta[]
+
+{es} aggregations are a powerful and flexible feature that enable you to
+summarize and retrieve complex insights about your data. You can summarize
+complex things like the number of web requests per day on a busy website, broken
+down by geography and browser type. If you use the same data set to try to
+calculate something as simple as a single number for the average duration of
+visitor web sessions, however, you can quickly run out of memory.
+
+Why does this occur? A web session duration is an example of a behavioral
+attribute not held on any one log record; it has to be derived by finding the
+first and last records for each session in our weblogs. This derivation requires
+some complex query expressions and a lot of memory to connect all the data
+points. If you have an ongoing background process that fuses related events from
+one index into entity-centric summaries in another index, you get a more useful,
+joined-up picture--this is essentially what _{dataframes}_ are.
+
+You might want to consider using {dataframes} instead of aggregations when:
+
+* You need a complete _feature index_ rather than a top-N set of items.
++
+In {ml}, you often need a complete set of behavioral features rather just the
+top-N. For example, if you are predicting customer churn, you might look at
+features such as the number of website visits in the last week, the total number
+of sales, or the number of emails sent. The {stack} {ml-features} create models
+based on this multi-dimensional feature space, so they benefit from full feature
+indices ({dataframes}).
++
+This scenario also applies when you are trying to search across the results of
+an aggregation or multiple aggregations. Aggregation results can be ordered or
+filtered, but there are
+{ref}/search-aggregations-bucket-terms-aggregation.html#search-aggregations-bucket-terms-aggregation-order[limitations to ordering]
+and
+{ref}/search-aggregations-pipeline-bucket-selector-aggregation.html[filtering by bucket selector]
+is constrained by the maximum number of buckets returned. If you want to search
+all aggregation results, you need to create the complete {dataframe}. If you
+need to sort or filter the aggregation results by multiple fields, {dataframes}
+are particularly useful.
+
+* You need to sort aggregation results by a pipeline aggregation.
++
+{ref}/search-aggregations-pipeline.html[Pipeline aggregations] cannot be used
+for sorting. Technically, this is because pipeline aggregations are run during
+the reduce phase after all other aggregations have already completed. If you
+create a {dataframe}, you can effectively perform multiple passes over the data.
+
+* You want to create summary tables to optimize queries.
++
+For example, if you
+have a high level dashboard that is accessed by a large number of users and it
+uses a complex aggregation over a large dataset, it may be more efficient to
+create a {dataframe} to cache results. Thus, each user doesn't need to run the
+aggregation query.
+
+Though there are multiple ways to create {dataframes}, this content pertains
+to one specific method: _{dataframe-transforms}_.
+
+* <<ml-transform-overview>>
+* <<df-api-quickref>>
+* <<dataframe-examples>>
+* <<dataframe-troubleshooting>>
+* <<dataframe-limitations>>
+--
+
 include::overview.asciidoc[]
 include::api-quickref.asciidoc[]
 include::dataframe-examples.asciidoc[]

--- a/docs/en/stack/data-frames/index.asciidoc
+++ b/docs/en/stack/data-frames/index.asciidoc
@@ -22,6 +22,11 @@ points. If you have an ongoing background process that fuses related events from
 one index into entity-centric summaries in another index, you get a more useful,
 joined-up picture--this is essentially what _{dataframes}_ are.
 
+
+[discrete]
+[[ml-dataframes-usage]]
+== When to use {dataframes}
+
 You might want to consider using {dataframes} instead of aggregations when:
 
 * You need a complete _feature index_ rather than a top-N set of items.

--- a/docs/en/stack/data-frames/limitations.asciidoc
+++ b/docs/en/stack/data-frames/limitations.asciidoc
@@ -1,3 +1,4 @@
+[role="xpack"]
 [[dataframe-limitations]]
 == {dataframe-cap} limitations
 [subs="attributes"]

--- a/docs/en/stack/data-frames/overview.asciidoc
+++ b/docs/en/stack/data-frames/overview.asciidoc
@@ -1,65 +1,25 @@
 [role="xpack"]
-[[ml-dataframes]]
-= {dataframe-transforms-cap}
-
-[partintro]
---
+[[ml-transform-overview]]
+== Overview
 
 beta[]
 
-{es} aggregations are a powerful and flexible feature that enable you to
-summarize and retrieve complex insights about your data. You can summarize
-complex things like the number of web requests per day on a busy website, broken
-down by geography and browser type. If you use the same data set to try to
-calculate something as simple as a single number for the average duration of
-visitor web sessions, however, you can quickly run out of memory. Why does this
-occur? A web session duration is an example of a behavioral attribute not held
-on any one log record; it has to be derived by finding the first and last
-records for each session in our weblogs. This derivation requires some complex
-query expressions and a lot of memory to connect all the data points. If you
-have an ongoing background process that fuses related events from one index into
-entity-centric summaries in another index, you get a more useful joined-up
-picture--this is essentially what _{dataframes}_ are.
+A _{dataframe}_ is a two-dimensional tabular data structure. In the context of
+the {stack}, it is a transformation of data that is indexed in {es}. For
+example, you can use {dataframes} to _pivot_ your data into a new entity-centric
+index. By transforming and summarizing your data, it becomes possible to
+visualize and analyze it in alternative and interesting ways.
 
-You might want to consider using {dataframes} instead of aggregations when:
+A lot of {es} indices are organized as a stream of events: each event is an 
+individual document, for example a single item purchase. {dataframes-cap} enable
+you to summarize this data, bringing it into an organized, more
+analysis-friendly format. For example, you can summarize all the purchases of a
+single customer.
 
-* You need a complete _feature index_ rather than a top-N set of items.
-
-** In {ml}, you often need a complete set of behavioral features rather just the
-top-N. For example, if you are predicting customer churn, you might look at
-features such as the number of website visits in the last week, the total number
-of sales, or the number of emails sent. The {stack} {ml-features} create models
-based on this multi-dimensional feature space, so they benefit from full feature
-indices ({dataframes}).
-** When you are trying to search across the results of an aggregation or
-multiple aggregations. Aggregation results can be ordered or filtered, but there
-are
-{ref}/search-aggregations-bucket-terms-aggregation.html#search-aggregations-bucket-terms-aggregation-order[limitations to ordering]
-and
-{ref}/search-aggregations-pipeline-bucket-selector-aggregation.html[filtering by bucket selector]
-is constrained by the maximum number of buckets returned. If you want to search
-all aggregation results, you need to create the complete {dataframe}. If you
-need to sort or filter the aggregation results by multiple fields, {dataframes}
-are particularly useful.
-
-* You need to sort aggregation results by a pipeline aggregation.
-{ref}/search-aggregations-pipeline.html[Pipeline aggregations] cannot be used
-for sorting. Technically, this is because pipeline aggregations are run during
-the reduce phase after all other aggregations have already completed. If you
-create a {dataframe}, you can effectively perform multiple passes over the data.
-
-* You want to create summary tables to optimize queries. For example, if you
-have a high level dashboard that is accessed by a large number of users and it
-uses a complex aggregation over a large dataset, it may be more efficient to
-create a {dataframe} to cache results. Thus, each user doesn't need to run the
-aggregation query.
-
-Though there are multiple ways to create {dataframes}, this content pertains
-<<<<<<< HEAD
-to one specific method: {dataframe-transforms}. {dataframe-transforms-cap}
-enable you to define a pivot, which is a set of features that transform the
-index into a different, more digestible format. Pivoting results in a summary of
-your data, which is the {dataframe}.
+You can create {dataframes} by using {dataframe-transforms}.
+{dataframe-transforms-cap} enable you to define a pivot, which is a set of
+features that transform the index into a different, more digestible format.
+Pivoting results in a summary of your data, which is the {dataframe}.
 
 To define a pivot, first you select one or more fields that you will use to
 group your data. You can select categorical fields (terms) and numerical fields
@@ -103,11 +63,6 @@ items in every product category in the last year.
 [role="screenshot"]
 image::images/ml-dataframepivot.jpg["Example of a data frame pivot in {kib}"]
 
-IMPORTANT: The {dataframe-transform-cap} leaves your source index intact. It
+IMPORTANT: The {dataframe-transform} leaves your source index intact. It
 creates a new index that is dedicated to the {dataframe}.
 
---
-=======
-to one specific method: _{dataframe-transforms}_.
---
->>>>>>> [DOCS] Adds data frame transform overview

--- a/docs/en/stack/data-frames/overview.asciidoc
+++ b/docs/en/stack/data-frames/overview.asciidoc
@@ -7,25 +7,28 @@
 
 beta[]
 
-A _{dataframe}_ is a transformation of data that has been indexed in {es}. 
-Use data frames to _pivot_ your data into a new entity centric index for example. 
-By transforming and summarizing your data, it becomes possible to visualize and 
-analyze it in alternative and interesting ways.
+A _{dataframe}_ is a two-dimensional tabular data structure. In the context of
+the {stack}, it is a transformation of data that is indexed in {es}. For
+example, you can use {dataframes} to _pivot_ your data into a new entity centric
+index. By transforming and summarizing your data, it becomes possible to
+visualize and analyze it in alternative and interesting ways.
 
 A lot of {es} indices are organized as a stream of events: each event is an 
-individual document, for example a single item purchase. 
-{dataframe-transforms-cap} enable you to summarize this data, bringing it into 
-an organized, more analysis-friendly format. For example, you can summarize all 
-the purchases of a single customer (see the example below).
+individual document, for example a single item purchase. {dataframes-cap} enable
+you to summarize this data, bringing it into an organized, more
+analysis-friendly format. For example, you can summarize all the purchases of a
+single customer.
 
-{dataframe-transforms-cap} enable you to define a pivot which is a set of features 
-that transform the index into a different, more digestible format. Pivoting 
-results in a summary of your data (which is the {dataframe} itself).
+Though there are multiple ways to create {dataframes}, this content pertains
+to one specific method: {dataframe-transforms}. {dataframe-transforms-cap}
+enable you to define a pivot, which is a set of features that transform the
+index into a different, more digestible format. Pivoting results in a summary of
+your data, which is the {dataframe}.
 
-Defining a pivot consist of two main parts. First, you select one or more fields 
-that your data will be grouped by. Principally you can select categorical 
-fields (terms) for grouping. You can also select numerical fields, in this case, 
-the field values will be bucketed using an interval you specify.
+To define a pivot, first you select one or more fields that you will use to
+group your data. You can select categorical fields (terms) and numerical fields
+for grouping. If you use numerical fields, the field values are bucketed using
+an interval that you specify.
 
 The second step is deciding how you want to aggregate the grouped data. When 
 using aggregations, you practically ask questions about the index. There are 
@@ -33,16 +36,16 @@ different types of aggregations, each with its own purpose and output. To learn
 more about the supported aggregations and group-by fields, see 
 {ref}/data-frame-transform-resource.html[{dataframe-transform-cap} resources].
 
-As an optional step, it's also possible to add a query to further limit the 
-scope of the aggregation.
+As an optional step, you can also add a query to further limit the scope of the
+aggregation.
 
 The {dataframe-transform} performs a composite aggregation that 
 paginates through all the data defined by the source index query. The output of
 the aggregation is stored in a destination index. Each time the 
-{dataframe-transform} queries the source index, it creates a *checkpoint*. You 
+{dataframe-transform} queries the source index, it creates a _checkpoint_. You 
 can decide whether you want the {dataframe-transform} to run once (batch 
 {dataframe-transform}) or continuously ({cdataframe-transform}). A batch 
-{dataframe-transform} is a single operation that will only reach checkpoint 1. 
+{dataframe-transform} is a single operation that has a single checkpoint. 
 {cdataframe-transforms-cap} continually increment and process checkpoints as new 
 source data is ingested.
 
@@ -54,16 +57,17 @@ its price, the ordered quantity, the exact date of the order, and some customer
 information (name, gender, location, etc). Your dataset contains all the transactions 
 from last year.
 
-If you want to check the sales in the different categories in your last fiscal year,
-define a {dataframe} that is grouped by the product categories (women's shoes, men's
-clothing, etc.) and the order date with the interval of the last year, then set 
-a sum aggregation on the ordered quantity. The result is a {dataframe} pivot that 
-shows the number of sold items in every product category in the last year.
+If you want to check the sales in the different categories in your last fiscal
+year, define a {dataframe-transform} that groups the data by the product
+categories (women's shoes, men's clothing, etc.) and the order date. Use the
+last year as the interval for the order date. Then add a sum aggregation on the
+ordered quantity. The result is a {dataframe} that shows the number of sold
+items in every product category in the last year.
 
 [role="screenshot"]
 image::images/ml-dataframepivot.jpg["Example of a data frame pivot in {kib}"]
 
-IMPORTANT: The {dataframe-transform-cap} leaves your source index intact. A new 
-index will be created dedicated to the {dataframe}.
+IMPORTANT: The {dataframe-transform-cap} leaves your source index intact. It
+creates a new index that is dedicated to the {dataframe}.
 
 --

--- a/docs/en/stack/data-frames/overview.asciidoc
+++ b/docs/en/stack/data-frames/overview.asciidoc
@@ -1,6 +1,9 @@
 [role="xpack"]
 [[ml-transform-overview]]
-== Overview
+== {dataframe-transform-cap} overview
+++++
+<titleabbrev>Overview</titleabbrev>
+++++
 
 beta[]
 

--- a/docs/en/stack/data-frames/overview.asciidoc
+++ b/docs/en/stack/data-frames/overview.asciidoc
@@ -7,19 +7,55 @@
 
 beta[]
 
-A _{dataframe}_ is a two-dimensional tabular data structure. In the context of
-the {stack}, it is a transformation of data that is indexed in {es}. For
-example, you can use {dataframes} to _pivot_ your data into a new entity centric
-index. By transforming and summarizing your data, it becomes possible to
-visualize and analyze it in alternative and interesting ways.
+{es} aggregations are a powerful and flexible feature that enable you to
+summarize and retrieve complex insights about your data. You can summarize
+complex things like the number of web requests per day on a busy website, broken
+down by geography and browser type. If you use the same data set to try to
+calculate something as simple as a single number for the average duration of
+visitor web sessions, however, you can quickly run out of memory. Why does this
+occur? A web session duration is an example of a behavioral attribute not held
+on any one log record; it has to be derived by finding the first and last
+records for each session in our weblogs. This derivation requires some complex
+query expressions and a lot of memory to connect all the data points. If you
+have an ongoing background process that fuses related events from one index into
+entity-centric summaries in another index, you get a more useful joined-up
+picture--this is essentially what _{dataframes}_ are.
 
-A lot of {es} indices are organized as a stream of events: each event is an 
-individual document, for example a single item purchase. {dataframes-cap} enable
-you to summarize this data, bringing it into an organized, more
-analysis-friendly format. For example, you can summarize all the purchases of a
-single customer.
+You might want to consider using {dataframes} instead of aggregations when:
+
+* You need a complete _feature index_ rather than a top-N set of items.
+
+** In {ml}, you often need a complete set of behavioral features rather just the
+top-N. For example, if you are predicting customer churn, you might look at
+features such as the number of website visits in the last week, the total number
+of sales, or the number of emails sent. The {stack} {ml-features} create models
+based on this multi-dimensional feature space, so they benefit from full feature
+indices ({dataframes}).
+** When you are trying to search across the results of an aggregation or
+multiple aggregations. Aggregation results can be ordered or filtered, but there
+are
+{ref}/search-aggregations-bucket-terms-aggregation.html#search-aggregations-bucket-terms-aggregation-order[limitations to ordering]
+and
+{ref}/search-aggregations-pipeline-bucket-selector-aggregation.html[filtering by bucket selector]
+is constrained by the maximum number of buckets returned. If you want to search
+all aggregation results, you need to create the complete {dataframe}. If you
+need to sort or filter the aggregation results by multiple fields, {dataframes}
+are particularly useful.
+
+* You need to sort aggregation results by a pipeline aggregation.
+{ref}/search-aggregations-pipeline.html[Pipeline aggregations] cannot be used
+for sorting. Technically, this is because pipeline aggregations are run during
+the reduce phase after all other aggregations have already completed. If you
+create a {dataframe}, you can effectively perform multiple passes over the data.
+
+* You want to create summary tables to optimize queries. For example, if you
+have a high level dashboard that is accessed by a large number of users and it
+uses a complex aggregation over a large dataset, it may be more efficient to
+create a {dataframe} to cache results. Thus, each user doesn't need to run the
+aggregation query.
 
 Though there are multiple ways to create {dataframes}, this content pertains
+<<<<<<< HEAD
 to one specific method: {dataframe-transforms}. {dataframe-transforms-cap}
 enable you to define a pivot, which is a set of features that transform the
 index into a different, more digestible format. Pivoting results in a summary of
@@ -71,3 +107,7 @@ IMPORTANT: The {dataframe-transform-cap} leaves your source index intact. It
 creates a new index that is dedicated to the {dataframe}.
 
 --
+=======
+to one specific method: _{dataframe-transforms}_.
+--
+>>>>>>> [DOCS] Adds data frame transform overview


### PR DESCRIPTION
This PR moves the content from docs/en/stack/data-frames/dataframes.asciidoc into a lower-level "Overview" page.  It then adds information to the highest-level "Data frame transforms" page about when it makes sense to use data frames instead of aggregations.