### PR TITLE
fix typo in command-line for certificate generation

### DIFF
--- a/docs/en/stack/security/securing-communications/tutorial-tls-certificates.asciidoc
+++ b/docs/en/stack/security/securing-communications/tutorial-tls-certificates.asciidoc
@@ -48,10 +48,10 @@ Run the following command:
 ["source","sh",subs="attributes,callouts"]
 ----------------------------------------------------------------------
 ./bin/elasticsearch-certutil cert \
-  --ca elastic-stack-ca.p12 \<1>
-  --dns localhost \<2>
-  --ip 127.0.0.1,::1 \<3>
-  --out config/certs/node-1.p12 <4>
+  --ca elastic-stack-ca.p12 \//<1>
+  --dns localhost \//<2>
+  --ip 127.0.0.1,::1 \//<3>
+  --out config/certs/node-1.p12 //<4>
 ----------------------------------------------------------------------
 // NOTCONSOLE
 <1> The `--ca` parameter contains the name of certificate authority that you

--- a/docs/en/stack/security/securing-communications/tutorial-tls-certificates.asciidoc
+++ b/docs/en/stack/security/securing-communications/tutorial-tls-certificates.asciidoc
@@ -48,10 +48,10 @@ Run the following command:
 ["source","sh",subs="attributes,callouts"]
 ----------------------------------------------------------------------
 ./bin/elasticsearch-certutil cert \
---ca elastic-stack-ca.p12 \ <1>
---dns localhost \ <2>
---ip 127.0.0.1,::1 <3>
---out config/certs/node-1.p12 <4>
+  --ca elastic-stack-ca.p12 \<1>
+  --dns localhost \<2>
+  --ip 127.0.0.1,::1 \<3>
+  --out config/certs/node-1.p12 <4>
 ----------------------------------------------------------------------
 // NOTCONSOLE
 <1> The `--ca` parameter contains the name of certificate authority that you


### PR DESCRIPTION
This fixes two issues with the example command to generate a node certificate:

- it adds a backslash that was missing on one of the lines, which prevented the subsequent flag from being read
- it removes the blank space between the end-of-line backslashes and the line markings (e.g. `"\ <2>"` becomes `"\<2>"`), which added invisible spaces to the command when copied-and-pasted, resulting in most of the lines being ignored even though it looked right on the terminal

@lcawl, I don't know much about our asciidoc practices / build system, and my only concern is that the second item (removing the spaces) might keep it from recognizing the footnote symbols. If so I imagine you can advise me how to do it correctly :-)