### PR TITLE
[DOCS] Reuse glossary items from ES glossary

### DIFF
--- a/docs/en/glossary/glossary.asciidoc
+++ b/docs/en/glossary/glossary.asciidoc
@@ -36,23 +36,11 @@ endif::cloud-terms[]
 ifdef::elasticsearch-terms[]
 
 [[glossary-analysis]] analysis ::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=analysis-def]
+--
 
-Analysis is the process of converting <<glossary-text,full text>> to
-<<glossary-term,terms>>. Depending on which analyzer is used, these phrases:
-`FOO BAR`, `Foo-Bar`, `foo,bar` will probably all result in the
-terms `foo` and `bar`. These terms are what is actually stored in
-the index.
-+
-A full text query (not a <<glossary-term,term>> query) for `FoO:bAR` will
-also be analyzed to the terms `foo`,`bar` and will thus match the
-terms stored in the index.
-+
-It is this process of analysis (both at index time and at search time)
-that allows {es} to perform full text queries.
-+
-Also see <<glossary-text,text>> and <<glossary-term,term>>.
-+
-//Source: Elasticsearch
 endif::elasticsearch-terms[]
 ifdef::cloud-terms[]
 
@@ -112,13 +100,11 @@ endif::cloud-terms[]
 ifdef::elasticsearch-terms,cloud-terms[]
 
 [[glossary-cluster]] cluster ::
-
-A cluster consists of one or more <<glossary-node,nodes>> which share the
-same cluster name. Each cluster has a single master node which is
-chosen automatically by the cluster and which can be replaced if the
-current master node fails.
 +
-//Source: Elasticsearch
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=cluster-def]
+--
+
 endif::elasticsearch-terms,cloud-terms[]
 ifdef::logstash-terms[]
 
@@ -179,19 +165,19 @@ endif::cloud-terms[]
 ifdef::xpack-terms[]
 
 [[glossary-ccr]] {ccr} (CCR)::
-
-The {ccr} feature enables you to replicate indices in remote clusters to your
-local cluster. For more information, see {stack-ov}/xpack-ccr.html[{ccr-cap}].  
 +
-//Source: X-Pack
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=ccr-def]
+--
+
 endif::xpack-terms[]
 ifdef::elasticsearch-terms[]
 [[glossary-ccs]] {ccs} (CCS)::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=ccs-def]
+--
 
-The {ccs} feature enables any node to act as a federated client across
-multiple clusters. See {ref}/modules-cross-cluster-search.html[{ccs-cap}].   
-
-//Source: Elasticsearch
 endif::elasticsearch-terms[]
 ifdef::xpack-terms[]
 
@@ -227,21 +213,11 @@ endif::cloud-terms[]
 ifdef::elasticsearch-terms[]
 
 [[glossary-document]] document ::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=document-def]
+--
 
-A document is a JSON document which is stored in {es}. It is
-like a row in a table in a relational database. Each document is
-stored in an <<glossary-index,index>> and has a <<glossary-type,type>> and an
-<<glossary-id,id>>.
-+
-A document is a JSON object (also known in other languages as a hash /
-hashmap / associative array) which contains zero or more
-<<glossary-field,fields>>, or key-value pairs.
-+
-The original JSON document that is indexed will be stored in the
-<<glossary-source_field,`_source` field>>, which is returned by default when
-getting or searching for a document.
-+
-//Source: Elasticsearch
 endif::elasticsearch-terms[]
 
 [[glossary-ecs]] Elastic Common Schema (ECS) ::
@@ -264,30 +240,21 @@ endif::logstash-terms[]
 ifdef::elasticsearch-terms,logstash-terms[]
 
 [[glossary-field]] field ::
-endif::elasticsearch-terms,logstash-terms[]
-ifdef::elasticsearch-terms[]
-A <<glossary-document,document>> contains a list of fields, or key-value
-pairs. The value can be a simple (scalar) value (for example, a string,
-integer, date), or a nested structure like an array or an object. A field is
-similar to a column in a table in a relational database.
 +
-The <<glossary-mapping,mapping>> for each field has a field _type_ (not to
-be confused with document <<glossary-type,type>>) which indicates the type
-of data that can be stored in that field, eg `integer`, `string`,
-`object`. The mapping also allows you to define (amongst other things)
-how the value for a field should be analyzed.
-+
-//Source: Elasticsearch
-+
-endif::elasticsearch-terms[]
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=field-def]
+
+
+ifdef::elasticsearch-terms,logstash-terms[]
 ifdef::logstash-terms[]
 In Logstash, this term refers to an <<glossary-event,event>> property. For
 example, each event in an apache access log has properties, such as a status
 code (200, 404), request path ("/", "index.html"), HTTP verb (GET, POST), client
 IP address, and so on. Logstash uses the term "fields" to refer to these
 properties.
-+
+
 //Source: Logstash
+--
 endif::logstash-terms[]
 ifdef::logstash-terms[]
 
@@ -305,16 +272,11 @@ endif::logstash-terms[]
 ifdef::elasticsearch-terms[]
 
 [[glossary-filter]] filter ::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=filter-def]
+--
 
-A filter is a non-scoring <<glossary-query,query>>, meaning that it does not
-score documents. It is only concerned about answering the question - "Does this
-document match?". The answer is always a simple, binary yes or no. This kind of
-query is said to be made in a {ref}/query-filter-context.html[filter context], hence it
-is called a filter. Filters are simple checks for set inclusion or exclusion. In
-most cases, the goal of filtering is to reduce the number of documents that have
-to be examined.
-
-//Source: Elasticsearch
 endif::elasticsearch-terms[]
 ifdef::logstash-terms[]
 
@@ -331,11 +293,11 @@ grok, mutate, drop, clone, and geoip. Filter stages are optional.
 endif::logstash-terms[]
 ifdef::xpack-terms[]
 [[glossary-follower-index]] follower index ::  
-  
-Follower indices are the target indices for <<glossary-ccr,{ccr}>>. They exist
-in your local cluster and replicate <<glossary-leader-index,leader indices>>.
 +
-//Source: X-Pack
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=follower-index-def]
+--
+
 endif::xpack-terms[]
 ifdef::logstash-terms[]
 
@@ -359,33 +321,29 @@ period of time.
 endif::logstash-terms[]
 ifdef::elasticsearch-terms[]
 
-[[glossary-id]] id ::
-
-The ID of a <<glossary-document,document>> identifies a document. The
-`index/id` of a document must be unique. If no ID is provided,
-then it will be auto-generated. (Also see <<glossary-routing,routing>>).
+[[glossary-id]] ID ::
 +
-//Source: Elasticsearch
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=id-def]
+--
+
 endif::elasticsearch-terms[]
 ifdef::elasticsearch-terms[]
 
 [[glossary-index]] index ::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=index-def]
+--
 
-An index is like a _table_ in a relational database. It has a
-<<glossary-mapping,mapping>> which contains a <<glossary-type,type>>,
-which contains the <<glossary-field,fields>> in the index.
-+
-An index is a logical namespace which maps to one or more
-<<glossary-primary-shard,primary shards>> and can have zero or more
-<<glossary-replica-shard,replica shards>>.
-+
-//Source: Elasticsearch
 endif::elasticsearch-terms[]
 ifdef::elasticsearch-terms[]
 
 [[glossary-index-alias]] index alias ::
-
++
+--
 include::{es-repo-dir}/glossary.asciidoc[tag=index-alias-def]
+--
 
 endif::elasticsearch-terms[]
 ifdef::logstash-terms[]
@@ -420,11 +378,11 @@ necessary to perform an analytics task. There are two types: {anomaly-jobs} and
 endif::xpack-terms[]
 ifdef::xpack-terms[]
 [[glossary-leader-index]] leader index ::  
-    
-Leader indices are the source indices for <<glossary-ccr,{ccr}>>. They exist
-on remote clusters and are replicated to 
-<<glossary-follower-index,follower indices>>.
-//Source: X-Pack
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=leader-index-def]
+--
+
 endif::xpack-terms[]
 ifdef::xpack-terms[]
 
@@ -441,15 +399,11 @@ endif::xpack-terms[]
 ifdef::elasticsearch-terms[]
 
 [[glossary-mapping]] mapping ::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=mapping-def]
+--
 
-A mapping is like a _schema definition_ in a relational database. Each
-<<glossary-index,index>> has a mapping, which defines a <<glossary-type,type>>,
-plus a number of index-wide settings.
-+
-A mapping can either be defined explicitly, or it will be generated
-automatically when a document is indexed.
-+
-//Source: Elasticsearch
 endif::elasticsearch-terms[]
 ifdef::cloud-terms[]
 
@@ -462,14 +416,6 @@ Also see <<glossary-node,node>>.
 +
 //Source: Cloud
 endif::cloud-terms[]
-ifdef::elasticsearch-terms[]
-
-[[glossary-merge]] merge ::
-
-The combining of Lucene segments, either automatically in the background or initiated using force merge.
-+
-//Source: Elasticsearch
-endif::elasticsearch-terms[]
 ifdef::logstash-terms[]
 
 [[glossary-message-broker]] message broker ::
@@ -484,15 +430,11 @@ endif::logstash-terms[]
 ifdef::elasticsearch-terms,cloud-terms[]
 
 [[glossary-node]] node ::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=node-def]
+--
 
-A node is a running instance of {es} or {kib} which belongs to a
-<<glossary-cluster,cluster>>. Multiple nodes can be started on a single server
-for testing purposes, but usually you should have one node per server.
-+
-At startup, a node will use unicast to discover an existing cluster with
-the same cluster name and will try to join that cluster.
-+
-//Source: Elasticsearch
 endif::elasticsearch-terms,cloud-terms[]
 ifdef::logstash-terms[]
 
@@ -561,21 +503,11 @@ endif::logstash-terms[]
 ifdef::elasticsearch-terms[]
 
 [[glossary-primary-shard]] primary shard ::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=primary-shard-def]
+--
 
-Each document is stored in a single primary <<glossary-shard,shard>>. When
-you index a document, it is indexed first on the primary shard, then
-on all <<glossary-replica-shard,replicas>> of the primary shard.
-+
-By default, an <<glossary-index,index>> has 5 primary shards. You can
-specify fewer or more primary shards to scale the number of
-<<glossary-document,documents>> that your index can handle.
-+
-You cannot change the number of primary shards in an index, once the
-index is created.
-+
-See also <<glossary-routing,routing>>.
-+
-//Source: Elasticsearch
 endif::elasticsearch-terms[]
 ifdef::cloud-terms[]
 
@@ -589,55 +521,38 @@ nodes handling the user requests.
 endif::cloud-terms[]
 ifdef::elasticsearch-terms[]
 [[glossary-query]] query ::
-
-A request for information from {es}. You can think of a query as a question,
-written in a way {es} understands. A search consists of one or more queries
-combined.
 +
-There are two types of queries: _scoring queries_ and _filters_. For more
-information about query types, see {ref}/query-filter-context.html[Query and filter context].
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=query-def]
+--
 
-//Source: Elasticsearch
 endif::elasticsearch-terms[]
 ifdef::elasticsearch-terms[]
 
 [[glossary-recovery]] recovery ::
-The process of syncing a shard copy from a source shard. Upon completion, the recovery process makes the shard copy available for queries.
 +
-Recovery automatically occurs anytime a shard moves to a different node in the same cluster, including:
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=recovery-def]
+--
 
-* Node startup
-* Node failure
-* Index shard replication
-* Snapshot restoration
-+
-//Source: Elasticsearch
 endif::elasticsearch-terms[]
 ifdef::elasticsearch-terms[]
 
 [[glossary-reindex]] reindex ::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=reindex-def]
+--
 
-To cycle through some or all documents in one or more indices, re-writing them into the same or new index in a local or remote cluster. This is most commonly done to update mappings, or to upgrade Elasticsearch between two incompatible index versions.
-//Source: Elasticsearch
 endif::elasticsearch-terms[]
 ifdef::elasticsearch-terms[]
 
 [[glossary-replica-shard]] replica shard ::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=replica-shard-def]
+--
 
-Each <<glossary-primary-shard,primary shard>> can have zero or more
-replicas. A replica is a copy of the primary shard, and has two
-purposes:
-+
-1.  increase failover: a replica shard can be promoted to a primary
-shard if the primary fails
-2.  increase performance: get and search requests can be handled by
-primary or replica shards.
-+
-By default, each primary shard has one replica, but the number of
-replicas can be changed dynamically on an existing index. A replica
-shard will never be started on the same node as its primary shard.
-+
-//Source: Elasticsearch
 endif::elasticsearch-terms[]
 ifdef::cloud-terms[]
 
@@ -653,19 +568,11 @@ endif::cloud-terms[]
 ifdef::elasticsearch-terms[]
 
 [[glossary-routing]] routing ::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=routing-def]
+--
 
-When you index a document, it is stored on a single
-<<glossary-primary-shard,primary shard>>. That shard is chosen by hashing
-the `routing` value. By default, the `routing` value is derived from
-the ID of the document or, if the document has a specified parent
-document, from the ID of the parent document (to ensure that child and
-parent documents are stored on the same shard).
-+
-This value can be overridden by specifying a `routing` value at index
-time, or a {ref}/mapping-routing-field.html[routing field] in the
-<<glossary-mapping,mapping>>.
-+
-//Source: Elasticsearch
 endif::elasticsearch-terms[]
 ifdef::cloud-terms[]
 
@@ -688,22 +595,11 @@ endif::cloud-terms[]
 ifdef::elasticsearch-terms[]
 
 [[glossary-shard]] shard ::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=shard-def]
+--
 
-A shard is a single Lucene instance. It is a low-level “worker” unit
-which is managed automatically by {es}. An index is a logical
-namespace which points to <<glossary-primary-shard,primary>> and
-<<glossary-replica-shard,replica>> shards.
-+
-Other than defining the number of primary and replica shards that an
-index should have, you never need to refer to shards directly.
-Instead, your code should deal only with an index.
-+
-{es} distributes shards amongst all <<glossary-node,nodes>> in the
-<<glossary-cluster,cluster>>, and can move shards automatically from one
-node to another in the case of node failure, or the addition of new
-nodes.
-+
-//Source: Elasticsearch
 endif::elasticsearch-terms[]
 ifdef::logstash-terms[]
 
@@ -717,29 +613,29 @@ endif::logstash-terms[]
 ifdef::elasticsearch-terms[]
 
 [[glossary-shrink]] shrink ::
-
-To reduce the amount of shards in an index. See the {ref}/indices-shrink-index.html[shrink index API].
 +
-//Source: Elasticsearch
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=shrink-def]
+--
+
 endif::elasticsearch-terms[]
 ifdef::elasticsearch-terms[]
 
 [[glossary-source_field]] source field ::
-
-By default, the JSON document that you index will be stored in the
-`_source` field and will be returned by all get and search requests.
-This allows you access to the original object directly from search
-results, rather than requiring a second step to retrieve the object
-from an ID.
 +
-//Source: Elasticsearch
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=source-field-def]
+--
+
 endif::elasticsearch-terms[]
 ifdef::elasticsearch-terms[]
 
 [[glossary-split]] split ::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=split-def]
+--
 
-To grow the amount of shards in an index. See the {ref}/indices-split-index.html[split index API].
-//Source: Elasticsearch
 endif::elasticsearch-terms[]
 ifdef::cloud-terms[]
 
@@ -752,40 +648,29 @@ endif::cloud-terms[]
 ifdef::elasticsearch-terms[]
 
 [[glossary-term]] term ::
-
-A term is an exact value that is indexed in {es}. The terms
-`foo`, `Foo`, `FOO` are NOT equivalent. Terms (i.e. exact values) can
-be searched for using _term_ queries. +
-See also <<glossary-text,text>> and <<glossary-analysis,analysis>>.
 +
-//Source: Elasticsearch
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=term-def]
+--
+
 endif::elasticsearch-terms[]
 ifdef::elasticsearch-terms[]
 
 [[glossary-text]] text ::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=text-def]
+--
 
-Text (or full text) is ordinary unstructured text, such as this
-paragraph. By default, text will be <<glossary-analysis,analyzed>> into
-<<glossary-term,terms>>, which is what is actually stored in the index.
-+
-Text <<glossary-field,fields>> need to be analyzed at index time in order to
-be searchable as full text, and keywords in full text queries must be
-analyzed at search time to produce (and search for) the same terms
-that were generated at index time.
-+
-See also <<glossary-term,term>> and <<glossary-analysis,analysis>>.
-+
-//Source: Elasticsearch
 endif::elasticsearch-terms[]
 ifdef::elasticsearch-terms[]
 
 [[glossary-type]] type ::
-
-A type used to represent the _type_ of document, e.g. an `email`, a `user`, or a `tweet`.
-Types are deprecated and are in the process of being removed.  See
-{ref}/removal-of-types.html[Removal of mapping types].
 +
-//Source: Elasticsearch
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=type-def]
+--
+
 endif::elasticsearch-terms[]
 ifdef::logstash-terms[]
 


### PR DESCRIPTION
Replaces duplicated glossary definitions with tagged regions from the Elasticsearch glossary.

Dependent on elastic/elasticsearch#46782. CI failures are expected until then.

Relates to elastic/elasticsearch#46683.