### PR TITLE
Updates location of version attribute for multiple books

### DIFF
--- a/docs/en/gke-on-prem/index.asciidoc
+++ b/docs/en/gke-on-prem/index.asciidoc
@@ -1,4 +1,4 @@
-include::{asciidoc-dir}/../../shared/versions.asciidoc[]
+include::{asciidoc-dir}/../../shared/versions/stack/{source_branch}.asciidoc[]
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
 :gke: https://cloud.google.com/gke-on-prem/

--- a/docs/en/glossary/index.asciidoc
+++ b/docs/en/glossary/index.asciidoc
@@ -6,7 +6,7 @@
 :logstash-terms:       true
 :xpack-terms:          true
 
-include::{asciidoc-dir}/../../shared/versions.asciidoc[]
+include::{asciidoc-dir}/../../shared/versions/stack/{source_branch}.asciidoc[]
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
 include::intro.asciidoc[]

--- a/docs/en/infraops/index.asciidoc
+++ b/docs/en/infraops/index.asciidoc
@@ -5,7 +5,7 @@
 
 = Infrastructure Monitoring Guide
 
-include::{asciidoc-dir}/../../shared/versions.asciidoc[]
+include::{asciidoc-dir}/../../shared/versions/stack/{source_branch}.asciidoc[]
 
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 

--- a/docs/en/siem/index.asciidoc
+++ b/docs/en/siem/index.asciidoc
@@ -6,7 +6,7 @@
 
 = SIEM Guide (Beta)
 
-include::{asciidoc-dir}/../../shared/versions.asciidoc[]
+include::{asciidoc-dir}/../../shared/versions/stack/{source_branch}.asciidoc[]
 
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 


### PR DESCRIPTION
Related to elastic/docs#804
Depends on elastic/docs#1148 and elastic/docs#1147

This PR changes the location of the shared version attributes (so that updates are not required every time there's a new branch).