### PR TITLE
Updates location of version attributes for Getting started with Stack

### DIFF
--- a/docs/en/getting-started/index.asciidoc
+++ b/docs/en/getting-started/index.asciidoc
@@ -14,7 +14,7 @@
 :kib-repo-dir:      {docdir}/../../../../kibana/docs
 :xes-repo-dir:      {docdir}/../../../../elasticsearch/x-pack/docs/en
 
-include::{asciidoc-dir}/../../shared/versions.asciidoc[]
+include::{asciidoc-dir}/../../shared/versions/stack/{source_branch}.asciidoc[]
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
 include::get-started-stack.asciidoc[]


### PR DESCRIPTION
Related to https://github.com/elastic/docs/issues/804
Depends on elastic/docs#1148 and elastic/docs#1147

This PR changes the location of the shared version attributes (so that updates are not required every time there's a new branch).
