### PR TITLE
[7.x] [DOCS] Fixes TOC in the anomaly detection index

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/index.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/index.asciidoc
@@ -8,7 +8,6 @@
 analysis and anomaly results are displayed in {kib} dashboards.
 
 * <<ml-overview>>
-* <<create-jobs>>
 * <<ml-concepts>>
 * <<ml-configuration>>
 //* <<ml-getting-started>>


### PR DESCRIPTION
This PR removes an unnecessary menu link from the Anomaly Detection index section.