### PR TITLE
[7.x] Removes Watcher from Stack Overview (#546)

### DIFF
--- a/docs/en/stack/index.asciidoc
+++ b/docs/en/stack/index.asciidoc
@@ -24,8 +24,6 @@ include::security/index.asciidoc[]
 
 include::monitoring/index.asciidoc[]
 
-include::{xes-repo-dir}/watcher/index.asciidoc[]
-
 include::ml/anomaly-detection/index.asciidoc[]
 
 include::ml/df-analytics/index.asciidoc[]

--- a/docs/en/stack/introduction.asciidoc
+++ b/docs/en/stack/introduction.asciidoc
@@ -13,7 +13,6 @@ For a quick overview, see: https://www.elastic.co/products
 * {stack-gs}/get-started-elastic-stack.html[Getting started with the {stack}]
 * <<security-getting-started, Getting Started with Security>>
 * <<xpack-monitoring, Getting Started with Monitoring>>
-* <<watcher-getting-started, Getting Started with Alerting and Notification>>
 * {kibana-ref}/xpack-reporting.html[Reporting from Kibana]
 * {kibana-ref}/graph-getting-started.html[Getting Started with Graph]
 

--- a/docs/en/stack/redirects.asciidoc
+++ b/docs/en/stack/redirects.asciidoc
@@ -41,8 +41,6 @@ Having trouble? Here are solutions to common problems you might encounter.
 
 * <<security-troubleshooting>>
 
-* <<watcher-troubleshooting>>
-
 * <<monitoring-troubleshooting>>
 
 * <<ml-troubleshooting>>
@@ -56,7 +54,6 @@ include::help.asciidoc[tag=get-help]
 === Limitations
 
 * <<security-limitations>>
-* <<watcher-limitations>>
 * <<ml-limitations>>
 * <<dataframe-limitations>>
 
@@ -179,7 +176,7 @@ See {ref}/transforms.html[Transforming data].
 === Monitoring in a production environment
 
 This page has moved.
-// See {ref}/monitoring-production.html[Monitoring in a production environment].
+See {ref}/monitoring-production.html[Monitoring in a production environment].
 
 [role="exclude",id="how-monitoring-works"]
 === How monitoring works
@@ -191,4 +188,239 @@ See {ref}/how-monitoring-works.html[How monitoring works].
 == Troubleshooting monitoring
 
 This page has moved.
-// See {ref}/monitoring-troubleshooting.html[Troubleshooting monitoring].
+See {ref}/monitoring-troubleshooting.html[Troubleshooting monitoring].
+
+[role="exclude",id="xpack-alerting"]
+=== Alerting on cluster and index events
+
+This page has moved. 
+See {ref}/xpack-alerting.html[Alerting on cluster and index events].
+
+[role="exclude",id="watcher-getting-started"]
+=== Getting started with Watcher
+
+This page has moved. 
+See {ref}/watcher-getting-started.html[Getting started with Watcher].
+
+[role="exclude",id="how-watcher-works"]
+=== How Watcher works
+
+[[watch-definition]]
+This page has moved.
+[[watch-active-state]]
+See {ref}/how-watcher-works.html[How Watcher works].
+
+[role="exclude",id="encrypting-data"]
+=== Encrypting sensitive data in Watcher
+
+This page has moved. 
+See {ref}/encrypting-data.html[Encrypting sensitive data in Watcher].
+
+[role="exclude",id="input"]
+=== Inputs
+
+This page has moved. 
+See {ref}/input.html[Inputs].
+
+[role="exclude",id="input-simple"]
+=== Simple input
+
+This page has moved. 
+See {ref}/input-simple.html[Simple input].
+
+[role="exclude",id="input-search"]
+=== Search input
+
+This page has moved. 
+See {ref}/input-search.html[Search input].
+
+[role="exclude",id="input-http"]
+=== HTTP input
+
+This page has moved. 
+See {ref}/input-http.html[HTTP input].
+
+[role="exclude",id="input-chain"]
+=== Chain input
+
+This page has moved. 
+See {ref}/input-chain.html[Chain input].
+
+[role="exclude",id="trigger"]
+=== Triggers
+
+This page has moved. 
+See {ref}/trigger.html[Triggers].
+
+[role="exclude",id="trigger-schedule"]
+=== Schedule trigger
+
+[[schedule-cron]]
+This page has moved. 
+See {ref}/trigger-schedule.html[Schedule trigger].
+
+[role="exclude",id="condition"]
+=== Conditions
+
+This page has moved. 
+See {ref}/condition.html[Conditions].
+
+[role="exclude",id="condition-always"]
+=== Always condition
+
+This page has moved. 
+See {ref}/condition-always.html[Always condition].
+
+[role="exclude",id="condition-never"]
+=== Never condition
+
+This page has moved. 
+See {ref}/condition-never.html[Never condition].
+
+[role="exclude",id="condition-compare"]
+=== Compare condition
+
+This page has moved. 
+See {ref}/condition-compare.html[Compare condition].
+
+[role="exclude",id="condition-array-compare"]
+=== Array compare condition
+
+This page has moved. 
+See {ref}/condition-array-compare.html[Array compare condition].
+
+[role="exclude",id="condition-script"]
+=== Script condition
+
+This page has moved. 
+See {ref}/condition-script.html[Script condition].
+
+[role="exclude",id="actions"]
+=== Actions
+
+[[actions-ack-throttle]]
+This page has moved. 
+See {ref}/actions.html[Actions].
+
+[role="exclude",id="action-foreach"]
+=== Running an action for each element in an array
+
+This page has moved. 
+See {ref}/action-foreach.html[Running an action for each element in an array].
+
+[role="exclude",id="action-conditions"]
+=== Adding conditions to actions
+
+This page has moved. 
+See {ref}/action-conditions.html[Adding conditions to actions].
+
+[role="exclude",id="actions-email"]
+=== Email action
+
+[[configuring-email]]
+This page has moved. 
+[[email-html-sanitization]]
+See {ref}/actions-email.html[Email action].
+[[email-action-attributes]]
+[[configuring-email-actions]]
+
+[role="exclude",id="actions-webhook"]
+=== Webhook action
+
+This page has moved. 
+See {ref}/actions-webhook.html[Webhook action].
+
+[role="exclude",id="actions-index"]
+=== Index action
+
+This page has moved. 
+See {ref}/actions-index.html[Index action].
+
+[role="exclude",id="actions-logging"]
+=== Logging action
+
+This page has moved. 
+See {ref}/actions-logging.html[Logging action].
+
+[role="exclude",id="actions-slack"]
+=== Slack action
+
+[[configuring-slack-actions]]
+This page has moved. 
+See {ref}/actions-slack.html[Slack action].
+
+[role="exclude",id="actions-pagerduty"]
+=== PagerDuty action
+
+[[pagerduty-event-trigger-incident-attributes]]
+This page has moved. 
+[[configuring-pagerduty-actions]]
+See {ref}/actions-pagerduty.html[PagerDuty action].
+
+[role="exclude",id="actions-jira"]
+=== Jira action
+
+[[jira-action-attributes]]
+This page has moved.
+[[configuring-jira-actions]]
+See {ref}/actions-jira.html[Jira action].
+
+[role="exclude",id="transform"]
+=== Watcher transforms
+
+This page has moved. 
+See {ref}/transform.html[Watcher transforms].
+
+[role="exclude",id="transform-search"]
+=== Search transform
+
+This page has moved. 
+See {ref}/transform-search.html[Search transform].
+
+[role="exclude",id="transform-script"]
+=== Script transform
+
+This page has moved. 
+See {ref}/transform-script.html[Script transform].
+
+[role="exclude",id="transform-chain"]
+=== Chain transform
+
+This page has moved. 
+See {ref}/transform-chain.html[Chain transform].
+
+[role="exclude",id="managing-watches"]
+=== Managing watches
+
+This page has moved. 
+See {ref}/managing-watches.html[Managing watches].
+
+[role="exclude",id="example-watches"]
+=== Example watches
+
+This page has moved. 
+See {ref}/example-watches.html[Example watches].
+
+[role="exclude",id="watch-cluster-status"]
+=== Watching the status of an Elasticsearch cluster
+
+This page has moved. 
+See {ref}/watch-cluster-status.html[Watching the status of an Elasticsearch cluster].
+
+[role="exclude",id="watching-meetup-data"]
+=== Watching event data
+
+This page has moved. 
+See {ref}/watching-meetup-data.html[Watching event data].
+
+[role="exclude",id="watcher-troubleshooting"]
+=== Troubleshooting Watcher
+
+This page has moved. 
+See {ref}/watcher-troubleshooting.html[Troubleshooting Watcher].
+
+[role="exclude",id="watcher-limitations"]
+=== Watcher limitations
+
+This page has moved. 
+See {ref}/watcher-limitations.html[Watcher limitations].


### PR DESCRIPTION
Backports https://github.com/elastic/stack-docs/pull/546/

Depends on https://github.com/elastic/kibana/pull/46871 and https://github.com/elastic/elasticsearch/pull/47255