### PR TITLE
[DOCS] Adds Beats 7.3 release highlights

### DIFF
--- a/docs/en/install-upgrade/highlights.asciidoc
+++ b/docs/en/install-upgrade/highlights.asciidoc
@@ -30,7 +30,7 @@ include::{apm-repo-dir}/apm-release-notes.asciidoc[tag=notable-v73-highlights]
 This list summarizes the most important enhancements in Beats.
 For the complete list, go to {beats-ref}/release-highlights.html[Beats release highlights].
 
-//include::{beats-repo-dir}/highlights-7.3.0.asciidoc[tag=notable-highlights]
+include::{beats-repo-dir}/highlights-7.3.0.asciidoc[tag=notable-highlights]
 
 [[elasticsearch-highlights]]
 === {es} highlights


### PR DESCRIPTION
This PR depends on https://github.com/elastic/beats/pull/13138

After that PR is backported to 7.3, this PR can integrate those release highlights in the Installation and Upgrade Guide (https://www.elastic.co/guide/en/elastic-stack/current/beats-highlights.html)