### PR TITLE
[DOCS] Changes wording to move away from data frame terminology in Stack Docs

### DIFF
--- a/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
@@ -19,10 +19,11 @@ the Elastic {dfanalytics} feature:
 
 [float]
 [[dfa-deletion-limitations]]
-=== Deleting a {dfanalytics-job} does not delete the {dataframe} destination index
+=== Deleting a {dfanalytics-job} does not delete the destination index
 
 The {ref}/delete-dfanalytics.html[delete {dfanalytics-job} API] does not delete
-the {dataframe} destination index. That index must be deleted separately.
+the destination index that contains the annotated data of the {dfanalytics}. 
+That index must be deleted separately.
 
 [float]
 [[dfa-update-limitations]]

--- a/docs/en/stack/ml/df-analytics/evaluatedf-api.asciidoc
+++ b/docs/en/stack/ml/df-analytics/evaluatedf-api.asciidoc
@@ -17,7 +17,7 @@ results of an {oldetection} analysis by using {binarysc}.
 
 To evaluate the {dfanalytics} with this API, you need to annotate your index 
 that contains the results of the analysis with a field that marks each 
-{dataframe} row with the ground truth. For example, in case of {oldetection}, 
+document with the ground truth. For example, in case of {oldetection}, 
 the field must indicate whether the given data point really is an outlier or 
 not. The {evaluatedf-api} evaluates the performance of the {dfanalytics} against 
 this manually provided ground truth.


### PR DESCRIPTION
Related to https://github.com/elastic/stack-docs/issues/518

This PR changes the wording of the data frame analytics limitation- and the evaluate data frame analytics pieces to move away from the data frame terminology.

Other occurrences of the `data frame` or `data frames` expressions were necessary to leave in the text (limitation piece & index).

List of occurrences:

```
Istvan-MacBook-Pro:stack-docs[master]$ find docs -name '*.asciidoc' | xargs egrep 'data frame'
Istvan-MacBook-Pro:stack-docs[master]$ find docs -name '*.asciidoc' | xargs egrep 'dataframe'
docs/en/stack/redirects.asciidoc:* <<dataframe-limitations>>
docs/en/stack/ml/df-analytics/ecommerce-outliers.asciidoc:For more details about creating {transforms}, see <<ecommerce-dataframes>>.
docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc:=== Deleting a {dfanalytics-job} does not delete the {dataframe} destination index
docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc:the {dataframe} destination index. That index must be deleted separately.
docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc:[[dfa-dataframe-size-limitations]]
docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc:=== {dataframe-cap} memory limitation
docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc:{dfanalytics-cap} can analyze {dataframes} that fit into the memory limit 
docs/en/stack/ml/df-analytics/index.asciidoc:{stack-ov}/ml-dataframes.html[{dataframe}]. 
docs/en/stack/ml/df-analytics/index.asciidoc:{dataframes} which can be used as the source for {dfanalytics}.
docs/en/stack/ml/df-analytics/evaluatedf-api.asciidoc:{dataframe} row with the ground truth. For example, in case of {oldetection}, 
Istvan-MacBook-Pro:stack-docs[master]$ 
```