### PR TITLE
[DOCS] Adds the evaluate API endpoint base to the quick reference page

### DIFF
--- a/docs/en/stack/ml/df-analytics/api-quickref.asciidoc
+++ b/docs/en/stack/ml/df-analytics/api-quickref.asciidoc
@@ -2,8 +2,7 @@
 [[ml-dfanalytics-apis]]
 == API quick reference
 
-With the exception of the evaluation API, all {dfanalytics} endpoints have the
-following base:
+All {dfanalytics} endpoints have the following base:
 
 [source,js]
 ----
@@ -11,6 +10,13 @@ following base:
 ----
 // NOTCONSOLE
 
+The evaluation API endpoint has the following base:
+
+[source,js]
+----
+/_ml/data_frame/_evaluate
+----
+// NOTCONSOLE
 
 * {ref}/put-dfanalytics.html[Create {dfanalytics-jobs}]
 * {ref}/delete-dfanalytics.html[Delete {dfanalytics-jobs}]


### PR DESCRIPTION
This PR adds the evaluate API endpoint base to the API quick reference page.

Related issue: https://github.com/elastic/ml-team/issues/187#issuecomment-513165387