### PR TITLE
[7.x] [DOCS] Removes transforms redirect duplication

### DIFF
--- a/docs/en/stack/redirects.asciidoc
+++ b/docs/en/stack/redirects.asciidoc
@@ -424,11 +424,6 @@ See {ref}/watcher-troubleshooting.html[Troubleshooting Watcher].
 
 This page has moved.
 
-[role="exclude",id="ml-dataframes"]	[role="exclude",id="ml-dataframes"]
-=== Transforming data
-
-See {ref}/transforms.html[Transforming data].
-
 [role="exclude",id="ml-troubleshooting"]
 === Troubleshooting {ml} {anomaly-detect}
 


### PR DESCRIPTION
Removes the transforms redirect duplication from redirect.asciidoc.