### PR TITLE
[DOCS] Fixes incorrect substitution in Jobs section

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/jobs.asciidoc
@@ -20,7 +20,7 @@ categories and partitions. Some of these more advanced job configurations
 are described in the following section: <<ml-configuring>>.
 
 For a description of all the job properties, see
-{ref}/ml-job-resource.html[{anomaly-job-cap} resources].
+{ref}/ml-job-resource.html[{anomaly-jobs-cap} resources].
 
 In {kib}, there are wizards that help you create specific types of jobs, such
 as _single metric_, _multi-metric_, and _population_ jobs. A single metric job


### PR DESCRIPTION
This PR fixes an incorrect substitution on the Jobs page.