### PR TITLE
Removes deleted pages for transforms

### DIFF
--- a/docs/en/stack/ml/df-analytics/ecommerce-outliers.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ecommerce-outliers.asciidoc
@@ -132,7 +132,8 @@ PUT _data_frame/transforms/ecommerce-customer-sales
 --------------------------------------------------
 // TEST[skip:set up sample data]
 
-For more details about creating {transforms}, see <<ecommerce-dataframes>>.
+For more details about creating {transforms}, see
+{ref}/ecommerce-transforms.html[Transforming the eCommerce sample data].
 --
 
 . Start the {transform}.

--- a/docs/en/stack/ml/df-analytics/index.asciidoc
+++ b/docs/en/stack/ml/df-analytics/index.asciidoc
@@ -13,9 +13,8 @@ annotated data. You can slice and dice the data extended with the results as you
 normally do with any other data set.
 
 IMPORTANT: Using {dfanalytics} requires source data to be structured as a two 
-dimensional "tabular" data structure, in other words a 
-{stack-ov}/ml-dataframes.html[{dataframe}]. 
-{ref}/transform-apis.html[{transforms-cap}] allow you to create 
+dimensional "tabular" data structure, in other words a {dataframe}. 
+{ref}/transforms.html[{transforms-cap}] enable you to create 
 {dataframes} which can be used as the source for {dfanalytics}.
 
 * <<dfa-outlier-detection>>

--- a/docs/en/stack/redirects.asciidoc
+++ b/docs/en/stack/redirects.asciidoc
@@ -58,7 +58,6 @@ include::help.asciidoc[tag=get-help]
 * <<security-limitations>>
 * <<watcher-limitations>>
 * <<ml-limitations>>
-* <<dataframe-limitations>>
 
 [role="exclude",id="xpack-ccr"]
 === Cross-cluster replication

--- a/docs/en/stack/redirects.asciidoc
+++ b/docs/en/stack/redirects.asciidoc
@@ -74,6 +74,7 @@ See {ref}/ccr-overview.html[{ccr-cap} overview].
 
 [role="exclude",id="ccr-requirements"]
 === Requirements for leader indices
+[[ccr-overview-beats]]
 
 This page has moved. 
 See {ref}/ccr-requirements.html[Requirements for leader indices].
@@ -101,75 +102,3 @@ See {ref}/remote-recovery.html[Remote recovery].
 
 This page has moved. 
 See {ref}/ccr-upgrading.html[Upgrading clusters].
-
-[role="exclude",id="dataframe-limitations"]
-=== {transform-cap} limitations
-
-This page has moved. 
-See {ref}/transform-limitations.html[{transform-cap} limitations].
-
-[role="exclude",id="dataframe-troubleshooting"]
-=== Troubleshooting {transforms}
-
-This page has moved. 
-See {ref}/transform-troubleshooting.html[Troubleshooting {transforms}].
-
-[role="exclude",id="example-clientips"]
-=== Finding suspicious client IPs by using scripted metrics
-
-This page has moved. 
-See {ref}/transform-examples.html#example-clientips[Finding suspicious client IPs by using scripted metrics].
-
-[role="exclude",id="example-airline"]
-=== Finding air carriers with the most delay
-
-This page has moved. 
-See {ref}/transform-examples.html#example-airline[Finding air carriers with the most delays].
-
-[role="exclude",id="example-best-customers"]
-=== Finding your best customers
-
-This page has moved. 
-See {ref}/transform-examples.html#example-best-customers[Finding your best customers].
-
-[role="exclude",id="ecommerce-dataframes"]
-=== Transforming the eCommerce sample data
-
-This page has moved. 
-See {ref}/ecommerce-transforms.html[Transforming the eCommerce sample data].
-
-[role="exclude",id="dataframe-examples"]
-=== {transform-cap} examples
-
-This page has moved. 
-See {ref}/transform-examples.html[{transform-cap} examples]
-
-[role="exclude",id="df-api-quickref"]
-=== {transform-cap} API quick reference
-
-This page has moved. 
-See {ref}/transform-api-quickref.html[API quick reference].
-
-[role="exclude",id="ml-transform-checkpoints"]
-=== How {transform} checkpoints work
-
-This page has moved. 
-See {ref}/transform-checkpoints.html[How {transform} checkpoints work].
-
-[role="exclude",id="ml-transforms-usage"]
-=== When to use {transforms}
-
-This page has moved. 
-See {ref}/transform-usage.html[When to use {transforms}].
-
-[role="exclude",id="ml-transform-overview"]
-=== {transform-cap} overview
-
-This page has moved. 
-See {ref}/transform-overview.html[Overview].
-
-[role="exclude",id="ml-dataframes"]
-=== Transforming data
-
-This page has moved. 
-See {ref}/transforms.html[Transforming data].


### PR DESCRIPTION
Related to https://github.com/elastic/docs/pull/1220
This PR cleans up some deleted pages now that redirects exist.
It also re-adds an anchor that was mistakenly removed in earlier PRs.