### PR TITLE
Updates location of version attributes for Stack Overview

### DIFF
--- a/docs/en/stack/index.asciidoc
+++ b/docs/en/stack/index.asciidoc
@@ -1,7 +1,6 @@
 = Elastic Stack Overview
 
 :doctype:           book
-:source_branch:     master
 :forum:             https://discuss.elastic.co/c/x-pack
 :security-forum:    https://discuss.elastic.co/c/shield
 :watcher-forum:     https://discuss.elastic.co/c/watcher

--- a/docs/en/stack/index.asciidoc
+++ b/docs/en/stack/index.asciidoc
@@ -1,7 +1,7 @@
 = Elastic Stack Overview
 
 :doctype:           book
-
+:source_branch:     master
 :forum:             https://discuss.elastic.co/c/x-pack
 :security-forum:    https://discuss.elastic.co/c/shield
 :watcher-forum:     https://discuss.elastic.co/c/watcher
@@ -16,7 +16,7 @@
 :es-repo-dir:       {docdir}/../../../../elasticsearch/docs/reference
 :stack-repo-dir:    {docdir}
 :beats-repo-dir:    {docdir}/../../../../beats/libbeat/docs
-include::{asciidoc-dir}/../../shared/versions.asciidoc[]
+include::{asciidoc-dir}/../../shared/versions/stack/{source_branch}.asciidoc[]
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
 include::introduction.asciidoc[]


### PR DESCRIPTION
Depends on https://github.com/elastic/docs/pull/1148

This PR changes the location of the shared version attributes (so that updates are not required every time there's a new branch).

NOTE: The source_branch attribute definition should be removed from this PR after https://github.com/elastic/docs/pull/1147 is merged.