### PR TITLE
Remove incorrect note for Kerberos support in Kibana

### DIFF
--- a/docs/en/stack/security/authentication/kerberos-realm.asciidoc
+++ b/docs/en/stack/security/authentication/kerberos-realm.asciidoc
@@ -5,8 +5,7 @@
 You can configure the {stack} {security-features} to support Kerberos V5
 authentication, an industry standard protocol to authenticate users in {es}.
 
-NOTE: You cannot use the Kerberos realm to authenticate users in {kib}
-and on the transport network layer.
+NOTE: You cannot use the Kerberos realm to authenticate on the transport network layer.
 
 To authenticate users with Kerberos, you need to
 {ref}/configuring-kerberos-realm.html[configure a Kerberos realm] and


### PR DESCRIPTION
Now that we added support for Kerberos in 7.3, this commit
removes the incorrect note from the docs that it is not supported.