### PR TITLE
[DOCS] Revamps Data Fame Analytics section

### DIFF
--- a/docs/en/stack/ml/df-analytics/dfa-outlierdetection.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-outlierdetection.asciidoc
@@ -1,6 +1,6 @@
 [role="xpack"]
 [[dfa-outlier-detection]]
-== {oldetection-cap}
+=== {oldetection-cap}
 
 
 {oldetection-cap} is an analysis for identifying data points (outliers) whose 
@@ -17,7 +17,7 @@ You can create {oldetection} {dfanalytics-jobs} in {kib} or by using the
 
 [discrete]
 [[dfa-outlier-algorithms]]
-=== {oldetection-cap} algorithms
+==== {oldetection-cap} algorithms
 
 In the {stack}, we use an ensemble of four different distance and density based 
 {oldetection} methods. By default, you don't need to select the methods or 
@@ -74,7 +74,7 @@ altered data.
 
 [discrete]
 [[dfa-feature-influence]]
-=== Feature influence
+==== Feature influence
 
 Besides the {olscore}, another value is calculated during {oldetection}: 
 the feature influence score. As we mentioned, there are multiple features of a 

--- a/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
@@ -1,6 +1,6 @@
 [role="xpack"]
 [[dfa-regression]]
-== {regression-cap}
+=== {regression-cap}
 
 {reganalysis-cap} is a {ml} process for estimating the relationships among 
 different fields in your data, then making further predictions based on these 
@@ -31,7 +31,7 @@ has a riverside view or not and so on.
 
 [discrete]
 [[dfa-regression-features]]
-=== {feature-vars-cap}
+==== {feature-vars-cap}
 
 When you perform {reganalysis}, you must identify a subset of fields that you 
 want to use to create a model for predicting other fields. We refer to these 
@@ -53,7 +53,7 @@ Arrays are not supported.
 
 [discrete]
 [[dfa-regression-supervised]]
-=== Training the {regression} algorithm
+==== Training the {regression} algorithm
 
 {regression-cap} is a supervised machine learning process, which means that you 
 need to supply a labeled training dataset that has some {feature-vars} and a 
@@ -65,18 +65,18 @@ points.
 
 The relationships between the {feature-vars} and the {depvar} are described as a 
 mathematical function. {reganalysis-cap} tries to find the best prediction for 
-the {depvar} by combining the predictions from multiple base learners – algorithms that generalize from the dataset. The 
-performance of an ensemble is usually better than the performance of each 
-individual base learner because the individual learners will make different 
-errors. These average out when their predictions are combined. The ensemble 
-learning technique that we use in the {stack} is a type of boosting called 
-extreme gradient boost (XGboost) which combines decision trees with gradient 
-boosting methodologies.
+the {depvar} by combining the predictions from multiple base learners – 
+algorithms that generalize from the dataset. The performance of an ensemble is 
+usually better than the performance of each individual base learner because the 
+individual learners will make different errors. These average out when their 
+predictions are combined. The ensemble learning technique that we use in the 
+{stack} is a type of boosting called extreme gradient boost (XGboost) which 
+combines decision trees with gradient boosting methodologies.
 
  
 [discrete]
 [[dfa-regression-evaluation]]
-=== Measuring model performance
+==== Measuring model performance
 
 You can measure how well the model has performed on your training dataset by 
 using the `regression` evaluation type of the 

--- a/docs/en/stack/ml/df-analytics/evaluatedf-api.asciidoc
+++ b/docs/en/stack/ml/df-analytics/evaluatedf-api.asciidoc
@@ -1,6 +1,6 @@
 [role="xpack"]
 [[ml-dfanalytics-evaluate]]
-== Evaluating {dfanalytics}
+=== Evaluating {dfanalytics}
 
 Using the {dfanalytics} features to gain insights from a data set is an 
 iterative process. You might need to experiment with different analyses, 
@@ -24,7 +24,7 @@ this manually provided ground truth.
 
 [discrete]
 [[ml-dfanalytics-binary-soft-classification]]
-=== {binarysc-cap} evaluation
+==== {binarysc-cap} evaluation
 
 This evaluation type is suitable for analyses which calculate a probability that 
 each data point in a data set is a member of a class or not. The {binarysc} 
@@ -37,7 +37,7 @@ evaluation type offers the following metrics to evaluate the model performance:
 
 [discrete]
 [[ml-dfanalytics-confusion-matrix]]
-==== Confusion matrix
+===== Confusion matrix
 
 A confusion matrix provides four measures of how well the {dfanalytics} worked 
 on your data set:
@@ -66,7 +66,7 @@ matrix at different thresholds (by default, 0.25, 0.5, and 0.75).
 
 [discrete]
 [[ml-dfanalytics-precision-recall]]
-==== Precision and recall
+===== Precision and recall
 
 A confusion matrix is a useful measure, but it could be hard to compare the 
 results across the different algorithms. Precision and recall values
@@ -87,7 +87,7 @@ threshold levels for computing precision and recall.
 
 [discrete]
 [[ml-dfanalytics-roc]]
-==== Receiver operating characteristic curve
+===== Receiver operating characteristic curve
 
 The receiver operating characteristic (ROC) curve is a plot that represents the 
 performance of the binary classification process at different thresholds. It 
@@ -103,7 +103,7 @@ the algorithm performance by using these values.
 
 [discrete]
 [[ml-dfanalytics-regression-evaluation]]
-=== {regression-cap} evaluation
+==== {regression-cap} evaluation
 
 This evaluation type is suitable for evaluating {regression} models. The 
 {regression} evaluation type offers the following metrics to evaluate the model 
@@ -115,7 +115,7 @@ performance:
 
 [discrete]
 [[ml-dfanalytics-mse]]
-==== Mean squared error
+===== Mean squared error
 
 The API provides a MSE by computing the 
 average squared sum of the difference between the true value and the value that 
@@ -125,7 +125,7 @@ You can use the MSE to measure how well the {reganalysis} model is performing.
 
 [discrete]
 [[ml-dfanalytics-r-sqared]]
-==== R-squared
+===== R-squared
 
 Another evaluation metrics for {reganalysis} is R-squared (R^2^). It represents 
 the goodness of fit and measures how much of the variation in the data the 

--- a/docs/en/stack/ml/df-analytics/index.asciidoc
+++ b/docs/en/stack/ml/df-analytics/index.asciidoc
@@ -9,11 +9,10 @@ dimensional "tabular" data structure, in other words a {dataframe}.
 {ref}/transforms.html[{transforms-cap}] enable you to create 
 {dataframes} which can be used as the source for {dfanalytics}.
 
+experimental[]
 
 {dfanalytics-cap} enable you to perform different analyses of your data and 
 annotate it with the results.
-
-experimental[]
 
 * <<ml-dfa-overview>>
 * <<ml-dfa-concepts>>

--- a/docs/en/stack/ml/df-analytics/index.asciidoc
+++ b/docs/en/stack/ml/df-analytics/index.asciidoc
@@ -13,7 +13,7 @@ annotate it with the results.
 * <<ml-dfa-overview>>
 * <<ml-dfa-concepts>>
 * <<ml-dfanalytics-apis>>
-* <dfanalytics-examples>
+* <<dfanalytics-examples>>
 * <<ml-dfa-limitations>>
 
 --

--- a/docs/en/stack/ml/df-analytics/index.asciidoc
+++ b/docs/en/stack/ml/df-analytics/index.asciidoc
@@ -2,32 +2,25 @@
 [[ml-dfanalytics]]
 = {ml-cap} {dfanalytics}
 
-[partintro]
---
-{dfanalytics-cap} enable you to perform different analyses of your data and 
-annotate it with the results. Essentially, as part of its output, {dfanalytics} 
-appends the results of the analysis to the source data. By doing this, it 
-provides additional insights into the data. The process leaves the source index 
-intact, it creates a new index that contains a copy of the source data and the 
-annotated data. You can slice and dice the data extended with the results as you 
-normally do with any other data set.
-
 IMPORTANT: Using {dfanalytics} requires source data to be structured as a two 
 dimensional "tabular" data structure, in other words a {dataframe}. 
 {ref}/transforms.html[{transforms-cap}] enable you to create 
 {dataframes} which can be used as the source for {dfanalytics}.
 
-* <<dfa-outlier-detection>>
-* <<dfa-regression>>
-* <<ml-dfanalytics-evaluate>>
+{dfanalytics-cap} enable you to perform different analyses of your data and 
+annotate it with the results.
+
+* <<ml-dfa-overview>>
+* <<ml-dfa-concepts>>
 * <<ml-dfanalytics-apis>>
+* <dfanalytics-examples>
 * <<ml-dfa-limitations>>
 
 --
 
-include::dfa-outlierdetection.asciidoc[]
-include::dfa-regression.asciidoc[]
-include::evaluatedf-api.asciidoc[]
+include::ml-dfa-overview.asciidoc[]
+include::ml-dfa-concepts.asciidoc[]
 include::api-quickref.asciidoc[]
 include::examples.asciidoc[]
 include::dfanalytics-limitations.asciidoc[]
+

--- a/docs/en/stack/ml/df-analytics/index.asciidoc
+++ b/docs/en/stack/ml/df-analytics/index.asciidoc
@@ -2,6 +2,8 @@
 [[ml-dfanalytics]]
 = {ml-cap} {dfanalytics}
 
+[partintro]	
+--
 IMPORTANT: Using {dfanalytics} requires source data to be structured as a two 
 dimensional "tabular" data structure, in other words a {dataframe}. 
 {ref}/transforms.html[{transforms-cap}] enable you to create 
@@ -23,4 +25,3 @@ include::ml-dfa-concepts.asciidoc[]
 include::api-quickref.asciidoc[]
 include::examples.asciidoc[]
 include::dfanalytics-limitations.asciidoc[]
-

--- a/docs/en/stack/ml/df-analytics/ml-dfa-concepts.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-concepts.asciidoc
@@ -1,0 +1,14 @@
+[role="xpack"]
+[[ml-dfa-concepts]]
+== Concepts
+
+This section explains the fundamental concepts of the Elastic {ml} {dfanalytics} 
+feature and the corresponding {evaluatedf-api}.
+
+* <<dfa-outlier-detection>>
+* <<dfa-regression>>
+* <<ml-dfanalytics-evaluate>>
+
+include::dfa-outlierdetection.asciidoc[]
+include::dfa-regression.asciidoc[]
+include::evaluatedf-api.asciidoc[]

--- a/docs/en/stack/ml/df-analytics/ml-dfa-overview.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-overview.asciidoc
@@ -2,8 +2,6 @@
 [[ml-dfa-overview]]
 == Overview
 
-[partintro]
---
 {dfanalytics-cap} enable you to perform different analyses of your data and 
 annotate it with the results. Essentially, as part of its output, {dfanalytics} 
 appends the results of the analysis to the source data. By doing this, it 

--- a/docs/en/stack/ml/df-analytics/ml-dfa-overview.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-overview.asciidoc
@@ -1,0 +1,32 @@
+[role="xpack"]
+[[ml-dfa-overview]]
+== Overview
+
+[partintro]
+--
+{dfanalytics-cap} enable you to perform different analyses of your data and 
+annotate it with the results. Essentially, as part of its output, {dfanalytics} 
+appends the results of the analysis to the source data. By doing this, it 
+provides additional insights into the data. The process leaves the source index 
+intact, it creates a new index that contains a copy of the source data and the 
+annotated data. You can slice and dice the data extended with the results as you 
+normally do with any other data set.
+
+You can evaluate the {dfanalytics} performance by using the {evaluatedf-api} 
+against a marked up data set. It helps you understand error distributions and 
+identifies the points where the {dfanalytics} model performs well or less 
+trustworthily.
+
+For the available types of {dfanalytics} and the evaluation methods, consult the 
+table below.
+
+
+[width="50%"]
+.{dfanalytics-cap} overview table
+|===
+| Type of {dfanalytics}     | Learning type | Evaluation type
+
+| {outlierdetection}        | unsupervised  | {binarysc}
+| {regression}              | supervised    | {regression}
+|===
+

--- a/docs/en/stack/ml/df-analytics/ml-dfa-overview.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-overview.asciidoc
@@ -24,7 +24,7 @@ table below.
 |===
 | Type of {dfanalytics}     | Learning type | Evaluation type
 
-| {outlierdetection}        | unsupervised  | {binarysc}
+| {oldetection}             | unsupervised  | {binarysc}
 | {regression}              | supervised    | {regression}
 |===
 


### PR DESCRIPTION
This PR reorganizes the ML Data Frame Analytics section to align with the ML feature template.

Related issue: https://github.com/elastic/stack-docs/issues/608

[ML feature template](https://raw.githubusercontent.com/elastic/stack-docs/master/docs/en/stack/ml/doc-template/ml-feature-template.asciidoc)

Preview: http://stack-docs_613.docs-preview.app.elstc.co/guide/en/elastic-stack-overview/master/ml-dfanalytics.html