### PR TITLE
Update Kibana release highlights in Install Upgrade Guide

### DIFF
--- a/docs/en/install-upgrade/highlights.asciidoc
+++ b/docs/en/install-upgrade/highlights.asciidoc
@@ -65,7 +65,6 @@ include::{es-repo-dir}/reference/release-notes/highlights-8.0.0.asciidoc[tag=not
 coming[8.0.0]
 
 This list summarizes the most important enhancements in {kib} {version}.
-For the complete list, go to {kibana-ref}/release-highlights.html[{kib} release highlights].
 
 :leveloffset: +1
 


### PR DESCRIPTION
This PR removes some introductory text from the Kibana release highlights in the Installation and Upgrade Guide. Related to https://github.com/elastic/kibana/pull/42768

