### PR TITLE
[DOCS] Adds data frame analytics limitations

### DIFF
--- a/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
@@ -1,0 +1,59 @@
+[role="xpack"]
+[[ml-dfa-limitations]]
+== {dfanalytics-cap} limitations
+
+experimental[]
+
+The following limitations and known problems apply to the 7.3 release of 
+the Elastic {dfanalytics} feature:
+
+[float]
+[[dfa-ccs-limitations]]
+=== {ccs-cap} limitation
+
+{ccs-cap} is not supported in 7.3 for {dfanalytics}.
+
+[float]
+[[dfa-deletion-limitations]]
+=== Deleting a {dfanalytics-job} does not delete the {dataframe} destination index
+
+When deleting a {dfanalytics-job} using 
+`DELETE _ml/data_frame/analytics/<data_frame_analytics_id>` the {dataframe} 
+destination index won't be deleted. This object must be deleted separately.
+
+[float]
+[[dfa-update-limitations]]
+=== Cannot update a {dfanalytics-job}
+
+{dfanalytics-cap} configurations cannot be updated. Please delete and 
+then create a new {dfanalytics-job} instead.
+
+[float]
+[[dfa-datatype-limitations]]
+=== {dfanalytics-cap} data type limitation
+
+{dfanalytics-cap} only support numeric fields and don't support fields that 
+contain arrays. The analysis will skip every document that has such fields.
+
+[float]
+[[dfa-dataframe-size-limitations]]
+=== {dataframe-cap} memory limitation
+
+{dfanalytics-cap} can analyze {dataframes} that fit into the memory limit 
+dedicated for {ml} processes. For general {ml} settings, see 
+{ref}/ml-settings.html[{ml-cap} settings in {es}].
+
+[float]
+[[dfa-categorical-limitations]]
+=== Categorical fields are not supported in {dfanalytics}
+
+Currently, categorical fields are not considered as feature fields for 
+{oldetection}, so they cannot be used during the analysis.
+
+[float]
+[[dfa-missing-fields-limitations]]
+=== Missing values in analyzed fields
+
+If there are missing values in feature fields (fields that are subjects of the 
+{dfanalytics}), then the document that contains the fields with the missing 
+values will be skipped during the analysis.

--- a/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
@@ -22,15 +22,14 @@ the Elastic {dfanalytics} feature:
 === Deleting a {dfanalytics-job} does not delete the {dataframe} destination index
 
 The {ref}/delete-dfanalytics.html[delete {dfanalytics-job} API] does not delete
-the {dataframe} 
-destination index. That index must be deleted separately.
+the {dataframe} destination index. That index must be deleted separately.
 
 [float]
 [[dfa-update-limitations]]
 === Cannot update a {dfanalytics-job}
 
-You cannot update {dfanalytics-cap} configurations. Instead, delete the {dfanalytics-job} and
-create a new one.
+You cannot update {dfanalytics-cap} configurations. Instead, delete the 
+{dfanalytics-job} and create a new one.
 
 [float]
 [[dfa-dataframe-size-limitations]]

--- a/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
@@ -40,10 +40,11 @@ dedicated for {ml} processes. For general {ml} settings, see
 [[dfa-field-limitations]]
 === Field limitations in {dfanalytics}
 
-Currently, categorical fields are not considered as feature fields for 
-{oldetection}, so they cannot be used during the analysis. {dfanalytics-cap} 
-only support numeric fields and don't support fields that contain arrays. The 
-analysis will skip every document that has such fields.
+Currently, {oldetection} only supports numeric features. Non-numeric fields will 
+be excluded from the analysis by default. If such a field is explicitly included 
+in the analysis, starting the {dfanalytics} should result in failure. Arrays are 
+not supported either. Documents that contain analyzed fields with unsupported 
+values will be skipped entirely.
 
 [float]
 [[dfa-missing-fields-limitations]]

--- a/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
@@ -29,13 +29,6 @@ destination index won't be deleted. This object must be deleted separately.
 then create a new {dfanalytics-job} instead.
 
 [float]
-[[dfa-datatype-limitations]]
-=== {dfanalytics-cap} data type limitation
-
-{dfanalytics-cap} only support numeric fields and don't support fields that 
-contain arrays. The analysis will skip every document that has such fields.
-
-[float]
 [[dfa-dataframe-size-limitations]]
 === {dataframe-cap} memory limitation
 
@@ -44,11 +37,13 @@ dedicated for {ml} processes. For general {ml} settings, see
 {ref}/ml-settings.html[{ml-cap} settings in {es}].
 
 [float]
-[[dfa-categorical-limitations]]
-=== Categorical fields are not supported in {dfanalytics}
+[[dfa-field-limitations]]
+=== Field limitations in {dfanalytics}
 
 Currently, categorical fields are not considered as feature fields for 
-{oldetection}, so they cannot be used during the analysis.
+{oldetection}, so they cannot be used during the analysis. {dfanalytics-cap} 
+only support numeric fields and don't support fields that contain arrays. The 
+analysis will skip every document that has such fields.
 
 [float]
 [[dfa-missing-fields-limitations]]

--- a/docs/en/stack/ml/df-analytics/index.asciidoc
+++ b/docs/en/stack/ml/df-analytics/index.asciidoc
@@ -20,8 +20,10 @@ dimensional "tabular" data structure, in other words a
 
 * <<dfa-outlier-detection>>
 * <<ml-dfanalytics-apis>>
+* <<ml-dfa-limitations>>
 
 --
 
 include::dfa-outlierdetection.asciidoc[]
 include::api-quickref.asciidoc[]
+include::dfanalytics-limitations.asciidoc[]


### PR DESCRIPTION
This PR adds the data frame analytics limitations subsection to the Machine learning data frame analytics section.