### PR TITLE
[Docs] Corrects SIEM linux_anomalous_network_service job description

### DIFF
--- a/docs/en/siem/machine-learning.asciidoc
+++ b/docs/en/siem/machine-learning.asciidoc
@@ -162,9 +162,6 @@ Beats required on hosts:
 linux_anomalous_network_service:: Searches for unusual listening ports that
 could indicate execution of unauthorized services, backdoors, or persistence mechanisms.
 +
-Rarely used listening ports can point to system vulnerabilities, and backdoor or
-rootkit persistence mechanisms.
-+
 Beats required on hosts:
 
 * Auditbeat


### PR DESCRIPTION
Dev correction for ML job description.
Removed second paragraph as it was inaccurate and did not add anything to the first one.