### PR TITLE
Remove Beta from the Infrastructure UI doc

### DIFF
--- a/docs/en/infraops/infra-ui-intro.asciidoc
+++ b/docs/en/infraops/infra-ui-intro.asciidoc
@@ -2,8 +2,6 @@
 [role="xpack"]
 == {infra-ui} UI
 
-beta[]
-
 After you have infrastructure monitoring <<install-infrastructure-monitoring,up and running>>
 and data is streaming to {es}, use the {infra-ui} UI in {kib} to monitor your
 infrastructure and identify problems in real time.


### PR DESCRIPTION
Noticed an inconsistency in the documentation:
https://www.elastic.co/guide/en/infrastructure/guide/current/infrastructure-ui-overview.html#infrastructure-ui-overview

On the Kibana page beta warning has been removed:
https://www.elastic.co/guide/en/kibana/current/infra-ui.html

Beta warning should be removed as [Elastic Infrastructure GA Released](https://www.elastic.co/blog/elastic-infrastructure-app-released)

Thanks.