### PR TITLE
Updates version attributes filename

### DIFF
--- a/docs/en/getting-started/index.asciidoc
+++ b/docs/en/getting-started/index.asciidoc
@@ -14,7 +14,7 @@
 :kib-repo-dir:      {docdir}/../../../../kibana/docs
 :xes-repo-dir:      {docdir}/../../../../elasticsearch/x-pack/docs/en
 
-include::{asciidoc-dir}/../../shared/versions74.asciidoc[]
+include::{asciidoc-dir}/../../shared/versions75.asciidoc[]
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
 include::get-started-stack.asciidoc[]

--- a/docs/en/infraops/index.asciidoc
+++ b/docs/en/infraops/index.asciidoc
@@ -5,7 +5,7 @@
 
 = Infrastructure Monitoring Guide
 
-include::{asciidoc-dir}/../../shared/versions74.asciidoc[]
+include::{asciidoc-dir}/../../shared/versions75.asciidoc[]
 
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 

--- a/docs/en/stack/index.asciidoc
+++ b/docs/en/stack/index.asciidoc
@@ -16,7 +16,7 @@
 :es-repo-dir:       {docdir}/../../../../elasticsearch/docs/reference
 :stack-repo-dir:    {docdir}
 :beats-repo-dir:    {docdir}/../../../../beats/libbeat/docs
-include::{asciidoc-dir}/../../shared/versions74.asciidoc[]
+include::{asciidoc-dir}/../../shared/versions75.asciidoc[]
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
 include::introduction.asciidoc[]


### PR DESCRIPTION
Related to https://github.com/elastic/docs/pull/1109 and https://github.com/elastic/docs/pull/1108

This PR updates the books in the 7.x branch to use the appropriate shared version attributes file.