### PR TITLE
[DOCS] Add index alias definition to Stack Docs glossary

### DIFF
--- a/docs/en/glossary/glossary.asciidoc
+++ b/docs/en/glossary/glossary.asciidoc
@@ -381,6 +381,13 @@ An index is a logical namespace which maps to one or more
 +
 //Source: Elasticsearch
 endif::elasticsearch-terms[]
+ifdef::elasticsearch-terms[]
+
+[[glossary-index-alias]] index alias ::
+
+include::{es-repo-dir}/glossary.asciidoc[tag=index-alias-def]
+
+endif::elasticsearch-terms[]
 ifdef::logstash-terms[]
 
 [[glossary-indexer]] indexer ::

--- a/docs/en/glossary/index.asciidoc
+++ b/docs/en/glossary/index.asciidoc
@@ -9,5 +9,7 @@
 include::{asciidoc-dir}/../../shared/versions.asciidoc[]
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
+:es-repo-dir:          {docdir}/../../../../elasticsearch/docs/reference
+
 include::intro.asciidoc[]
 include::glossary.asciidoc[]


### PR DESCRIPTION
Reuses the [index alias](https://www.elastic.co/guide/en/elasticsearch/reference/master/glossary.html#glossary-index-alias) definition from the [Elasticsearch Reference Guide's glossary](https://www.elastic.co/guide/en/elasticsearch/reference/master/glossary.html).

If successful, we can reuse this pattern for other ES glossary items.

Dependent on elastic/docs#1164. CI will fail until that PR is merged.