### PR TITLE
[docs] Update Hadoop to use version attribute

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -29,7 +29,7 @@ Upgrade Assistant provides information about which {dfeeds} need to be updated.
 ++++
 
 //This list summarizes the most important breaking changes in APM. 
-There are no breaking changes in 7.3.0.
+There are no breaking changes in {version}.
 For the complete list, go to
 {apm-get-started-ref}/apm-breaking-changes.html[APM breaking changes].
 


### PR DESCRIPTION
I think the hardwiring of `7.3.0` is a bug. Everywhere else, including the header for this section, uses `{version}`.