### PR TITLE
Updates 7.3.0 release highlights and breaking changes

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -28,8 +28,6 @@ Upgrade Assistant provides information about which {dfeeds} need to be updated.
 <titleabbrev>APM</titleabbrev>
 ++++
 
-coming[7.3.0]
-
 This list summarizes the most important breaking changes in APM. 
 For the complete list, go to {apm-server-ref-70}/breaking-changes.html[APM Server 7.0 breaking changes].
 
@@ -40,8 +38,6 @@ For the complete list, go to {apm-server-ref-70}/breaking-changes.html[APM Serve
 ++++
 <titleabbrev>Beats</titleabbrev>
 ++++
-
-coming[7.3.0]
 
 This list summarizes the most important breaking changes in Beats. For the
 complete list, go to {beats-ref}/breaking-changes.html[Beats breaking changes].
@@ -56,8 +52,6 @@ include::{beats-repo-dir}/breaking-7.0.asciidoc[tag=notable-breaking-changes]
 <titleabbrev>{es}</titleabbrev>
 ++++
 
-coming[7.3.0]
-
 This list summarizes the most important breaking changes in {es} {version}. For
 the complete list, go to {ref}/breaking-changes.html[{es} breaking changes].
 
@@ -69,8 +63,6 @@ include::{es-repo-dir}/reference/migration/migrate_7_3.asciidoc[tag=notable-brea
 ++++
 <titleabbrev>{es} Hadoop</titleabbrev>
 ++++
-
-coming[7.3.0]
 
 This list summarizes the most important breaking changes in {es} Hadoop {version}.
 For the complete list, go to
@@ -85,8 +77,6 @@ include::{hadoop-repo-dir}/appendix/breaking.adoc[tag=notable-v7-breaking-change
 <titleabbrev>{kib}</titleabbrev>
 ++++
 
-coming[7.3.0]
-
 This list summarizes the most important breaking changes in {kib} {version}. For
 the complete list, go to {kibana-ref}/breaking-changes.html[{kib} breaking changes].
 
@@ -98,8 +88,6 @@ include::{kib-repo-dir}/migration/migrate_7_3.asciidoc[tag=notable-breaking-chan
 ++++
 <titleabbrev>{ls}</titleabbrev>
 ++++
-
-coming[7.3.0]
 
 This list summarizes the most important breaking changes in {ls} {version}. For
 the complete list, go to

--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -66,11 +66,12 @@ include::{es-repo-dir}/reference/migration/migrate_7_3.asciidoc[tag=notable-brea
 <titleabbrev>{es} Hadoop</titleabbrev>
 ++++
 
-This list summarizes the most important breaking changes in {es} Hadoop {version}.
+//This list summarizes the most important breaking changes in {es} Hadoop {version}.
+There are no breaking changes in 7.3.0.
 For the complete list, go to
 {hadoop-ref}/breaking-changes.html[Elasticsearch Hadoop breaking changes].
 
-include::{hadoop-repo-dir}/appendix/breaking.adoc[tag=notable-v7-breaking-changes]
+//include::{hadoop-repo-dir}/appendix/breaking.adoc[tag=notable-v7-breaking-changes]
 
 [[kibana-breaking-changes]]
 === {kib} breaking changes

--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -28,8 +28,10 @@ Upgrade Assistant provides information about which {dfeeds} need to be updated.
 <titleabbrev>APM</titleabbrev>
 ++++
 
-This list summarizes the most important breaking changes in APM. 
-For the complete list, go to {apm-server-ref-70}/breaking-changes.html[APM Server 7.0 breaking changes].
+//This list summarizes the most important breaking changes in APM. 
+There are no breaking changes in 7.3.0.
+For the complete list, go to
+{apm-get-started-ref}/apm-breaking-changes.html[APM breaking changes].
 
 //include::{apm-repo-dir}/apm-breaking-changes.asciidoc[tag=notable-v7-breaking-changes]
 

--- a/docs/en/install-upgrade/highlights.asciidoc
+++ b/docs/en/install-upgrade/highlights.asciidoc
@@ -4,12 +4,11 @@
 Each release brings new features and product improvements. This section
 highlights notable new features and enhancements in {version}.
 
-//** <<apm-highlights,APM>>
+** <<apm-highlights,APM>>
 ** <<beats-highlights,Beats>>
 ** <<elasticsearch-highlights,{es}>>
 ** <<kibana-higlights,{kib}>>
 
-////
 [[apm-highlights]]
 === APM highlights
 ++++
@@ -20,8 +19,7 @@ This list summarizes the most important enhancements in APM.
 For the complete list, go to
 {apm-overview-ref-v}/apm-release-notes.html[APM release highlights].
 
-include::{apm-repo-dir}/apm-release-notes.asciidoc[tag=notable-v7-highlights]
-////
+include::{apm-repo-dir}/apm-release-notes.asciidoc[tag=notable-v73-highlights]
 
 [[beats-highlights]]
 === Beats highlights

--- a/docs/en/install-upgrade/highlights.asciidoc
+++ b/docs/en/install-upgrade/highlights.asciidoc
@@ -16,8 +16,6 @@ highlights notable new features and enhancements in {version}.
 <titleabbrev>APM</titleabbrev>
 ++++
 
-coming[7.3.0]
-
 This list summarizes the most important enhancements in APM.
 For the complete list, go to
 {apm-overview-ref-v}/apm-release-notes.html[APM release highlights].
@@ -31,8 +29,6 @@ include::{apm-repo-dir}/apm-release-notes.asciidoc[tag=notable-v7-highlights]
 <titleabbrev>Beats</titleabbrev>
 ++++
 
-coming[7.3.0]
-
 This list summarizes the most important enhancements in Beats.
 For the complete list, go to {beats-ref}/release-highlights.html[Beats release highlights].
 
@@ -44,8 +40,6 @@ For the complete list, go to {beats-ref}/release-highlights.html[Beats release h
 ++++
 <titleabbrev>{es}</titleabbrev>
 ++++
-
-coming[7.3.0]
 
 This list summarizes the most important enhancements in {es} {version}.
 For the complete list, go to {ref}/release-highlights.html[{es} release highlights].
@@ -64,8 +58,6 @@ include::{es-repo-dir}/reference/release-notes/highlights-7.3.0.asciidoc[tag=not
 ++++
 <titleabbrev>{kib}</titleabbrev>
 ++++
-
-coming[7.3.0]
 
 This list summarizes the most important enhancements in {kib} {version}.
 For the complete list, go to {kibana-ref}/release-highlights.html[{kib} release highlights].

--- a/docs/en/install-upgrade/highlights.asciidoc
+++ b/docs/en/install-upgrade/highlights.asciidoc
@@ -42,13 +42,11 @@ For the complete list, go to {beats-ref}/release-highlights.html[Beats release h
 This list summarizes the most important enhancements in {es} {version}.
 For the complete list, go to {ref}/release-highlights.html[{es} release highlights].
 
-////
 :leveloffset: +1
 
 include::{es-repo-dir}/reference/release-notes/highlights-7.3.0.asciidoc[tag=notable-highlights]
 
 :leveloffset: -1
-////
 
 [[kibana-higlights]]
 === {kib} highlights


### PR DESCRIPTION
This PR removes the coming[7.3.0] tags from the Installation and Upgrade Guide. It also makes changes to pick up the APM and Elasticsearch release highlights and breaking changes.

This PR must be merged after https://github.com/elastic/elasticsearch/pull/45066