### PR TITLE
[DOCS] Adds classification and classification evaluation conceptual documentation

### DIFF
--- a/docs/en/stack/ml/df-analytics/dfa-classification.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-classification.asciidoc
@@ -5,17 +5,17 @@
 experimental[]
 
 {classification-cap} is a {ml} process for predicting the class or category of a 
-given datapoint in a dataset. Typical examples for {classification} problems are 
+given data point in a dataset. Typical examples of {classification} problems are 
 predicting loan risk, classifying music, or detecting cancer in a DNA sequence. 
-In the first case for example, our dataset consists of data on loan applicants 
+In the first case, for example, our dataset consists of data on loan applicants 
 that covers investment history, employment status, debit status, and so on. 
-Based on the historical data, the {classification} analysis predicts whether it 
-is safe or risky to lend money to a given loan applicant. In the second case, 
-the data we have represents songs and the analysis – based on the features of 
-the data points – classifies the songs as hip-hop, country, classical, or any 
-other genre that available in the set of categories we have. Therefore, 
+Based on historical data, the {classification} analysis predicts whether it is 
+safe or risky to lend money to a given loan applicant. In the second case, the 
+data we have represents songs and the analysis – based on the features of the 
+data points – classifies the songs as hip-hop, country, classical, or any 
+other genres available in the set of categories we have. Therefore, 
 {classification} is for predicting discrete, categorical values, unlike 
-{regression} which predicts continuous, numerical values.
+{reganalysis} which predicts continuous, numerical values.
 
 From the perspective of the possible output, there are two types of 
 {classification}: binary and multi-class {classification}. In binary 
@@ -24,7 +24,7 @@ The loan example above is a binary {classification} problem where the two
 potential outputs are `safe` or `risky`. The music classification problem is an 
 example of multi-class {classification} where there are many different potential 
 outputs; one for every possible music genre. In the {version} version of the 
-{stack}, you can perform binary {classification} analysis.
+{stack}, you can perform binary {classanalysis}.
 
 
 [discrete]
@@ -45,8 +45,8 @@ supported in the {feature-var} fields.
 ==== Training the {classification} algorithm
 
 {classification-cap} – just like {regression} – is a supervised {ml} process. It 
-means that you need to supply a labeled training dataset that has some feature 
-variables and a {depvar}. The {classification} algorithm learns the 
+means that you need to supply a labeled training dataset that has some 
+{feature-vars} and a {depvar}. The {classification} algorithm learns the 
 relationships between the features and the {depvar}. Once you’ve trained the 
 model on your training dataset, you can reuse the knowledge that the model has 
 learned about the relationships between the data points to classify new data.
@@ -70,10 +70,9 @@ You can measure how well the model has performed on your dataset by using the
 `classification` evaluation type of the 
 {ref}/evaluate-dfanalytics.html[evaluate {dfanalytics} API]. The metric that the 
 evaluation provides you is the multi-class confusion matrix which tells you how 
-many times a given datapoint that belongs to a given class was classified 
-correctly with its class and incorrectly with another class. In other words, how 
-many times your datapoint that belongs to the X class was mistakenly classified 
-as Y.
+many times a given data point that belongs to a given class was classified 
+correctly and incorrectly. In other words, how many times your data point that 
+belongs to the X class was mistakenly classified as Y.
 
 Another crucial measurement is how well your model performs on unseen data 
 points. To assess how well the trained model will perform on data it has never 

--- a/docs/en/stack/ml/df-analytics/dfa-classification.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-classification.asciidoc
@@ -1,0 +1,84 @@
+[role="xpack"]
+[[dfa-classification]]
+=== {classification-cap}
+
+experimental[]
+
+{classification-cap} is a {ml} process for predicting the class or category of a 
+given datapoint in a dataset. Typical examples for {classification} problems are 
+predicting loan risk, classifying music, or detecting cancer in a DNA sequence. 
+In the first case for example, our dataset consists of data on loan applicants 
+that covers investment history, employment status, debit status, and so on. 
+Based on the historical data, the {classification} analysis predicts whether it 
+is safe or risky to lend money to a given loan applicant. In the second case, 
+the data we have represents songs and the analysis – based on the features of 
+the data points – classifies the songs as hip-hop, country, classical, or any 
+other genre that available in the set of categories we have. Therefore, 
+{classification} is for predicting discrete, categorical values, unlike 
+{regression} which predicts continuous, numerical values.
+
+From the perspective of the possible output, there are two types of 
+{classification}: binary and multi-class {classification}. In binary 
+{classification} the variable you want to predict has only two potential values. 
+The loan example above is a binary {classification} problem where the two 
+potential outputs are `safe` or `risky`. The music classification problem is an 
+example of multi-class {classification} where there are many different potential 
+outputs; one for every possible music genre. In the {version} version of the 
+{stack}, you can perform binary {classification} analysis.
+
+
+[discrete]
+[[dfa-classification-features]]
+==== {feature-vars-cap}
+
+When you perform {classification}, you must identify a subset of fields that you 
+want to use to create a model for predicting another field value. We refer to 
+these fields as _{feature-vars}_ and _{depvar}_, respectively. 
+{feature-vars-cap} are the values that the {depvar} value depends on. There are 
+three different types of {feature-vars} that you can use with our 
+{classification} algorithm: numerical, categorical, and boolean. Arrays are not 
+supported in the {feature-var} fields.
+
+
+[discrete]
+[[dfa-classification-supervised]]
+==== Training the {classification} algorithm
+
+{classification-cap} – just like {regression} – is a supervised {ml} process. It 
+means that you need to supply a labeled training dataset that has some feature 
+variables and a {depvar}. The {classification} algorithm learns the 
+relationships between the features and the {depvar}. Once you’ve trained the 
+model on your training dataset, you can reuse the knowledge that the model has 
+learned about the relationships between the data points to classify new data.
+
+
+[discrete]
+[[dfa-classification-model]]
+===== {classification-cap} models
+
+The ensemble algorithm that we use in the {stack} is a type of boosting called 
+boosted tree regression model which combines multiple weak models into a 
+composite one. We use decision trees to learn to predict the probability that 
+a feature belongs to a certain class.
+
+
+[discrete]
+[[dfa-classification-evaluation]]
+==== Measuring model performance
+
+You can measure how well the model has performed on your dataset by using the 
+`classification` evaluation type of the 
+{ref}/evaluate-dfanalytics.html[evaluate {dfanalytics} API]. The metric that the 
+evaluation provides you is the multi-class confusion matrix which tells you how 
+many times a given datapoint that belongs to a given class was classified 
+correctly with its class and incorrectly with another class. In other words, how 
+many times your datapoint that belongs to the X class was mistakenly classified 
+as Y.
+
+Another crucial measurement is how well your model performs on unseen data 
+points. To assess how well the trained model will perform on data it has never 
+seen before, you must set aside a proportion of the training dataset for 
+testing. This split of the dataset is the testing dataset. Once the model has 
+been trained, you can let the model predict the value of the data points it has 
+never seen before and compare the prediction to the actual value by using the 
+evaluate {dfanalytics} API.

--- a/docs/en/stack/ml/df-analytics/dfa-classification.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-classification.asciidoc
@@ -59,7 +59,7 @@ learned about the relationships between the data points to classify new data.
 The ensemble algorithm that we use in the {stack} is a type of boosting called 
 boosted tree regression model which combines multiple weak models into a 
 composite one. We use decision trees to learn to predict the probability that 
-a feature belongs to a certain class.
+a data point belongs to a certain class.
 
 
 [discrete]

--- a/docs/en/stack/ml/df-analytics/evaluatedf-api.asciidoc
+++ b/docs/en/stack/ml/df-analytics/evaluatedf-api.asciidoc
@@ -119,10 +119,10 @@ performance:
 [[ml-dfanalytics-mse]]
 ===== Mean squared error
 
-The API provides a MSE by computing the 
-average squared sum of the difference between the true value and the value that 
-the {regression} model predicted. (Avg (predicted value-actual value)^2^).
-You can use the MSE to measure how well the {reganalysis} model is performing.
+The API provides a MSE by computing the average squared sum of the difference 
+between the true value and the value that the {regression} model predicted. 
+(Avg (predicted value-actual value)^2^). You can use the MSE to measure how well 
+the {reganalysis} model is performing.
 
 
 [discrete]
@@ -131,8 +131,31 @@ You can use the MSE to measure how well the {reganalysis} model is performing.
 
 Another evaluation metrics for {reganalysis} is R-squared (R^2^). It represents 
 the goodness of fit and measures how much of the variation in the data the 
-predictions are able to explain. The value of R^2^ are less than or equal to 1, where 1 
-indicates that the predictions and true values are equal. A value of 0 is 
-obtained when all the predictions are set to the mean of the true values. A 
+predictions are able to explain. The value of R^2^ are less than or equal to 1, 
+where 1 indicates that the predictions and true values are equal. A value of 0 
+is obtained when all the predictions are set to the mean of the true values. A 
 value of 0.5 for R^2^ would indicate that, the predictions are 1 - 0.5^(1/2)^ 
 (about 30%) closer to true values than their mean.
+
+
+[discrete]
+[[ml-dfanalytics-classification]]
+==== {classification-cap} evaluation
+
+This evaluation type is suitable for evaluating {classification} models. In the 
+{version} version of the {stack}, {classification} evaluation handles two 
+classes. The {classification} evaluation offers the following metrics to 
+evaluate the model performance:
+
+* Multi-class confusion matrix
+
+
+[discrete]
+[[ml-dfanalytics-mccm]]
+===== Multi-class confusion matrix
+
+The multi-class confusion matrix contains the number of occurrences where the 
+analysis classified data points correctly with their actual class as well as the 
+number of occurrences where it misclassified them with another class. This way, 
+the multi-class confusion matrix provides a summary about the performance of the 
+{classification} analysis.

--- a/docs/en/stack/ml/df-analytics/evaluatedf-api.asciidoc
+++ b/docs/en/stack/ml/df-analytics/evaluatedf-api.asciidoc
@@ -156,6 +156,6 @@ evaluate the model performance:
 
 The multi-class confusion matrix contains the number of occurrences where the 
 analysis classified data points correctly with their actual class as well as the 
-number of occurrences where it misclassified them with another class. This way, 
-the multi-class confusion matrix provides a summary about the performance of the 
+number of occurrences where it misclassified them with another class. The 
+multi-class confusion matrix provides a summary about the performance of the 
 {classification} analysis.

--- a/docs/en/stack/ml/df-analytics/ml-dfa-concepts.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-concepts.asciidoc
@@ -7,8 +7,10 @@ feature and the corresponding {evaluatedf-api}.
 
 * <<dfa-outlier-detection>>
 * <<dfa-regression>>
+* <<dfa-classification>>
 * <<ml-dfanalytics-evaluate>>
 
 include::dfa-outlierdetection.asciidoc[]
 include::dfa-regression.asciidoc[]
+include::dfa-classification.asciidoc[]
 include::evaluatedf-api.asciidoc[]

--- a/docs/en/stack/ml/df-analytics/ml-dfa-overview.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-overview.asciidoc
@@ -22,9 +22,10 @@ table below.
 [width="50%"]
 .{dfanalytics-cap} overview table
 |===
-| Type of {dfanalytics}     | Learning type | Evaluation type
+| {dfanalytics-cap} type    | Learning type | Evaluation type
 
 | {oldetection}             | unsupervised  | {binarysc}
 | {regression}              | supervised    | {regression}
+| {classification}          | supervised    | {classification}
 |===
 


### PR DESCRIPTION
This PR adds classification conceptual documentation to the data frame analytics docs.

Related issue: https://github.com/elastic/stack-docs/issues/629

Depends on https://github.com/elastic/docs/pull/1260 (attributes)