### PR TITLE
Add docs for `create_doc` index privilege

### DIFF
--- a/docs/en/stack/security/authorization/privileges.asciidoc
+++ b/docs/en/stack/security/authorization/privileges.asciidoc
@@ -161,7 +161,18 @@ action.
 --
 NOTE: This privilege does not restrict the index operation to the creation
 of documents but instead restricts API use to the index API. The index API allows a user
-to overwrite a previously indexed document.
+to overwrite a previously indexed document. See `create_doc` privilege for an alternative.
+
+--
+
+`create_doc`::
+Privilege to index documents but does not allow a user to update existing documents.
+Also grants access to the update mapping action.
++
+--
+NOTE: When indexing documents with an external `_id` either via Index API or Bulk API
+the request must use `op_type` as `create`. If `_id`s are generated automatically then
+the authorization happens as if the `op_type` is set to `create`.
 
 --
 


### PR DESCRIPTION
This commit adds documentation for new index privilege
`create_doc` which only allows indexing of new documents
but no updates to existing documents via Index or Bulk APIs.

Relates: https://github.com/elastic/elasticsearch/pull/45806