### PR TITLE
[DOCS] Updates data frame transform terminology

### DIFF
--- a/docs/en/stack/ml/df-analytics/index.asciidoc
+++ b/docs/en/stack/ml/df-analytics/index.asciidoc
@@ -15,7 +15,7 @@ normally do with any other data set.
 IMPORTANT: Using {dfanalytics} requires source data to be structured as a two 
 dimensional "tabular" data structure, in other words a 
 {stack-ov}/ml-dataframes.html[{dataframe}]. 
-{ref}/data-frame-apis.html[{dataframe-transforms-cap}] allow you to create 
+{ref}/data-frame-apis.html[{transforms-cap}] allow you to create 
 {dataframes} which can be used as the source for {dfanalytics}.
 
 * <<dfa-outlier-detection>>

--- a/docs/en/stack/security/authorization/built-in-roles.asciidoc
+++ b/docs/en/stack/security/authorization/built-in-roles.asciidoc
@@ -39,12 +39,12 @@ suitable for writing beats output to {es}.
 
 [[built-in-roles-data-frame-transforms-admin]] `data_frame_transforms_admin` ::
 Grants `manage_data_frame_transforms` cluster privileges, which enable you to
-manage data frame transforms. This role also includes all
+manage {transforms}. This role also includes all
 {kibana-ref}/kibana-privileges.html[Kibana privileges] for the {ml-features}.
 
 [[built-in-roles-data-frame-transforms-user]] `data_frame_transforms_user` ::
 Grants `monitor_data_fram_transforms` cluster privileges, which enable you to
-use data frame transforms. This role also includes all
+use {transforms}. This role also includes all
 {kibana-ref}/kibana-privileges.html[Kibana privileges] for the {ml-features}.
 
 [[built-in-roles-ingest-user]] `ingest_admin` ::

--- a/docs/en/stack/security/authorization/privileges.asciidoc
+++ b/docs/en/stack/security/authorization/privileges.asciidoc
@@ -48,7 +48,7 @@ manage follower indices and auto-follow patterns. This privilege is necessary
 only on clusters that contain follower indices. 
 
 `manage_data_frame_transforms`::
-All operations related to managing data frames.
+All operations related to managing {transforms}.
 
 `manage_ilm`::
 All {Ilm} operations related to managing policies.
@@ -120,7 +120,7 @@ All cluster read-only operations, like cluster health and state, hot threads,
 node info, node and cluster stats, and pending cluster tasks.
 
 `monitor_data_frame_transforms`::
-All read-only operations related to data frames.
+All read-only operations related to {transforms}.
 
 `monitor_ml`::
 All read-only {ml} operations, such as getting information about {dfeeds}, jobs,


### PR DESCRIPTION
Related to https://github.com/elastic/stack-docs/issues/478

This PR fixes occurrences of data frame transforms in the stack-docs repo.