### PR TITLE
[DOCS] Augment outlier overview with links to creation

### DIFF
--- a/docs/en/stack/ml/df-analytics/dfa-outlierdetection.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-outlierdetection.asciidoc
@@ -12,6 +12,13 @@ training data set to teach {oldetection} to recognize outliers. Unsupervised
 {oldetection} uses various machine learning techniques to find which data points 
 are unusual compared to the majority of the data points.
 
+You can create {oldetection} {dfanalytics-jobs} in {kib} or by using the
+{ref}/put-dfanalytics.html[create {dfanalytics-jobs} API].
+
+[discrete]
+[[dfa-outlier-algorithms]]
+=== {oldetection-cap} algorithms
+
 In the {stack}, we use an ensemble of four different distance and density based 
 {oldetection} methods. By default, you don't need to select the methods or 
 provide any parameters, but you can override the default behavior if you like. 


### PR DESCRIPTION
Related to https://github.com/elastic/kibana/issues/44556

This PR updates the outlier detection overview to include info about how to create the jobs (via Kibana or an API).  It also creates a section for the details about algorithms, though this is an optional change that can be reverted if necessary.