### PR TITLE
[7.3] [DOCS] Marks DFA and the related analytics types as experimental features

### DIFF
--- a/docs/en/stack/ml/df-analytics/dfa-outlierdetection.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-outlierdetection.asciidoc
@@ -2,6 +2,7 @@
 [[dfa-outlier-detection]]
 == {oldetection-cap}
 
+experimental[]
 
 {oldetection-cap} is an analysis for identifying data points (outliers) whose 
 feature values are different from those of the normal data points in a 

--- a/docs/en/stack/ml/df-analytics/evaluatedf-api.asciidoc
+++ b/docs/en/stack/ml/df-analytics/evaluatedf-api.asciidoc
@@ -2,6 +2,8 @@
 [[ml-dfanalytics-evaluate]]
 == Evaluating {dfanalytics}
 
+experimental[]
+
 Using the {dfanalytics} features to gain insights from a data set is an 
 iterative process. You might need to experiment with different analyses, 
 parameters, and ways to transform data before you arrive at a result that satisfies 

--- a/docs/en/stack/ml/df-analytics/index.asciidoc
+++ b/docs/en/stack/ml/df-analytics/index.asciidoc
@@ -17,6 +17,8 @@ dimensional "tabular" data structure, in other words a {dataframe}.
 {ref}/transforms.html[{transforms-cap}] enable you to create 
 {dataframes} which can be used as the source for {dfanalytics}.
 
+experimental[]
+
 * <<dfa-outlier-detection>>
 * <<ml-dfanalytics-evaluate>>
 * <<ml-dfanalytics-apis>>


### PR DESCRIPTION
This PR backports the following commit to the 7.3 branch (in a slightly changed form, as regression analysis is not available in 7.3):

[DOCS] Marks DFA and the related analytics types as experimental feataures #619