### PR TITLE
[7.4][DOCS] Fixes link to transform APIs (#525)

### DIFF
--- a/docs/en/stack/ml/df-analytics/index.asciidoc
+++ b/docs/en/stack/ml/df-analytics/index.asciidoc
@@ -15,7 +15,7 @@ normally do with any other data set.
 IMPORTANT: Using {dfanalytics} requires source data to be structured as a two 
 dimensional "tabular" data structure, in other words a 
 {stack-ov}/ml-dataframes.html[{dataframe}]. 
-{ref}/data-frame-apis.html[{transforms-cap}] allow you to create 
+{ref}/transform-apis.html[{transforms-cap}] allow you to create 
 {dataframes} which can be used as the source for {dfanalytics}.
 
 * <<dfa-outlier-detection>>


### PR DESCRIPTION
Backports https://github.com/elastic/stack-docs/pull/525