### PR TITLE
[DOCS][7.3] Adds data frame analytics field type and document limitation

### DIFF
--- a/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
@@ -56,3 +56,16 @@ values will be skipped entirely.
 If there are missing values in feature fields (fields that are subjects of the 
 {dfanalytics}), then the document that contains the fields with the missing 
 values will be skipped during the analysis.
+
+[float]
+[[dfa-od-field-type-docs-limitations]]
+=== {oldetection-cap} field type and document limitation
+
+{oldetection-cap} requires numeric or boolean data to analyze. The algorithms 
+don't support missing values (see also <<dfa-missing-fields-limitations>>), 
+therefore fields that have data types other than numeric or boolean are ignored. 
+Documents where included fields contain missing values, null values, or an array 
+are also ignored. Therefore a destination index may contain documents that don't 
+have an {olscore}. These documents are still reindexed from the source index to 
+the destination index, but they are not included in the {oldetection} analysis 
+and therefore no {olscore} is computed.


### PR DESCRIPTION
This PR applies the changes of https://github.com/elastic/stack-docs/pull/501 on the 7.3 branch (contains only the outlier detection limitation).