### PR TITLE
[7.3] [DOCS] Revamps Data Frame Analytics section

### DIFF
--- a/docs/en/stack/ml/df-analytics/dfa-outlierdetection.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-outlierdetection.asciidoc
@@ -1,6 +1,6 @@
 [role="xpack"]
 [[dfa-outlier-detection]]
-== {oldetection-cap}
+=== {oldetection-cap}
 
 experimental[]
 
@@ -12,6 +12,10 @@ We use unsupervised {oldetection} which means there is no need to provide a
 training data set to teach {oldetection} to recognize outliers. Unsupervised 
 {oldetection} uses various machine learning techniques to find which data points 
 are unusual compared to the majority of the data points.
+
+[discrete]
+[[dfa-outlier-algorithms]]
+==== {oldetection-cap} algorithms
 
 In the {stack}, we use an ensemble of four different distance and density based 
 {oldetection} methods. By default, you don't need to select the methods or 
@@ -68,7 +72,7 @@ altered data.
 
 [discrete]
 [[dfa-feature-influence]]
-=== Feature influence
+==== Feature influence
 
 Besides the {olscore}, another value is calculated during {oldetection}: 
 the feature influence score. As we mentioned, there are multiple features of a 

--- a/docs/en/stack/ml/df-analytics/evaluatedf-api.asciidoc
+++ b/docs/en/stack/ml/df-analytics/evaluatedf-api.asciidoc
@@ -1,6 +1,6 @@
 [role="xpack"]
 [[ml-dfanalytics-evaluate]]
-== Evaluating {dfanalytics}
+=== Evaluating {dfanalytics}
 
 experimental[]
 
@@ -26,7 +26,7 @@ this manually provided ground truth.
 
 [discrete]
 [[ml-dfanalytics-binary-soft-classification]]
-=== {binarysc-cap} evaluation
+==== {binarysc-cap} evaluation
 
 This evaluation type is suitable for analyses which calculate a probability that 
 each data point in a data set is a member of a class or not. The {binarysc} 
@@ -39,7 +39,7 @@ evaluation type offers the following metrics to evaluate the model performance:
 
 [discrete]
 [[ml-dfanalytics-confusion-matrix]]
-==== Confusion matrix
+===== Confusion matrix
 
 A confusion matrix provides four measures of how well the {dfanalytics} worked 
 on your data set:
@@ -68,7 +68,7 @@ matrix at different thresholds (by default, 0.25, 0.5, and 0.75).
 
 [discrete]
 [[ml-dfanalytics-precision-recall]]
-==== Precision and recall
+===== Precision and recall
 
 A confusion matrix is a useful measure, but it could be hard to compare the 
 results across the different algorithms. Precision and recall values
@@ -89,7 +89,7 @@ threshold levels for computing precision and recall.
 
 [discrete]
 [[ml-dfanalytics-roc]]
-==== Receiver operating characteristic curve
+===== Receiver operating characteristic curve
 
 The receiver operating characteristic (ROC) curve is a plot that represents the 
 performance of the binary classification process at different thresholds. It 

--- a/docs/en/stack/ml/df-analytics/index.asciidoc
+++ b/docs/en/stack/ml/df-analytics/index.asciidoc
@@ -4,29 +4,24 @@
 
 [partintro]
 --
-{dfanalytics-cap} enable you to perform different analyses of your data and 
-annotate it with the results. Essentially, as part of its output, {dfanalytics} 
-appends the results of the analysis to the source data. By doing this, it 
-provides additional insights into the data. The process leaves the source index 
-intact, it creates a new index that contains a copy of the source data and the 
-annotated data. You can slice and dice the data extended with the results as you 
-normally do with any other data set.
-
 IMPORTANT: Using {dfanalytics} requires source data to be structured as a two 
 dimensional "tabular" data structure, in other words a {dataframe}. 
-{ref}/transforms.html[{transforms-cap}] enable you to create 
-{dataframes} which can be used as the source for {dfanalytics}.
+{ref}/transforms.html[{transforms-cap}] enable you to create {dataframes} which 
+can be used as the source for {dfanalytics}.
 
 experimental[]
 
-* <<dfa-outlier-detection>>
-* <<ml-dfanalytics-evaluate>>
+{dfanalytics-cap} enable you to perform different analyses of your data and 
+annotate it with the results.
+
+* <<ml-dfa-overview>>
+* <<ml-dfa-concepts>>
 * <<ml-dfanalytics-apis>>
 * <<ml-dfa-limitations>>
 
 --
 
-include::dfa-outlierdetection.asciidoc[]
-include::evaluatedf-api.asciidoc[]
+include::ml-dfa-overview.asciidoc[]
+include::ml-dfa-concepts.asciidoc[]
 include::api-quickref.asciidoc[]
 include::dfanalytics-limitations.asciidoc[]

--- a/docs/en/stack/ml/df-analytics/ml-dfa-concepts.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-concepts.asciidoc
@@ -1,0 +1,12 @@
+[role="xpack"]
+[[ml-dfa-concepts]]
+== Concepts
+
+This section explains the fundamental concepts of the Elastic {ml} {dfanalytics} 
+feature and the corresponding {evaluatedf-api}.
+
+* <<dfa-outlier-detection>>
+* <<ml-dfanalytics-evaluate>>
+
+include::dfa-outlierdetection.asciidoc[]
+include::evaluatedf-api.asciidoc[]

--- a/docs/en/stack/ml/df-analytics/ml-dfa-overview.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-overview.asciidoc
@@ -1,0 +1,28 @@
+[role="xpack"]
+[[ml-dfa-overview]]
+== Overview
+
+{dfanalytics-cap} enable you to perform different analyses of your data and 
+annotate it with the results. Essentially, as part of its output, {dfanalytics} 
+appends the results of the analysis to the source data. By doing this, it 
+provides additional insights into the data. The process leaves the source index 
+intact, it creates a new index that contains a copy of the source data and the 
+annotated data. You can slice and dice the data extended with the results as you 
+normally do with any other data set.
+
+You can evaluate the {dfanalytics} performance by using the {evaluatedf-api} 
+against a marked up data set. It helps you understand error distributions and 
+identifies the points where the {dfanalytics} model performs well or less 
+trustworthily.
+
+For the available types of {dfanalytics} and the evaluation methods, consult the 
+table below.
+
+
+[width="50%"]
+.{dfanalytics-cap} overview table
+|===
+| Type of {dfanalytics}     | Learning type | Evaluation type
+
+| {oldetection}             | unsupervised  | {binarysc}
+|===


### PR DESCRIPTION
This PR backports the changes of the following commit: 

[DOCS] Revamps Data Fame Analytics section #613

Preview: http://stack-docs_635.docs-preview.app.elstc.co/guide/en/elastic-stack-overview/7.3/index.html