### PR TITLE
[DOCS] Add Kerberos configration redirect

### DIFF
--- a/docs/en/stack/redirects.asciidoc
+++ b/docs/en/stack/redirects.asciidoc
@@ -32,3 +32,8 @@ See <<elasticsearch-security>>.
 === Security files
 
 See {ref}/security-files.html[Security files].
+
+[role="exclude",id="configuring-kerberos-realm"]
+=== Kerberos authentication
+
+See {ref}/configuring-kerberos-realm.html[Configuring a Kerberos realm].


### PR DESCRIPTION
Adds a redirect for a broken link currently blocking the docs build.

This link is live in 7.3+ so it only affects the 7.2 branch.