### PR TITLE
Fixes transform links

### DIFF
--- a/docs/en/stack/ml/df-analytics/ecommerce-outliers.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ecommerce-outliers.asciidoc
@@ -132,7 +132,8 @@ PUT _data_frame/transforms/ecommerce-customer-sales
 --------------------------------------------------
 // TEST[skip:set up sample data]
 
-For more details about creating {transforms}, see <<ecommerce-dataframes>>.
+For more details about creating {transforms}, see
+{ref}/ecommerce-transforms.html[Transforming the eCommerce sample data].
 --
 
 . Start the {transform}.

--- a/docs/en/stack/ml/df-analytics/index.asciidoc
+++ b/docs/en/stack/ml/df-analytics/index.asciidoc
@@ -13,9 +13,8 @@ annotated data. You can slice and dice the data extended with the results as you
 normally do with any other data set.
 
 IMPORTANT: Using {dfanalytics} requires source data to be structured as a two 
-dimensional "tabular" data structure, in other words a 
-{stack-ov}/ml-dataframes.html[{dataframe}]. 
-{ref}/transform-apis.html[{transforms-cap}] allow you to create 
+dimensional "tabular" data structure, in other words a {dataframe}. 
+{ref}/transforms.html[{transforms-cap}] enable you to create 
 {dataframes} which can be used as the source for {dfanalytics}.
 
 * <<dfa-outlier-detection>>


### PR DESCRIPTION
Related to https://github.com/elastic/stack-docs/pull/544

This PR backports link fixes for content that moved from the Stack Overview to the Elasticsearch Guide. It does not, however, remove the deleted pages.