### PR TITLE
[DOCS] Adds conceptual documentation of regression and the related evaluation type

### DIFF
--- a/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
@@ -88,7 +88,7 @@ Another crucial measurement is how well your model performs on unseen
 data points. To assess how well the trained model will perform on data it has 
 never seen before, you must set aside a proportion of the training dataset for 
 testing. This split of the dataset is the testing dataset. Once the model has 
-been trained and found out the required coefficients, you can let the model 
+been trained, you can let the model 
 predict the value of the data points it has never seen before and compare the 
 prediction to the actual value. This test provides an estimate of a quantity 
 known as the _model generalization error_.

--- a/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
@@ -92,7 +92,7 @@ proportion of the training dataset needs to be set out for testing. This split
 of the dataset is the testing dataset. Once the model has been trained and found 
 out the required coefficients, you can let the model predict the value of the 
 data points it has never seen before and compare the prediction to the actual 
-value. This test provides an estimate of a quantity known as the *model 
+value. This test provides an estimate of a quantity known as the _model 
 generalization error*.
 
 Two concepts describe how well the {regression} algorithm was able to learn the 

--- a/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
@@ -24,7 +24,7 @@ monthly rent of a hundred square meter-size apartment.
 This is a simple example. Usually {regression} problems are multi-dimensional, 
 so the relationships that {reganalysis} tries to find are between multiple 
 fields. To extend our example, a more complex 
-{reganalysis} could take into account further {feature-vars} like the location 
+{reganalysis} could take into account additional factors such as the location 
 of the apartment in the city, on which floor it is, and whether the apartment 
 has a riverside view or not and so on.
 

--- a/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
@@ -80,7 +80,7 @@ that we use in the {stack} is a type of boosting called extreme gradient boost
 
 You can measure how well the model has performed on your training dataset by 
 using the `regression` evaluation type of the {ref}/evaluate-dfanalytics.html[evaluate {dfanalytics} API]. The 
-mean squared error value that the evaluation may provide you on the training 
+mean squared error (MSE) value that the evaluation may provide you on the training 
 dataset is the _training error_. Training the {regression} model means finding 
 the combination of model parameters that produces the lowest possible training 
 error.

--- a/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
@@ -3,8 +3,8 @@
 == {regression-cap}
 
 {reganalysis-cap} is a {ml} process for estimating the relationships among 
-a number of {feature-vars} and a {depvar} (or {con-targvar}), then making 
-further predictions based on the described relationship.
+a number of {feature-vars} and a {depvar}, then making further predictions based 
+on the described relationship.
 
 For example, suppose we are interested in finding the relationship between 
 apartment size and monthly rent in a city. In this simple example, the rent is 
@@ -35,11 +35,10 @@ apartment has a riverside view or not and so on.
 [dfa-regression-features]
 === {feature-vars-cap}
 
-{feature-vars-cap} are the values that the {con-targvar} value depends on 
-(that's why it is also called as {depvar}). If one or more of the {feature-vars} 
-changes that means that the {con-targvar} value also changes. There are three 
-different types of {feature-vars} that you can ship to the {regression} 
-algorithm:
+{feature-vars-cap} are the values that the {depvar} value depends on. If one or 
+more of the {feature-vars} changes that means that the {depvar} value also 
+changes. There are three different types of {feature-vars} that you can ship to 
+the {regression} algorithm:
 * Numerical. In our example, the size of the apartment was a 
   numerical {feature-var}.
 * Categorical. A variable that can have one value from a set of values. The 
@@ -47,6 +46,7 @@ algorithm:
   the location of the apartment in the city (borough) is a categorical variable.
 * Boolean. The riverside view in the example is a boolean value because an 
   apartment either has a riverside view or doesn't have one.
+Arrays are not supported.
 
 
 [discrete]
@@ -67,7 +67,7 @@ mathematical formula. {reganalysis-cap} tries to find the best value for the
 we use an ensemble learning model that uses multiple algorithms. The performance 
 of an ensemble is usually better than the performance of an individual 
 algorithm because each of the algorithms has a different bias, so each of them 
-falls into different traps. When they used together as a group, then they 
+falls into different traps. When they are used together as a group, then they 
 capture the characteristics of the data better. The ensemble learning technique 
 that we use in the {stack} is a type of boosting called extreme gradient boost 
 (XGboost) which combines decision trees with gradient boosting methodologies.
@@ -79,9 +79,10 @@ that we use in the {stack} is a type of boosting called extreme gradient boost
 
 You can measure how well the model has performed on your training dataset by 
 using the `regression` evaluation type of the evaluate {dfanalytics} API. The 
-error value that the evaluation provides you on the training dataset is the 
-*training error*. Training the {regression} model means finding the combination 
-of model parameters that produces the lowest possible training error.
+mean squared error value that the evaluation may provide you on the training 
+dataset is the *training error*. Training the {regression} model means finding 
+the combination of model parameters that produces the lowest possible training 
+error.
 
 The training error does not tell much about how the model will perform on unseen 
 data points, however, this is a crucial factor that you want to know. To assess 

--- a/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
@@ -39,6 +39,7 @@ has a riverside view or not and so on.
 more of the {feature-vars} changes, the {depvar} value also changes. There are 
 three different types of {feature-vars} that you can ship to the {regression} 
 algorithm:
+
 * Numerical. In our example, the size of the apartment was a 
   numerical {feature-var}.
 * Categorical. A variable that can have one value from a set of values. The 

--- a/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
@@ -3,7 +3,7 @@
 == {regression-cap}
 
 {reganalysis-cap} is a {ml} process for estimating the relationships among 
-different variables, then making further predictions based on these 
+different fields in your data, then making further predictions based on these 
 relationships.
 
 For example, suppose we are interested in finding the relationship between 

--- a/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
@@ -62,15 +62,14 @@ relationships between the data points to make certain inferences about new data
 points.
 
 The relationships between the {feature-vars} and the {depvar} is described as a 
-mathematical function. {reganalysis-cap} tries to find the best value for the 
-{depvar} by combining various {ml} techniques, that means that in the {stack}, 
-we use an ensemble learning model that uses multiple algorithms. The performance 
-of an ensemble is usually better than the performance of an individual 
-algorithm because each of the algorithms has a different bias, so each of them 
-falls into different traps. When they are used together as a group, then they 
-capture the characteristics of the data better. The ensemble learning technique 
-that we use in the {stack} is a type of boosting called extreme gradient boost 
-(XGboost) which combines decision trees with gradient boosting methodologies.
+mathematical function. {reganalysis-cap} tries to find the best prediction for 
+the {depvar} by combining the predictions from multiple base learners. The 
+performance of an ensemble is usually better than the performance of each 
+individual base learner because the individual learners will make different 
+errors. These average out when their predictions are combined. The ensemble 
+learning technique that we use in the {stack} is a type of boosting called 
+extreme gradient boost (XGboost) which combines decision trees with gradient 
+boosting methodologies.
 
  
 [discrete]

--- a/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
@@ -97,7 +97,7 @@ generalization error_.
 
 Two concepts describe how well the {regression} algorithm was able to learn the 
 relationship between the {feature-vars} and the {depvar}. _Underfitting_ is when 
-the model cannot capture the complexity of the dataset. Overfitting is when the 
+the model cannot capture the complexity of the dataset. _Overfitting_ is when the 
 model has trained through a dataset so sharply that it is capturing all the 
 details and cannot generalize well enough. A model that overfits the data has a 
 low mean squared error (MSE) value on the training dataset, but a high MSE value 

--- a/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
@@ -87,7 +87,7 @@ error.
 
 Another crucial measurement is how well your model performs on unseen 
 data points. To assess 
-how well the trained model will perform on data it has never seen before, a 
+how well the trained model will perform on data it has never seen before, you must set aside a 
 proportion of the training dataset needs to be set out for testing. This split 
 of the dataset is the testing dataset. Once the model has been trained and found 
 out the required coefficients, you can let the model predict the value of the 

--- a/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
@@ -86,7 +86,7 @@ the combination of model parameters that produces the lowest possible training
 error.
 
 Another crucial measurement is how well your model performs on unseen 
-data points, however, this is a crucial factor that you want to know. To assess 
+data points. To assess 
 how well the trained model will perform on data it has never seen before, a 
 proportion of the training dataset needs to be set out for testing. This split 
 of the dataset is the testing dataset. Once the model has been trained and found 

--- a/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
@@ -62,7 +62,7 @@ relationships between the data points to make certain inferences about new data
 points.
 
 The relationships between the {feature-vars} and the {depvar} is described as a 
-mathematical formula. {reganalysis-cap} tries to find the best value for the 
+mathematical function. {reganalysis-cap} tries to find the best value for the 
 {depvar} by combining various {ml} techniques, that means that in the {stack}, 
 we use an ensemble learning model that uses multiple algorithms. The performance 
 of an ensemble is usually better than the performance of an individual 

--- a/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
@@ -19,7 +19,7 @@ imaginary dataset consists of three data points:
 | 63        | 2300
 |===
 
-After the model described the relationship between the {feature-vars} and the 
+After the model determines the relationship between the {feature-vars} (apartment size) and the 
 {depvar}, it can predict the monthly rent of a hundred square meter-size 
 apartment.
 

--- a/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
@@ -96,7 +96,7 @@ value. This test provides an estimate of a quantity known as the _model
 generalization error_.
 
 Two concepts describe how well the {regression} algorithm was able to learn the 
-relationship between the {feature-vars} and the {depvar}. Underfitting is when 
+relationship between the {feature-vars} and the {depvar}. _Underfitting_ is when 
 the model cannot capture the complexity of the dataset. Overfitting is when the 
 model has trained through a dataset so sharply that it is capturing all the 
 details and cannot generalize well enough. A model that overfits the data has a 

--- a/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
@@ -98,7 +98,7 @@ generalization error_.
 Two concepts describe how well the {regression} algorithm was able to learn the 
 relationship between the {feature-vars} and the {depvar}. _Underfitting_ is when 
 the model cannot capture the complexity of the dataset. _Overfitting_ is when the 
-model has trained through a dataset so sharply that it is capturing all the 
+model has trained so specifically to a dataset that it is capturing all the 
 details and cannot generalize well enough. A model that overfits the data has a 
 low mean squared error (MSE) value on the training dataset, but a high MSE value 
 on the testing dataset. For more information about the evaluation metrics, see 

--- a/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
@@ -65,7 +65,7 @@ points.
 
 The relationships between the {feature-vars} and the {depvar} is described as a 
 mathematical function. {reganalysis-cap} tries to find the best prediction for 
-the {depvar} by combining the predictions from multiple base learners. The 
+the {depvar} by combining the predictions from multiple base learners – algorithms that generalize from the dataset. The 
 performance of an ensemble is usually better than the performance of each 
 individual base learner because the individual learners will make different 
 errors. These average out when their predictions are combined. The ensemble 

--- a/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
@@ -23,7 +23,7 @@ monthly rent of a hundred square meter-size apartment.
 
 This is a simple example. Usually {regression} problems are multi-dimensional, 
 so the relationships that {reganalysis} tries to find are between multiple 
-{feature-vars} and the {depvar}. To extend our example, a more complex 
+fields. To extend our example, a more complex 
 {reganalysis} could take into account further {feature-vars} like the location 
 of the apartment in the city, on which floor it is, and whether the apartment 
 has a riverside view or not and so on.

--- a/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
@@ -58,7 +58,7 @@ Arrays are not supported.
 {regression-cap} is a supervised machine learning process, which means that you 
 need to supply a labeled training dataset that has some {feature-vars} and a 
 {depvar}. The {regression} algorithm learns the relationships between the 
-features and the {depvar}. Once you've trained the model on your training 
+feature and the {depvar}. Once you've trained the model on your training 
 dataset, you can reuse the knowledge that the model has learned about the 
 relationships between the data points to make certain inferences about new data 
 points.

--- a/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
@@ -63,7 +63,7 @@ dataset, you can reuse the knowledge that the model has learned about the
 relationships between the data points to make certain inferences about new data 
 points.
 
-The relationships between the {feature-vars} and the {depvar} is described as a 
+The relationships between the {feature-vars} and the {depvar} are described as a 
 mathematical function. {reganalysis-cap} tries to find the best prediction for 
 the {depvar} by combining the predictions from multiple base learners – algorithms that generalize from the dataset. The 
 performance of an ensemble is usually better than the performance of each 

--- a/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
@@ -33,7 +33,9 @@ has a riverside view or not and so on.
 [[dfa-regression-features]]
 === {feature-vars-cap}
 
-When you perform {reganalysis}, you must identify a subset of fields that you want to use to create a model for predicting other fields. We refer to these fields as _feature variables_ and _dependent variables_, respectively.
+When you perform {reganalysis}, you must identify a subset of fields that you 
+want to use to create a model for predicting other fields. We refer to these 
+fields as _feature variables_ and _dependent variables_, respectively.
 {feature-vars-cap} are the values that the {depvar} value depends on. If one or 
 more of the {feature-vars} changes, the {depvar} value also changes. There are 
 three different types of {feature-vars} that you can use with our {regression} 

--- a/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
@@ -96,8 +96,8 @@ known as the _model generalization error_.
 Two concepts describe how well the {regression} algorithm was able to learn the 
 relationship between the {feature-vars} and the {depvar}. _Underfitting_ is when 
 the model cannot capture the complexity of the dataset. _Overfitting_ is when 
-the model has trained so specifically to a dataset that it is capturing all the 
-details and cannot generalize well enough. A model that overfits the data has a 
+the model is too specific to the training data set and is capturing details 
+which do not generalize to new data. A model that overfits the data has a 
 low MSE value on the training dataset and a high MSE value on the testing 
 dataset. For more information about the evaluation metrics, see 
 <<ml-dfanalytics-regression-evaluation>>.

--- a/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
@@ -79,7 +79,7 @@ that we use in the {stack} is a type of boosting called extreme gradient boost
 === Measuring model performance
 
 You can measure how well the model has performed on your training dataset by 
-using the `regression` evaluation type of the evaluate {dfanalytics} API. The 
+using the `regression` evaluation type of the {ref}/evaluate-dfanalytics.html[evaluate {dfanalytics} API]. The 
 mean squared error value that the evaluation may provide you on the training 
 dataset is the *training error*. Training the {regression} model means finding 
 the combination of model parameters that produces the lowest possible training 

--- a/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
@@ -37,7 +37,7 @@ has a riverside view or not and so on.
 
 {feature-vars-cap} are the values that the {depvar} value depends on. If one or 
 more of the {feature-vars} changes, the {depvar} value also changes. There are 
-three different types of {feature-vars} that you can ship to the {regression} 
+three different types of {feature-vars} that you can use with our {regression} 
 algorithm:
 
 * Numerical. In our example, the size of the apartment was a 

--- a/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
@@ -4,7 +4,7 @@
 
 {reganalysis-cap} is a {ml} process for estimating the relationships among 
 a number of {feature-vars} and a {depvar}, then making further predictions based 
-on the described relationship.
+on these relationships.
 
 For example, suppose we are interested in finding the relationship between 
 apartment size and monthly rent in a city. In this example, the rent is the 

--- a/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
@@ -20,7 +20,7 @@ imaginary dataset consists of three data points:
 |===
 
 After the model determines the relationship between the {feature-vars} (apartment size) and the 
-{depvar}, it can predict the monthly rent of a hundred square meter-size 
+{depvar} (rent), it can make predictions such as the monthly rent of a hundred square meter-size 
 apartment.
 
 This is a simple example, usually {regression} problems are multi-dimensional, 

--- a/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
@@ -33,6 +33,7 @@ has a riverside view or not and so on.
 [[dfa-regression-features]]
 === {feature-vars-cap}
 
+When you perform {reganalysis}, you must identify a subset of fields that you want to use to create a model for predicting other fields. We refer to these fields as _feature variables_ and _dependent variables_, respectively.
 {feature-vars-cap} are the values that the {depvar} value depends on. If one or 
 more of the {feature-vars} changes, the {depvar} value also changes. There are 
 three different types of {feature-vars} that you can use with our {regression} 

--- a/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
@@ -1,0 +1,103 @@
+[role="xpack"]
+[[dfa-regression]]
+== {regression-cap}
+
+{reganalysis-cap} is a {ml} process for estimating the relationships among 
+a number of {feature-vars} and a {depvar} (or {con-targvar}), then making 
+further predictions based on the described relationship.
+
+For example, suppose we are interested in finding the relationship between 
+apartment size and monthly rent in a city. In this simple example, the rent is 
+the {depvar} while the apartment size is the {feature-var} and we try to 
+find out the relationship between them in order to make further predictions. Our 
+imaginary dataset consists of three data points:
+
+|===
+| Size (m2) | Monthly rent 
+| 44        | 1600
+| 24        | 1055
+| 63        | 2300
+|===
+
+After the model described the relationship between the {feature-vars} and the 
+{depvar}, it can predict the monthly rent of a hundred square meter-size 
+apartment.
+
+Of course, this is a very simple example, usually {regression} problems are 
+multi-dimensional, so the relationships that {reganalysis} tries to find are 
+between multiple {feature-vars} and the {depvar}. To extend our example, a 
+more complex {reganalysis} could take into account further {feature-vars} like 
+the location of the apartment in the city, on which floor it is, and whether the 
+apartment has a riverside view or not and so on.
+
+
+[discrete]
+[dfa-regression-features]
+=== {feature-vars-cap}
+
+{feature-vars-cap} are the values that the {con-targvar} value depends on 
+(that's why it is also called as {depvar}). If one or more of the {feature-vars} 
+changes that means that the {con-targvar} value also changes. There are three 
+different types of {feature-vars} that you can ship to the {regression} 
+algorithm:
+* Numerical. In our example, the size of the apartment was a 
+  numerical {feature-var}.
+* Categorical. A variable that can have one value from a set of values. The 
+  value set has a fixed and limited number of possible items. In the example, 
+  the location of the apartment in the city (borough) is a categorical variable.
+* Boolean. The riverside view in the example is a boolean value because an 
+  apartment either has a riverside view or doesn't have one.
+
+
+[discrete]
+[dfa-regression-supervised]
+=== Training the {regression} algorithm
+
+{regression-cap} is a supervised machine learning process, which means that you 
+need to supply a labeled training dataset that has some {feature-vars} and a 
+{depvar}. The {regression} algorithm learns the relationships between the 
+features and the {depvar}. Once you've trained the model on your training 
+dataset, you can reuse the knowledge that the model has learned about the 
+relationships between the data points to make certain inferences about new data 
+points.
+
+The relationships between the {feature-vars} and the {depvar} is described as a 
+mathematical formula. {reganalysis-cap} tries to find the best value for the 
+{depvar} by combining various {ml} techniques, that means that in the {stack}, 
+we use an ensemble learning model that uses multiple algorithms. The performance 
+of an ensemble is usually better than the performance of an individual 
+algorithm because each of the algorithms has a different bias, so each of them 
+falls into different traps. When they used together as a group, then they 
+capture the characteristics of the data better. The ensemble learning technique 
+that we use in the {stack} is a type of boosting called extreme gradient boost 
+(XGboost) which combines decision trees with gradient boosting methodologies.
+
+ 
+[discrete]
+[dfa-regression-evaluation]
+=== Measuring model performance
+
+You can measure how well the model has performed on your training dataset by 
+using the `regression` evaluation type of the evaluate {dfanalytics} API. The 
+error value that the evaluation provides you on the training dataset is the 
+*training error*. Training the {regression} model means finding the combination 
+of model parameters that produces the lowest possible training error.
+
+The training error does not tell much about how the model will perform on unseen 
+data points, however, this is a crucial factor that you want to know. To assess 
+how well the trained model will perform on data it has never seen before, a 
+proportion of the training dataset needs to be set out for testing. This split 
+of the dataset is the testing dataset. Once the model has been trained and found 
+out the required coefficients, you can let the model predict the value of the 
+data points it has never seen before and compare the prediction to the actual 
+value. This test provides an estimate of a quantity known as the *model 
+generalization error*.
+
+Two concepts describe how well the {regression} algorithm was able to learn the 
+relationship between the {feature-vars} and the {depvar}. Underfitting is when 
+the model cannot capture the complexity of the dataset. Overfitting is when the 
+model has trained through a dataset so sharply that it is capturing all the 
+details and cannot generalize well enough. A model that overfits the data has a 
+low mean squared error (MSE) value on the training dataset, but a high MSE value 
+on the testing dataset. For more information about the evaluation metrics, see 
+<<ml-dfanalytics-regression-evaluation>>.

--- a/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
@@ -17,7 +17,7 @@ three data points:
 | 63        | 2300
 |===
 
-After the model determines the relationship between the {feature-vars} 
+After the model determines the relationship between the
 (apartment size) and the {depvar} (rent), it can make predictions such as the 
 monthly rent of a hundred square meter-size apartment.
 

--- a/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
@@ -88,7 +88,7 @@ error.
 Another crucial measurement is how well your model performs on unseen 
 data points. To assess 
 how well the trained model will perform on data it has never seen before, you must set aside a 
-proportion of the training dataset needs to be set out for testing. This split 
+proportion of the training dataset for testing. This split 
 of the dataset is the testing dataset. Once the model has been trained and found 
 out the required coefficients, you can let the model predict the value of the 
 data points it has never seen before and compare the prediction to the actual 

--- a/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
@@ -7,9 +7,9 @@ a number of {feature-vars} and a {depvar}, then making further predictions based
 on the described relationship.
 
 For example, suppose we are interested in finding the relationship between 
-apartment size and monthly rent in a city. In this simple example, the rent is 
-the {depvar} while the apartment size is the {feature-var} and we try to 
-find out the relationship between them in order to make further predictions. Our 
+apartment size and monthly rent in a city. In this example, the rent is the 
+{depvar} while the apartment size is the {feature-var} and we try to find out 
+the relationship between them in order to make further predictions. Our 
 imaginary dataset consists of three data points:
 
 |===
@@ -23,22 +23,22 @@ After the model described the relationship between the {feature-vars} and the
 {depvar}, it can predict the monthly rent of a hundred square meter-size 
 apartment.
 
-Of course, this is a very simple example, usually {regression} problems are 
-multi-dimensional, so the relationships that {reganalysis} tries to find are 
-between multiple {feature-vars} and the {depvar}. To extend our example, a 
-more complex {reganalysis} could take into account further {feature-vars} like 
-the location of the apartment in the city, on which floor it is, and whether the 
-apartment has a riverside view or not and so on.
+This is a simple example, usually {regression} problems are multi-dimensional, 
+so the relationships that {reganalysis} tries to find are between multiple 
+{feature-vars} and the {depvar}. To extend our example, a more complex 
+{reganalysis} could take into account further {feature-vars} like the location 
+of the apartment in the city, on which floor it is, and whether the apartment 
+has a riverside view or not and so on.
 
 
 [discrete]
-[dfa-regression-features]
+[[dfa-regression-features]]
 === {feature-vars-cap}
 
 {feature-vars-cap} are the values that the {depvar} value depends on. If one or 
-more of the {feature-vars} changes that means that the {depvar} value also 
-changes. There are three different types of {feature-vars} that you can ship to 
-the {regression} algorithm:
+more of the {feature-vars} changes, the {depvar} value also changes. There are 
+three different types of {feature-vars} that you can ship to the {regression} 
+algorithm:
 * Numerical. In our example, the size of the apartment was a 
   numerical {feature-var}.
 * Categorical. A variable that can have one value from a set of values. The 
@@ -50,7 +50,7 @@ Arrays are not supported.
 
 
 [discrete]
-[dfa-regression-supervised]
+[[dfa-regression-supervised]]
 === Training the {regression} algorithm
 
 {regression-cap} is a supervised machine learning process, which means that you 
@@ -74,7 +74,7 @@ that we use in the {stack} is a type of boosting called extreme gradient boost
 
  
 [discrete]
-[dfa-regression-evaluation]
+[[dfa-regression-evaluation]]
 === Measuring model performance
 
 You can measure how well the model has performed on your training dataset by 

--- a/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
@@ -85,7 +85,7 @@ dataset is the _training error_. Training the {regression} model means finding
 the combination of model parameters that produces the lowest possible training 
 error.
 
-The training error does not tell much about how the model will perform on unseen 
+Another crucial measurement is how well your model performs on unseen 
 data points, however, this is a crucial factor that you want to know. To assess 
 how well the trained model will perform on data it has never seen before, a 
 proportion of the training dataset needs to be set out for testing. This split 

--- a/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
@@ -81,7 +81,7 @@ that we use in the {stack} is a type of boosting called extreme gradient boost
 You can measure how well the model has performed on your training dataset by 
 using the `regression` evaluation type of the {ref}/evaluate-dfanalytics.html[evaluate {dfanalytics} API]. The 
 mean squared error value that the evaluation may provide you on the training 
-dataset is the *training error*. Training the {regression} model means finding 
+dataset is the _training error_. Training the {regression} model means finding 
 the combination of model parameters that produces the lowest possible training 
 error.
 

--- a/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
@@ -100,6 +100,6 @@ relationship between the {feature-vars} and the {depvar}. _Underfitting_ is when
 the model cannot capture the complexity of the dataset. _Overfitting_ is when the 
 model has trained so specifically to a dataset that it is capturing all the 
 details and cannot generalize well enough. A model that overfits the data has a 
-low mean squared error (MSE) value on the training dataset, but a high MSE value 
+low MSE value on the training dataset and a high MSE value 
 on the testing dataset. For more information about the evaluation metrics, see 
 <<ml-dfanalytics-regression-evaluation>>.

--- a/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
@@ -3,14 +3,12 @@
 == {regression-cap}
 
 {reganalysis-cap} is a {ml} process for estimating the relationships among 
-a number of {feature-vars} and a {depvar}, then making further predictions based 
-on these relationships.
+different variables, then making further predictions based on these 
+relationships.
 
 For example, suppose we are interested in finding the relationship between 
-apartment size and monthly rent in a city. In this example, the rent is the 
-{depvar} while the apartment size is the {feature-var} and we try to find out 
-the relationship between them in order to make further predictions. Our 
-imaginary dataset consists of three data points:
+apartment size and monthly rent in a city. Our imaginary dataset consists of 
+three data points:
 
 |===
 | Size (m2) | Monthly rent 
@@ -19,9 +17,9 @@ imaginary dataset consists of three data points:
 | 63        | 2300
 |===
 
-After the model determines the relationship between the {feature-vars} (apartment size) and the 
-{depvar} (rent), it can make predictions such as the monthly rent of a hundred square meter-size 
-apartment.
+After the model determines the relationship between the {feature-vars} 
+(apartment size) and the {depvar} (rent), it can make predictions such as the 
+monthly rent of a hundred square meter-size apartment.
 
 This is a simple example. Usually {regression} problems are multi-dimensional, 
 so the relationships that {reganalysis} tries to find are between multiple 
@@ -79,27 +77,27 @@ that we use in the {stack} is a type of boosting called extreme gradient boost
 === Measuring model performance
 
 You can measure how well the model has performed on your training dataset by 
-using the `regression` evaluation type of the {ref}/evaluate-dfanalytics.html[evaluate {dfanalytics} API]. The 
-mean squared error (MSE) value that the evaluation may provide you on the training 
-dataset is the _training error_. Training the {regression} model means finding 
-the combination of model parameters that produces the lowest possible training 
+using the `regression` evaluation type of the 
+{ref}/evaluate-dfanalytics.html[evaluate {dfanalytics} API]. The mean squared 
+error (MSE) value that the evaluation provides you on the training dataset is 
+the _training error_. Training the {regression} model means finding the 
+combination of model parameters that produces the lowest possible training 
 error.
 
 Another crucial measurement is how well your model performs on unseen 
-data points. To assess 
-how well the trained model will perform on data it has never seen before, you must set aside a 
-proportion of the training dataset for testing. This split 
-of the dataset is the testing dataset. Once the model has been trained and found 
-out the required coefficients, you can let the model predict the value of the 
-data points it has never seen before and compare the prediction to the actual 
-value. This test provides an estimate of a quantity known as the _model 
-generalization error_.
+data points. To assess how well the trained model will perform on data it has 
+never seen before, you must set aside a proportion of the training dataset for 
+testing. This split of the dataset is the testing dataset. Once the model has 
+been trained and found out the required coefficients, you can let the model 
+predict the value of the data points it has never seen before and compare the 
+prediction to the actual value. This test provides an estimate of a quantity 
+known as the _model generalization error_.
 
 Two concepts describe how well the {regression} algorithm was able to learn the 
 relationship between the {feature-vars} and the {depvar}. _Underfitting_ is when 
-the model cannot capture the complexity of the dataset. _Overfitting_ is when the 
-model has trained so specifically to a dataset that it is capturing all the 
+the model cannot capture the complexity of the dataset. _Overfitting_ is when 
+the model has trained so specifically to a dataset that it is capturing all the 
 details and cannot generalize well enough. A model that overfits the data has a 
-low MSE value on the training dataset and a high MSE value 
-on the testing dataset. For more information about the evaluation metrics, see 
+low MSE value on the training dataset and a high MSE value on the testing 
+dataset. For more information about the evaluation metrics, see 
 <<ml-dfanalytics-regression-evaluation>>.

--- a/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
@@ -23,7 +23,7 @@ After the model determines the relationship between the {feature-vars} (apartmen
 {depvar} (rent), it can make predictions such as the monthly rent of a hundred square meter-size 
 apartment.
 
-This is a simple example, usually {regression} problems are multi-dimensional, 
+This is a simple example. Usually {regression} problems are multi-dimensional, 
 so the relationships that {reganalysis} tries to find are between multiple 
 {feature-vars} and the {depvar}. To extend our example, a more complex 
 {reganalysis} could take into account further {feature-vars} like the location 

--- a/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
@@ -93,7 +93,7 @@ of the dataset is the testing dataset. Once the model has been trained and found
 out the required coefficients, you can let the model predict the value of the 
 data points it has never seen before and compare the prediction to the actual 
 value. This test provides an estimate of a quantity known as the _model 
-generalization error*.
+generalization error_.
 
 Two concepts describe how well the {regression} algorithm was able to learn the 
 relationship between the {feature-vars} and the {depvar}. Underfitting is when 

--- a/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
@@ -18,7 +18,7 @@ three data points:
 |===
 
 After the model determines the relationship between the
-(apartment size) and the {depvar} (rent), it can make predictions such as the 
+apartment size and the rent, it can make predictions such as the 
 monthly rent of a hundred square meter-size apartment.
 
 This is a simple example. Usually {regression} problems are multi-dimensional, 

--- a/docs/en/stack/ml/df-analytics/evaluatedf-api.asciidoc
+++ b/docs/en/stack/ml/df-analytics/evaluatedf-api.asciidoc
@@ -129,7 +129,7 @@ This value is called mean squared error.
 
 Another evaluation metrics for {reganalysis} is R-squared (R^2^). It represents 
 the goodness of fit and measures how much of the variation in the data the 
-predictions are able to explain. The value of R^2^ ranges from 0 to 1, where 1 
+predictions are able to explain. The value of R^2^ are less than or equal to 1, where 1 
 indicates that the predictions and true values are equal. A value of 0 is 
 obtained when all the predictions are set to the mean of the true values. A 
 value of 0.5 for R^2^ would indicate that, the predictions are 1 - 0.5^(1/2)^ 

--- a/docs/en/stack/ml/df-analytics/evaluatedf-api.asciidoc
+++ b/docs/en/stack/ml/df-analytics/evaluatedf-api.asciidoc
@@ -120,7 +120,7 @@ performance:
 The API provides a MSE by computing the 
 average squared sum of the difference between the true value and the value that 
 the {regression} model predicted. (Avg (predicted value-actual value)^2^).
-This value is called mean squared error.
+You can use the MSE to measure how well the {reganalysis} model is performing.
 
 
 [discrete]

--- a/docs/en/stack/ml/df-analytics/evaluatedf-api.asciidoc
+++ b/docs/en/stack/ml/df-analytics/evaluatedf-api.asciidoc
@@ -127,7 +127,10 @@ This value is called mean squared error.
 [[ml-dfanalytics-r-sqared]]
 ==== R-squared
 
-Another evaluation metrics for {reganalysis} is R-squared (R^2^). It measures 
-the perfection of the fit of the predicted values. The value of R^2^ ranges from 
-0 to 1, where 1 is the perfect fit. For example, if the R^2^is 0.50, then 50% of 
-the values are predicted correctly by the model.
+Another evaluation metrics for {reganalysis} is R-squared (R^2^). It represents 
+the goodness of fit and measures how much of the variation in the data the 
+predictions are able to explain. The value of R^2^ ranges from 0 to 1, where 1 
+indicates that the predictions and true values are equal. A value of 0 is 
+obtained when all the predictions are set to the mean of the true values. A 
+value of 0.5 for R^2^ would indicate that, the predictions are 1 - 0.5^(1/2)^ 
+(about 30%) closer to true values than their mean.

--- a/docs/en/stack/ml/df-analytics/evaluatedf-api.asciidoc
+++ b/docs/en/stack/ml/df-analytics/evaluatedf-api.asciidoc
@@ -117,7 +117,7 @@ performance:
 [[ml-dfanalytics-mse]]
 ==== Mean squared error
 
-You can measure how well the {reganalysis} model is performing by computing the 
+The API provides a MSE by computing the 
 average squared sum of the difference between the true value and the value that 
 the {regression} model predicted. (Avg (predicted value-actual value)^2^).
 This value is called mean squared error.

--- a/docs/en/stack/ml/df-analytics/evaluatedf-api.asciidoc
+++ b/docs/en/stack/ml/df-analytics/evaluatedf-api.asciidoc
@@ -120,7 +120,7 @@ performance:
 You can measure how well the {reganalysis} model is performing by computing the 
 average squared sum of the difference between the true value and the value that 
 the {regression} model predicted. (Avg (predicted value-actual value)^2^).
-This value is called mean squared error (MSE).
+This value is called mean squared error.
 
 
 [discrete]

--- a/docs/en/stack/ml/df-analytics/evaluatedf-api.asciidoc
+++ b/docs/en/stack/ml/df-analytics/evaluatedf-api.asciidoc
@@ -103,7 +103,7 @@ the algorithm performance by using these values.
 
 [discrete]
 [[ml-dfanalytics-regression-evaluation]]
-=== {regression} evaluation
+=== {regression-cap} evaluation
 
 This evaluation type is suitable for evaluating {regression} models. The 
 {regression} evaluation type offers the following metrics to evaluate the model 

--- a/docs/en/stack/ml/df-analytics/evaluatedf-api.asciidoc
+++ b/docs/en/stack/ml/df-analytics/evaluatedf-api.asciidoc
@@ -99,3 +99,35 @@ closer to 1, the better the algorithm performance.
 The {evaluatedf-api} can return the false positive rate (`fpr`) and the true 
 positive rate (`tpr`) at the different threshold levels, so you can visualize 
 the algorithm performance by using these values.
+
+
+[discrete]
+[[ml-dfanalytics-regression-evaluation]]
+=== {regression} evaluation
+
+This evaluation type is suitable for evaluating {regression} models. The 
+{regression} evaluation type offers the following metrics to evaluate the model 
+performance:
+
+* Mean squared error (MSE)
+* R-squared (R^2^)
+
+
+[discrete]
+[ml-dfanalytics-mse]
+==== Mean squared error (MSE)
+
+You can measure how well the {reganalysis} model is performing by computing the 
+average squared sum of the difference between the true value and the value that 
+the {regression} model predicted. (Avg (predicted value-actual value)^2^).
+This value is called mean squared error (MSE).
+
+
+[discrete]
+[ml-dfanalytics-r-sqared]
+==== R-squared
+
+Another evaluation metrics for {reganalysis} is R-squared (R^2^). It measures 
+the perfection of the fit of the predicted values. The value of R^2^ ranges from 
+0 to 1, where 1 is the perfect fit. For example, if the R^2^is 0.50, then 50% of 
+the values are predicted correctly by the model.

--- a/docs/en/stack/ml/df-analytics/evaluatedf-api.asciidoc
+++ b/docs/en/stack/ml/df-analytics/evaluatedf-api.asciidoc
@@ -115,7 +115,7 @@ performance:
 
 [discrete]
 [[ml-dfanalytics-mse]]
-==== Mean squared error (MSE)
+==== Mean squared error
 
 You can measure how well the {reganalysis} model is performing by computing the 
 average squared sum of the difference between the true value and the value that 

--- a/docs/en/stack/ml/df-analytics/evaluatedf-api.asciidoc
+++ b/docs/en/stack/ml/df-analytics/evaluatedf-api.asciidoc
@@ -114,7 +114,7 @@ performance:
 
 
 [discrete]
-[ml-dfanalytics-mse]
+[[ml-dfanalytics-mse]]
 ==== Mean squared error (MSE)
 
 You can measure how well the {reganalysis} model is performing by computing the 
@@ -124,7 +124,7 @@ This value is called mean squared error (MSE).
 
 
 [discrete]
-[ml-dfanalytics-r-sqared]
+[[ml-dfanalytics-r-sqared]]
 ==== R-squared
 
 Another evaluation metrics for {reganalysis} is R-squared (R^2^). It measures 

--- a/docs/en/stack/ml/df-analytics/index.asciidoc
+++ b/docs/en/stack/ml/df-analytics/index.asciidoc
@@ -19,6 +19,7 @@ dimensional "tabular" data structure, in other words a
 {dataframes} which can be used as the source for {dfanalytics}.
 
 * <<dfa-outlier-detection>>
+* <<dfa-regression>>
 * <<ml-dfanalytics-evaluate>>
 * <<ml-dfanalytics-apis>>
 * <<ml-dfa-limitations>>
@@ -26,6 +27,7 @@ dimensional "tabular" data structure, in other words a
 --
 
 include::dfa-outlierdetection.asciidoc[]
+include::dfa-regression.asciidoc[]
 include::evaluatedf-api.asciidoc[]
 include::api-quickref.asciidoc[]
 include::dfanalytics-limitations.asciidoc[]


### PR DESCRIPTION
This PR adds the conceptual overview of regression and the related evaluation type to the documentation. Also amends the index.asciidoc file to contain the new additions.

Depends on https://github.com/elastic/docs/pull/1124 because of the used attributes.

Related issue: https://github.com/elastic/ml-team/issues/203