### PR TITLE
Stages removal of security content

### DIFF
--- a/docs/en/stack/redirects.asciidoc
+++ b/docs/en/stack/redirects.asciidoc
@@ -351,3 +351,93 @@ See {ref}/watcher-troubleshooting.html[Troubleshooting Watcher].
 
 This page has moved. 
 See {ref}/watcher-limitations.html[Watcher limitations].
+
+[role="exclude",id="auditing"]
+=== Auditing security events
+
+This page has moved. 
+//See {ref}/auditing.html[Auditing security events].
+
+[role="exclude",id="audit-event-types"]
+=== Audit event types
+
+This page has moved.
+//See {ref}/audit-event-types.html[Audit event types].
+
+[role="exclude",id="audit-log-output"]
+=== Logfile audit output
+
+This page has moved.
+//See {ref}/audit-log-output.html[Logfile audit output].
+
+[role="exclude",id="auditing-search-queries"]
+=== Auditing search queries
+
+This page has moved.
+//See {ref}/auditing-search-queries.html[Auditing search queries].
+
+[role="exclude",id="encrypting-communications"]
+=== Encrypting communications
+
+This page has moved.
+//See {ref}/encrypting-communications.html[Encrypting communications].
+
+[role="exclude",id="ssl-tls"]
+=== Setting up TLS on a cluster
+
+This page has moved.
+//See {ref}/ssl-tls.html[Setting up TLS on a cluster].
+
+[role="exclude",id="ciphers"]
+=== Enabling cipher suites for stronger encryption
+
+This page has moved.
+See {ref}/ciphers.html[Enabling cipher suites for stronger encryption].
+
+[role="exclude",id="ip-filtering"]
+=== Restricting connections with IP filtering
+
+This page has moved.
+//See {ref}/ip-filtering.html[Restricting connections with IP filtering].
+
+[role="exclude",id="ccs-clients-integrations"]
+=== Cross cluster search, clients, and integrations
+
+This page has moved.
+//See {ref}/ccs-clients-integrations.html[Cross cluster search, clients, and integrations]. 
+
+[role="exclude",id="cross-cluster-configuring"]
+=== Cross cluster search and security
+
+This page has moved.
+//See {ref}/cross-cluster-configuring.html[Cross cluster search and security].
+
+[role="exclude",id="http-clients"]
+=== HTTP/REST clients and security
+
+This page has moved.
+//See {ref}/http-clients.html[].
+
+[role="exclude",id="hadoop"]
+=== ES-Hadoop and Security
+
+This page has moved.
+//See {ref}/hadoop.html[].
+
+[role="exclude",id="beats"]
+=== Beats and Security
+
+See:
+
+* {auditbeat-ref}/securing-beats.html[{auditbeat}]
+* {filebeat-ref}/securing-beats.html[{filebeat}]
+* {heartbeat-ref}/securing-beats.html[{heartbeat}]
+* {metricbeat-ref}/securing-beats.html[{metricbeat}]
+* {packetbeat-ref}/securing-beats.html[{packetbeat}]
+* {winlogbeat-ref}/securing-beats.html[{winlogbeat}]
+
+[role="exclude",id="secure-monitoring"]
+=== Monitoring and security
+
+This page has moved.
+//See {ref}/secure-monitoring.html[].

--- a/docs/en/stack/redirects.asciidoc
+++ b/docs/en/stack/redirects.asciidoc
@@ -367,8 +367,8 @@ This page has moved.
 [role="exclude",id="audit-log-output"]
 === Logfile audit output
 
-This page has moved.
 [[audit-log-ignore-policy]]
+This page has moved.
 //See {ref}/audit-log-output.html[Logfile audit output].
 
 [role="exclude",id="auditing-search-queries"]

--- a/docs/en/stack/redirects.asciidoc
+++ b/docs/en/stack/redirects.asciidoc
@@ -368,6 +368,7 @@ This page has moved.
 === Logfile audit output
 
 This page has moved.
+[[audit-log-ignore-policy]]
 //See {ref}/audit-log-output.html[Logfile audit output].
 
 [role="exclude",id="auditing-search-queries"]

--- a/docs/en/stack/security/index.asciidoc
+++ b/docs/en/stack/security/index.asciidoc
@@ -94,13 +94,13 @@ include::authentication/index.asciidoc[]
 
 include::authorization/index.asciidoc[]
 
-include::{xes-repo-dir}/security/auditing/index.asciidoc[]
+//TEMPORARILY OMIT:include::{xes-repo-dir}/security/auditing/index.asciidoc[]
 
-include::{xes-repo-dir}/security/securing-communications.asciidoc[]
+//TEMPORARILY OMIT:include::{xes-repo-dir}/security/securing-communications.asciidoc[]
 
-include::{xes-repo-dir}/security/using-ip-filtering.asciidoc[]
+//TEMPORARILY OMIT:include::{xes-repo-dir}/security/using-ip-filtering.asciidoc[]
 
-include::{xes-repo-dir}/security/ccs-clients-integrations.asciidoc[]
+//TEMPORARILY OMIT:include::{xes-repo-dir}/security/ccs-clients-integrations.asciidoc[]
 
 include::get-started-security.asciidoc[]
 


### PR DESCRIPTION
This PR is one of several staged PRs related to #46880

This PR creates deleted pages in the Stack Overview for content that was previously being pulled from
from https://github.com/elastic/elasticsearch/tree/master/x-pack/docs/en/security