### PR TITLE
[DOCS] Adds data frame analytics field type and document limitation

### DIFF
--- a/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
@@ -68,7 +68,7 @@ values will be skipped during the analysis.
 don't support missing values (see also <<dfa-missing-fields-limitations>>), 
 therefore fields that have data types other than numeric or boolean are ignored. Documents where 
 included fields contain missing values, null values, or an array are also
-ignored. Therefore a `dest` index may contain documents that don't have an 
+ignored. Therefore a destination index may contain documents that don't have an 
 {olscore}. These documents are still reindexed from `source` to `dest`, but they 
 are not included in the {oldetection} analysis and therefore no {olscore} is 
 computed.

--- a/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
@@ -77,7 +77,7 @@ computed.
 ==== {regression-cap}
 
 {regression-cap} supports fields that are numeric, boolean, text, keyword and ip 
-and is tolerant of missing values. Fields that are supported will be included in 
+. It is also tolerant of missing values. Fields that are supported are included in 
 the analysis, other fields will be ignored. Documents where included fields 
 contain an array will also be ignored. Documents in `dest` that don't contain a 
 results field will not be included in the {reganalysis}.

--- a/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
@@ -58,26 +58,24 @@ If there are missing values in feature fields (fields that are subjects of the
 values will be skipped during the analysis.
 
 [float]
-[[dfa-field-type-docs-limitations]]
-=== {dfanalytics-cap} field type and document limitation
-
-[float]
-==== {oldetection-cap}
+[[dfa-od-field-type-docs-limitations]]
+==== {oldetection-cap} field type and document limitation
 
 {oldetection-cap} requires numeric or boolean data to analyze. The algorithms 
 don't support missing values (see also <<dfa-missing-fields-limitations>>), 
-therefore fields that have data types other than numeric or boolean are ignored. Documents where 
-included fields contain missing values, null values, or an array are also
-ignored. Therefore a destination index may contain documents that don't have an 
-{olscore}. These documents are still reindexed from the source index to the destination index, but they 
-are not included in the {oldetection} analysis and therefore no {olscore} is 
-computed.
+therefore fields that have data types other than numeric or boolean are ignored. 
+Documents where included fields contain missing values, null values, or an array 
+are also ignored. Therefore a destination index may contain documents that don't 
+have an {olscore}. These documents are still reindexed from the source index to 
+the destination index, but they are not included in the {oldetection} analysis 
+and therefore no {olscore} is computed.
 
 [float]
-==== {regression-cap}
+[[dfa-regression-field-type-docs-limitations]]
+==== {regression-cap} field type and document limitation
 
-{regression-cap} supports fields that are numeric, boolean, text, keyword and ip 
-. It is also tolerant of missing values. Fields that are supported are included in 
-the analysis, other fields are ignored. Documents where included fields 
-contain an array are also ignored. Documents in the destination index that don't contain a 
-results field will not be included in the {reganalysis}.
+{regression-cap} supports fields that are numeric, boolean, text, keyword and 
+ip. It is also tolerant of missing values. Fields that are supported are 
+included in the analysis, other fields are ignored. Documents where included 
+fields contain an array are also ignored. Documents in the destination index 
+that don't contain a results field are not included in the {reganalysis}.

--- a/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
@@ -67,7 +67,7 @@ values will be skipped during the analysis.
 {oldetection-cap} requires numeric or boolean data to analyze. The algorithms 
 don't support missing values (see also <<dfa-missing-fields-limitations>>), 
 therefore fields that have data types other than numeric or boolean are ignored. Documents where 
-included fields contain missing values, null values, or an array also will be 
+included fields contain missing values, null values, or an array are also
 ignored. Therefore a `dest` index may contain documents that don't have an 
 {olscore}. These documents are still reindexed from `source` to `dest`, but they 
 are not included in the {oldetection} analysis and therefore no {olscore} is 

--- a/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
@@ -8,14 +8,14 @@
 
 experimental[]
 
-The following limitations and known problems apply to the 7.3 release of 
+The following limitations and known problems apply to the {version} release of 
 the Elastic {dfanalytics} feature:
 
 [float]
 [[dfa-ccs-limitations]]
 === {ccs-cap} limitation
 
-{ccs-cap} is not supported in 7.3 for {dfanalytics}.
+{ccs-cap} is not supported for {dfanalytics}.
 
 [float]
 [[dfa-deletion-limitations]]
@@ -56,3 +56,28 @@ values will be skipped entirely.
 If there are missing values in feature fields (fields that are subjects of the 
 {dfanalytics}), then the document that contains the fields with the missing 
 values will be skipped during the analysis.
+
+[float]
+[[dfa-field-type-docs-limitations]]
+=== {dfanalytics-cap} field type and document limitation
+
+[float]
+==== {oldetection-cap}
+
+{oldetection-cap} requires numeric or boolean data to analyze. The algorithms 
+don't support missing values (see also <<dfa-missing-fields-limitations>>), 
+therefore fields other than numeric or boolean will be ignored. Documents where 
+included fields contain missing values, null values, or an array also will be 
+ignored. Therefore a `dest` index may contain documents that don't have an 
+{olscore}. These documents are still reindexed from `source` to `dest`, but they 
+are not included in the {oldetection} analysis and therefore no {olscore} is 
+computed.
+
+[float]
+==== {regression-cap}
+
+{regression-cap} supports fields that are numeric, boolean, text, keyword and ip 
+and is tolerant of missing values. Fields that are supported will be included in 
+the analysis, other fields will be ignored. Documents where included fields 
+contain an array will also be ignored. Documents in `dest` that don't contain a 
+results field will not be included in the {reganalysis}.

--- a/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
@@ -69,7 +69,7 @@ don't support missing values (see also <<dfa-missing-fields-limitations>>),
 therefore fields that have data types other than numeric or boolean are ignored. Documents where 
 included fields contain missing values, null values, or an array are also
 ignored. Therefore a destination index may contain documents that don't have an 
-{olscore}. These documents are still reindexed from `source` to `dest`, but they 
+{olscore}. These documents are still reindexed from the source index to the destination index, but they 
 are not included in the {oldetection} analysis and therefore no {olscore} is 
 computed.
 

--- a/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
@@ -79,5 +79,5 @@ computed.
 {regression-cap} supports fields that are numeric, boolean, text, keyword and ip 
 . It is also tolerant of missing values. Fields that are supported are included in 
 the analysis, other fields are ignored. Documents where included fields 
-contain an array will also be ignored. Documents in `dest` that don't contain a 
+contain an array are also ignored. Documents in the destination index that don't contain a 
 results field will not be included in the {reganalysis}.

--- a/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
@@ -78,6 +78,6 @@ computed.
 
 {regression-cap} supports fields that are numeric, boolean, text, keyword and ip 
 . It is also tolerant of missing values. Fields that are supported are included in 
-the analysis, other fields will be ignored. Documents where included fields 
+the analysis, other fields are ignored. Documents where included fields 
 contain an array will also be ignored. Documents in `dest` that don't contain a 
 results field will not be included in the {reganalysis}.

--- a/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
@@ -66,7 +66,7 @@ values will be skipped during the analysis.
 
 {oldetection-cap} requires numeric or boolean data to analyze. The algorithms 
 don't support missing values (see also <<dfa-missing-fields-limitations>>), 
-therefore fields other than numeric or boolean will be ignored. Documents where 
+therefore fields that have data types other than numeric or boolean are ignored. Documents where 
 included fields contain missing values, null values, or an array also will be 
 ignored. Therefore a `dest` index may contain documents that don't have an 
 {olscore}. These documents are still reindexed from `source` to `dest`, but they 


### PR DESCRIPTION
This PR expands the limitation section with a new item about unsupported field types and documents.

Related issue: https://github.com/elastic/ml-team/issues/187#issuecomment-528351782