### PR TITLE
Fixes links to Beats 7.4 highlights and breaking changes

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -46,7 +46,7 @@ coming[7.4.0]
 This list summarizes the most important breaking changes in Beats. For the
 complete list, go to {beats-ref}/breaking-changes.html[Beats breaking changes].
 
-include::{beats-repo-dir}/breaking-7.0.asciidoc[tag=notable-breaking-changes]
+include::{beats-repo-dir}/breaking-7.4.asciidoc[tag=notable-breaking-changes]
 
 
 [[elasticsearch-breaking-changes]]

--- a/docs/en/install-upgrade/highlights.asciidoc
+++ b/docs/en/install-upgrade/highlights.asciidoc
@@ -36,7 +36,7 @@ coming[7.4.0]
 This list summarizes the most important enhancements in Beats.
 For the complete list, go to {beats-ref}/release-highlights.html[Beats release highlights].
 
-//include::{beats-repo-dir}/highlights-7.3.0.asciidoc[tag=notable-highlights]
+include::{beats-repo-dir}/highlights-7.4.0.asciidoc[tag=notable-highlights]
 
 [[elasticsearch-highlights]]
 === {es} highlights


### PR DESCRIPTION
Related to https://github.com/elastic/beats/pull/13803, which must be merged before this PR.

This PR adds links in the Installation and Upgrade Guide to the appropriate files in the beats repo.