### PR TITLE
Adds instructions for sending Beats monitoring data to ESMS

### DIFF
--- a/docs/en/stack/index.asciidoc
+++ b/docs/en/stack/index.asciidoc
@@ -15,7 +15,7 @@
 :xes-repo-dir:      {docdir}/../../../../elasticsearch/x-pack/docs/en
 :es-repo-dir:       {docdir}/../../../../elasticsearch/docs/reference
 :stack-repo-dir:    {docdir}
-
+:beats-repo-dir:    {docdir}/../../../../beats/libbeat/docs
 include::{asciidoc-dir}/../../shared/versions.asciidoc[]
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 

--- a/docs/en/stack/monitoring/esms.asciidoc
+++ b/docs/en/stack/monitoring/esms.asciidoc
@@ -60,10 +60,13 @@ include::{es-repo-dir}/monitoring/configuring-metricbeat.asciidoc[tag=disable-sy
 --
 
 . Identify where to send the {es} monitoring data and supply the necessary
-security information. Add the following settings in the {metricbeat}
-configuration file (`metricbeat.yml`):
+security information.
 +
 --
+// tag::metricbeat-config[]
+Add the following settings in the {metricbeat} configuration file
+(`metricbeat.yml`):
+
 [source,yaml]
 ----------------------------------
 output.elasticsearch:
@@ -76,6 +79,7 @@ output.elasticsearch:
 {stack-ov}/built-in-roles.html[`remote_monitoring_agent` built-in role]. 
 <3> Replace `MONITORING_AGENT_PASSWORD` with the value provided to you by the
 Elastic support team.
+// end::metricbeat-config[]
 --
 
 . {metricbeat-ref}/metricbeat-starting.html[Start {metricbeat}].
@@ -142,22 +146,10 @@ include::{kib-repo-dir}/monitoring/monitoring-metricbeat.asciidoc[tag=disable-sy
 --
 
 . Identify where to send the {kib} monitoring data and supply the necessary
-security information. Add the following settings in the {metricbeat}
-configuration file (`metricbeat.yml`):
+security information.
 +
 --
-[source,yaml]
-----------------------------------
-  output.elasticsearch:
-    hosts: ["MONITORING_ELASTICSEARCH_URL"] <1>
-    username: cloud_monitoring_agent <2>
-    password: MONITORING_AGENT_PASSWORD <3>
-----------------------------------
-<1> Replace `MONITORING_ELASTICSEARCH_URL` with the appropriate URL for {esms-init}.
-<2> The Elastic support team creates this user in {esms-init} and grants it the
-{stack-ov}/built-in-roles.html[`remote_monitoring_agent` built-in role]. 
-<3> Replace `MONITORING_AGENT_PASSWORD` with the value provided to you by the
-  Elastic support team.
+include::esms.asciidoc[tag=metricbeat-config]
 --
 
 . {metricbeat-ref}/metricbeat-starting.html[Start {metricbeat}]. 
@@ -172,3 +164,88 @@ that was provided to you by the Elastic support team.
 If you do not see your metrics yet, see
 <<monitoring-troubleshooting,Troubleshooting {monitor-features}>>.
 --
+
+[discrete]
+[[esms-beats]]
+=== Collecting monitoring data about Beats
+
+:beatname_lc:       packetbeat
+:beatname_uc:       {packetbeat}
+
+There are two methods for sending monitoring data about Beats to {esms-init}.
+You can send it directly to {esms-init} by using {metricbeat} or you can route
+it through exporters on the production cluster.
+
+TIP: It is simplest to use {metricbeat}.
+
+For example, to use {metricbeat} to monitor {beatname_uc}:
+
+. Enable the HTTP endpoint to allow external collection of monitoring data:
++
+--
+include::{beats-repo-dir}/monitoring/monitoring-metricbeat.asciidoc[tag=enable-http-endpoint]
+--
+
+. Disable the default collection of {beatname_uc} monitoring metrics. +
++
+--
+include::{beats-repo-dir}/monitoring/monitoring-metricbeat.asciidoc[tag=disable-beat-collection]
+--
+
+. Start {beatname_uc}.
+
+. {metricbeat-ref}/metricbeat-installation.html[Install {metricbeat}] on the 
+same server as {beatname_uc}. If you already have {metricbeat} installed on the
+server, skip this step.
+
+. Enable the `beat-xpack` module in {metricbeat}.
++
+--
+include::{beats-repo-dir}/monitoring/monitoring-metricbeat.asciidoc[tag=enable-beat-module]
+--
+
+. Configure the `beat-xpack` module in {metricbeat}. +
++
+--
+include::{beats-repo-dir}/monitoring/monitoring-metricbeat.asciidoc[tag=configure-beat-module]
+
+include::{beats-repo-dir}/monitoring/monitoring-metricbeat.asciidoc[tag=remote-monitoring-user]
+--
+
+. Optional: Disable the system module in the {metricbeat}.
++
+--
+include::{beats-repo-dir}/monitoring/monitoring-metricbeat.asciidoc[tag=disable-system-module]
+--
+
+. Identify where to send the monitoring data and supply the necessary security
+information.
++
+--
+include::esms.asciidoc[tag=metricbeat-config]
+--
+
+. {metricbeat-ref}/metricbeat-starting.html[Start {metricbeat}]. 
+
+. Verify that your monitoring data exists in {esms-init}.
++
+--
+Open {kib} in your web browser. Use the {kib} URL and the administrator user ID
+that was provided to you by the Elastic support team.
+{kibana-ref}/kibana-page.html[View the {kib} metrics] on the *Stack Monitoring* page.
+
+If you do not see your metrics yet, see
+<<monitoring-troubleshooting,Troubleshooting {monitor-features}>>.
+--
+
+For more information about monitoring Beats, see:
+
+* {auditbeat-ref}/monitoring.html[{auditbeat}]
+* {filebeat-ref}/monitoring.html[{filebeat}]
+* {functionbeat-ref}/monitoring.html[{functionbeat}] 
+* {heartbeat-ref}/monitoring.html[{heartbeat}]
+* {journalbeat-ref}/monitoring.html[{journalbeat}]
+* {metricbeat-ref}/monitoring.html[{metricbeat}]
+* {packetbeat-ref}/monitoring.html[{packetbeat}]
+* {winlogbeat-ref}/monitoring.html[{winlogbeat}] 
+

--- a/docs/en/stack/monitoring/esms.asciidoc
+++ b/docs/en/stack/monitoring/esms.asciidoc
@@ -17,8 +17,6 @@ Elastic support team.
 There are two methods for collecting and sending data about the health of your
 production cluster to {esms-init}: {metricbeat} or collectors and exporters.
 
-TIP: It is simplest to use {metricbeat}.
-
 To use {metricbeat}:
 
 . Enable the collection of monitoring data on your cluster.
@@ -104,8 +102,6 @@ There are two methods for sending monitoring data about {kib} to {esms-init}.
 You can send it directly to {esms-init} by using {metricbeat} or you can route
 it through exporters on the production cluster.
 
-TIP: It is simplest to use {metricbeat}. 
-
 To use {metricbeat}:
 
 . Disable the default collection of {kib} monitoring metrics. +
@@ -175,8 +171,6 @@ If you do not see your metrics yet, see
 There are two methods for sending monitoring data about Beats to {esms-init}.
 You can send it directly to {esms-init} by using {metricbeat} or you can route
 it through exporters on the production cluster.
-
-TIP: It is simplest to use {metricbeat}.
 
 For example, to use {metricbeat} to monitor {beatname_uc}:
 

--- a/docs/en/stack/monitoring/intro.asciidoc
+++ b/docs/en/stack/monitoring/intro.asciidoc
@@ -19,14 +19,15 @@ For more information, see:
 * <<monitoring-production>>
 * {ref}/es-monitoring.html[Monitoring {es}]
 * {kibana-ref}/xpack-monitoring.html[Monitoring {kib}]
-* {logstash-ref}/monitoring-logstash.html[Monitoring Logstash]
+* {logstash-ref}/monitoring-logstash.html[Monitoring {ls}]
 * Monitoring Beats:
-** {auditbeat-ref}/monitoring.html[Auditbeat]
-** {filebeat-ref}/monitoring.html[Filebeat]
-** {heartbeat-ref}/monitoring.html[Heartbeat]
-** {metricbeat-ref}/monitoring.html[Metricbeat]
-** {packetbeat-ref}/monitoring.html[Packetbeat]
-** {winlogbeat-ref}/monitoring.html[Winlogbeat] 
+** {auditbeat-ref}/monitoring.html[{auditbeat}]
+** {filebeat-ref}/monitoring.html[{filebeat}]
+** {functionbeat-ref}/monitoring.html[{functionbeat}] 
+** {heartbeat-ref}/monitoring.html[{heartbeat}]
+** {metricbeat-ref}/monitoring.html[{metricbeat}]
+** {packetbeat-ref}/monitoring.html[{packetbeat}]
+** {winlogbeat-ref}/monitoring.html[{winlogbeat}] 
 
 
 


### PR DESCRIPTION
Related to https://github.com/elastic/beats/issues/12647 and https://github.com/elastic/docs/pull/1043

This PR updates the instructions in the Stack Overview > Elastic Stack Monitoring Service page
(https://www.elastic.co/guide/en/elastic-stack-overview/master/esms.html) to include setup steps for collecting Beats monitoring data.