### PR TITLE
[DOCS] Fixes wrong section level in data frame analytics limitations

### DIFF
--- a/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
@@ -59,7 +59,7 @@ values will be skipped during the analysis.
 
 [float]
 [[dfa-od-field-type-docs-limitations]]
-==== {oldetection-cap} field type and document limitation
+=== {oldetection-cap} field type and document limitation
 
 {oldetection-cap} requires numeric or boolean data to analyze. The algorithms 
 don't support missing values (see also <<dfa-missing-fields-limitations>>), 
@@ -72,7 +72,7 @@ and therefore no {olscore} is computed.
 
 [float]
 [[dfa-regression-field-type-docs-limitations]]
-==== {regression-cap} field type and document limitation
+=== {regression-cap} field type and document limitation
 
 {regression-cap} supports fields that are numeric, boolean, text, keyword and 
 ip. It is also tolerant of missing values. Fields that are supported are 


### PR DESCRIPTION
This PR fixes two wrongly defined section level in the limitations piece.