### PR TITLE
Use shared versions file from elastic/docs for install-upgrade guide

### DIFF
--- a/docs/en/install-upgrade/index.asciidoc
+++ b/docs/en/install-upgrade/index.asciidoc
@@ -8,8 +8,8 @@
 :kib-repo-dir:       {docdir}/../../../../kibana/docs
 :ls-repo-dir:        {docdir}/../../../../logstash/docs
 
+include::{asciidoc-dir}/../../shared/versions/stack/{source_branch}.asciidoc[]
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
-include::{es-repo-dir}/Versions.asciidoc[]
 
 include::overview.asciidoc[]
 


### PR DESCRIPTION
This PR changes the location of the version attributes from the ES repo to a shared file in elastic/docs.

Unblocks elastic/elasticsearch#46719

Related to https://github.com/elastic/docs/issues/804
