### PR TITLE
[DOCS] Removes transform content from Stack Overview

### DIFF
--- a/docs/en/stack/index.asciidoc
+++ b/docs/en/stack/index.asciidoc
@@ -26,8 +26,6 @@ include::monitoring/index.asciidoc[]
 
 include::{xes-repo-dir}/watcher/index.asciidoc[]
 
-include::{es-repo-dir}/transform/index.asciidoc[]
-
 include::ml/anomaly-detection/index.asciidoc[]
 
 include::ml/df-analytics/index.asciidoc[]

--- a/docs/en/stack/redirects.asciidoc
+++ b/docs/en/stack/redirects.asciidoc
@@ -95,61 +95,61 @@ See {ref}/remote-recovery.html[Remote recovery].
 See {ref}/ccr-upgrading.html[Upgrading clusters].
 
 [role="exclude",id="dataframe-limitations"]
-=== Transform limitations
+=== {transform-cap} limitations
 
-TBD
+See {ref}/transform-limitations.html[{transform-cap} limitations].
 
 [role="exclude",id="dataframe-troubleshooting"]
-=== Troubleshooting transforms
+=== Troubleshooting {transforms}
 
-TBD
+See {ref}/transform-troubleshooting.html[Troubleshooting {transforms}].
 
 [role="exclude",id="example-clientips"]
 === Finding suspicious client IPs by using scripted metrics
 
-TBD
+See {ref}/transform-examples.html#example-clientips[Finding suspicious client IPs by using scripted metrics].
 
 [role="exclude",id="example-airline"]
 === Finding air carriers with the most delay
 
-TBD
+See {ref}/transform-examples.html#example-airline[Finding air carriers with the most delays].
 
 [role="exclude",id="example-best-customers"]
 === Finding your best customers
 
-TBD
+See {ref}/transform-examples.html#example-best-customers[Finding your best customers].
 
 [role="exclude",id="ecommerce-dataframes"]
 === Transforming the eCommerce sample data
 
-TBD
+See {ref}/ecommerce-transforms.html[Transforming the eCommerce sample data].
 
 [role="exclude",id="dataframe-examples"]
-=== Transform examples
+=== {transform-cap} examples
 
-TBD
+{ref}/transform-examples.html[{transform-cap} examples]
 
 [role="exclude",id="df-api-quickref"]
-=== Transform API quick reference
+=== {transform-cap} API quick reference
 
-TBD
+See {ref}/transform-api-quickref.html[API quick reference].
 
 [role="exclude",id="ml-transform-checkpoints"]
 === How {transform} checkpoints work
 
-TBD
+See {ref}/transform-checkpoints.html[How {transform} checkpoints work].
 
 [role="exclude",id="ml-transforms-usage"]
 === When to use {transforms}
 
-TBD
+See {ref}/transform-usage.html[When to use {transforms}].
 
 [role="exclude",id="ml-transform-overview"]
-=== Transform overview
+=== {transform-cap} overview
 
-TBD
+See {ref}/transform-overview.html[Overview].
 
 [role="exclude",id="ml-dataframes"]
 === Transforming data
 
-TBD
+See {ref}/transforms.html[Transforming data].

--- a/docs/en/stack/redirects.asciidoc
+++ b/docs/en/stack/redirects.asciidoc
@@ -71,7 +71,6 @@ See {ref}/ccr-overview.html[{ccr-cap} overview].
 
 [role="exclude",id="ccr-requirements"]
 === Requirements for leader indices
-[[ccr-overview-beats]]
 
 See {ref}/ccr-requirements.html[Requirements for leader indices].
 
@@ -98,59 +97,59 @@ See {ref}/ccr-upgrading.html[Upgrading clusters].
 [role="exclude",id="dataframe-limitations"]
 === Transform limitations
 
-//TBD
+TBD
 
 [role="exclude",id="dataframe-troubleshooting"]
 === Troubleshooting transforms
 
-//TBD
+TBD
 
 [role="exclude",id="example-clientips"]
 === Finding suspicious client IPs by using scripted metrics
 
-//TBD
+TBD
 
 [role="exclude",id="example-airline"]
 === Finding air carriers with the most delay
 
-//TBD
+TBD
 
 [role="exclude",id="example-best-customers"]
 === Finding your best customers
 
-//TBD
+TBD
 
 [role="exclude",id="ecommerce-dataframes"]
 === Transforming the eCommerce sample data
 
-//TBD
+TBD
 
 [role="exclude",id="dataframe-examples"]
 === Transform examples
 
-//TBD
+TBD
 
 [role="exclude",id="df-api-quickref"]
 === Transform API quick reference
 
-//TBD
+TBD
 
 [role="exclude",id="ml-transform-checkpoints"]
 === How {transform} checkpoints work
 
-//TBD
+TBD
 
 [role="exclude",id="ml-transforms-usage"]
 === When to use {transforms}
 
-//TBD
+TBD
 
 [role="exclude",id="ml-transform-overview"]
 === Transform overview
 
-//TBD
+TBD
 
 [role="exclude",id="ml-dataframes"]
 === Transforming data
 
-//TBD
+TBD

--- a/docs/en/stack/redirects.asciidoc
+++ b/docs/en/stack/redirects.asciidoc
@@ -94,3 +94,63 @@ See {ref}/remote-recovery.html[Remote recovery].
 === Upgrading clusters
 
 See {ref}/ccr-upgrading.html[Upgrading clusters].
+
+[role="exclude",id="dataframe-limitations"]
+=== Transform limitations
+
+//TBD
+
+[role="exclude",id="dataframe-troubleshooting"]
+=== Troubleshooting transforms
+
+//TBD
+
+[role="exclude",id="example-clientips"]
+=== Finding suspicious client IPs by using scripted metrics
+
+//TBD
+
+[role="exclude",id="example-airline"]
+=== Finding air carriers with the most delay
+
+//TBD
+
+[role="exclude",id="example-best-customers"]
+=== Finding your best customers
+
+//TBD
+
+[role="exclude",id="ecommerce-dataframes"]
+=== Transforming the eCommerce sample data
+
+//TBD
+
+[role="exclude",id="dataframe-examples"]
+=== Transform examples
+
+//TBD
+
+[role="exclude",id="df-api-quickref"]
+=== Transform API quick reference
+
+//TBD
+
+[role="exclude",id="ml-transform-checkpoints"]
+=== How {transform} checkpoints work
+
+//TBD
+
+[role="exclude",id="ml-transforms-usage"]
+=== When to use {transforms}
+
+//TBD
+
+[role="exclude",id="ml-transform-overview"]
+=== Transform overview
+
+//TBD
+
+[role="exclude",id="ml-dataframes"]
+=== Transforming data
+
+//TBD

--- a/docs/en/stack/redirects.asciidoc
+++ b/docs/en/stack/redirects.asciidoc
@@ -31,6 +31,7 @@ See <<elasticsearch-security>>.
 [role="exclude",id="security-files"]
 === Security files
 
+This page has moved. 
 See {ref}/security-files.html[Security files].
 
 [role="exclude",id="troubleshooting"]
@@ -62,94 +63,113 @@ include::help.asciidoc[tag=get-help]
 [role="exclude",id="xpack-ccr"]
 === Cross-cluster replication
 
+This page has moved. 
 See {ref}/xpack-ccr.html[{ccr-cap}].
 
 [role="exclude",id="ccr-overview"]
 === {ccr-cap} overview
 
+This page has moved. 
 See {ref}/ccr-overview.html[{ccr-cap} overview].
 
 [role="exclude",id="ccr-requirements"]
 === Requirements for leader indices
 
+This page has moved. 
 See {ref}/ccr-requirements.html[Requirements for leader indices].
 
 [role="exclude",id="ccr-auto-follow"]
 === Automatically following indices
 
+This page has moved. 
 See {ref}/ccr-auto-follow.html[Automatically following indices].
 
 [role="exclude",id="ccr-getting-started"]
 === Getting started with {ccr}
 
+This page has moved. 
 See {ref}/ccr-getting-started.html[Getting started with {ccr}].
 
 [role="exclude",id="remote-recovery"]
 === Remote recovery
 
+This page has moved. 
 See {ref}/remote-recovery.html[Remote recovery].
 
 [role="exclude",id="ccr-upgrading"]
 === Upgrading clusters
 
+This page has moved. 
 See {ref}/ccr-upgrading.html[Upgrading clusters].
 
 [role="exclude",id="dataframe-limitations"]
 === {transform-cap} limitations
 
-See {ref}/transform-limitations.html[{transform-cap} limitations].
+This page has moved. 
+//See {ref}/transform-limitations.html[{transform-cap} limitations].
 
 [role="exclude",id="dataframe-troubleshooting"]
 === Troubleshooting {transforms}
 
-See {ref}/transform-troubleshooting.html[Troubleshooting {transforms}].
+This page has moved. 
+//See {ref}/transform-troubleshooting.html[Troubleshooting {transforms}].
 
 [role="exclude",id="example-clientips"]
 === Finding suspicious client IPs by using scripted metrics
 
-See {ref}/transform-examples.html#example-clientips[Finding suspicious client IPs by using scripted metrics].
+This page has moved. 
+//See {ref}/transform-examples.html#example-clientips[Finding suspicious client IPs by using scripted metrics].
 
 [role="exclude",id="example-airline"]
 === Finding air carriers with the most delay
 
-See {ref}/transform-examples.html#example-airline[Finding air carriers with the most delays].
+This page has moved. 
+//See {ref}/transform-examples.html#example-airline[Finding air carriers with the most delays].
 
 [role="exclude",id="example-best-customers"]
 === Finding your best customers
 
-See {ref}/transform-examples.html#example-best-customers[Finding your best customers].
+This page has moved. 
+//See {ref}/transform-examples.html#example-best-customers[Finding your best customers].
 
 [role="exclude",id="ecommerce-dataframes"]
 === Transforming the eCommerce sample data
 
-See {ref}/ecommerce-transforms.html[Transforming the eCommerce sample data].
+This page has moved. 
+//See {ref}/ecommerce-transforms.html[Transforming the eCommerce sample data].
 
 [role="exclude",id="dataframe-examples"]
 === {transform-cap} examples
 
-{ref}/transform-examples.html[{transform-cap} examples]
+This page has moved. 
+//See {ref}/transform-examples.html[{transform-cap} examples]
 
 [role="exclude",id="df-api-quickref"]
 === {transform-cap} API quick reference
 
-See {ref}/transform-api-quickref.html[API quick reference].
+This page has moved. 
+//See {ref}/transform-api-quickref.html[API quick reference].
 
 [role="exclude",id="ml-transform-checkpoints"]
 === How {transform} checkpoints work
 
-See {ref}/transform-checkpoints.html[How {transform} checkpoints work].
+This page has moved. 
+//See {ref}/transform-checkpoints.html[How {transform} checkpoints work].
 
 [role="exclude",id="ml-transforms-usage"]
 === When to use {transforms}
 
-See {ref}/transform-usage.html[When to use {transforms}].
+This page has moved. 
+//See {ref}/transform-usage.html[When to use {transforms}].
 
 [role="exclude",id="ml-transform-overview"]
 === {transform-cap} overview
 
-See {ref}/transform-overview.html[Overview].
+This page has moved. 
+//See {ref}/transform-overview.html[Overview].
 
 [role="exclude",id="ml-dataframes"]
 === Transforming data
 
-See {ref}/transforms.html[Transforming data].
+This page has moved. 
+//See {ref}/transforms.html[Transforming data].


### PR DESCRIPTION
Related to elastic/stack-docs#503 and https://github.com/elastic/elasticsearch/pull/46846

This PR moves the content related to transform into closer proximity to the documentation for the data rollups feature.