### PR TITLE
[Backport 7.3] add additional SSLHandshakeException

### DIFF
--- a/docs/en/stack/security/troubleshooting.asciidoc
+++ b/docs/en/stack/security/troubleshooting.asciidoc
@@ -244,7 +244,7 @@ found in the `keystore` or `truststore` and needs to be added to trust this
 certificate.
 --
 
-`javax.net.ssl.SSLHandshakeException: Invalid ECDH ServerKeyExchange signature``::
+`javax.net.ssl.SSLHandshakeException: Invalid ECDH ServerKeyExchange signature`::
 +
 --
 The `Invalid ECDH ServerKeyExchange signature` can indicate that a key and a corresponding certificate don't match and are

--- a/docs/en/stack/security/troubleshooting.asciidoc
+++ b/docs/en/stack/security/troubleshooting.asciidoc
@@ -244,6 +244,14 @@ found in the `keystore` or `truststore` and needs to be added to trust this
 certificate.
 --
 
+`javax.net.ssl.SSLHandshakeException: Invalid ECDH ServerKeyExchange signature``::
++
+--
+The `Invalid ECDH ServerKeyExchange signature` can indicate that a key and a corresponding certificate don't match and are
+causing the handshake to fail.
+Verify the contents of each of the files you are using for your configured certificate authorities, certificates and keys. In particular, check that the key and certificate belong to the same key pair. 
+--
+
 [[trb-security-ssl]]
 === Common SSL/TLS exceptions
 


### PR DESCRIPTION
Add addition to SSLHandshakeException troubleshooting guide for ECDH ServerKeyExchange
that might be caused by cert/cacert/key mismatch.

Backport of: #332

Co-Authored-By: Tim Vernum <tim@adjective.org>
Co-Authored-By: Peter Dyson <peter.dyson@geekpete.com>