### PR TITLE
Use new repo path attributes

### DIFF
--- a/docs/en/getting-started/index.asciidoc
+++ b/docs/en/getting-started/index.asciidoc
@@ -11,11 +11,8 @@
 :blog-ref:          https://www.elastic.co/blog/
 :wikipedia:         https://en.wikipedia.org/wiki
 
-:kib-repo-dir:      {docdir}/../../../../kibana/docs
-:xes-repo-dir:      {docdir}/../../../../elasticsearch/x-pack/docs/en
-
-include::{asciidoc-dir}/../../shared/versions/stack/{source_branch}.asciidoc[]
-include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
+include::{docs-root}/shared/versions/stack/{source_branch}.asciidoc[]
+include::{docs-root}/shared/attributes.asciidoc[]
 
 include::get-started-stack.asciidoc[]
 include::get-started-docker.asciidoc[]

--- a/docs/en/gke-on-prem/index.asciidoc
+++ b/docs/en/gke-on-prem/index.asciidoc
@@ -1,5 +1,5 @@
-include::{asciidoc-dir}/../../shared/versions/stack/{source_branch}.asciidoc[]
-include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
+include::{docs-root}/shared/versions/stack/{source_branch}.asciidoc[]
+include::{docs-root}/shared/attributes.asciidoc[]
 
 :gke: https://cloud.google.com/gke-on-prem/
 :elasticgetstarted: {stack-gs}/get-started-elastic-stack.html

--- a/docs/en/glossary/glossary.asciidoc
+++ b/docs/en/glossary/glossary.asciidoc
@@ -38,7 +38,7 @@ ifdef::elasticsearch-terms[]
 [[glossary-analysis]] analysis ::
 +
 --
-include::{es-repo-dir}/glossary.asciidoc[tag=analysis-def]
+include::{es-glossary}[tag=analysis-def]
 --
 
 endif::elasticsearch-terms[]
@@ -102,7 +102,7 @@ ifdef::elasticsearch-terms,cloud-terms[]
 [[glossary-cluster]] cluster ::
 +
 --
-include::{es-repo-dir}/glossary.asciidoc[tag=cluster-def]
+include::{es-glossary}[tag=cluster-def]
 --
 
 endif::elasticsearch-terms,cloud-terms[]
@@ -167,7 +167,7 @@ ifdef::xpack-terms[]
 [[glossary-ccr]] {ccr} (CCR)::
 +
 --
-include::{es-repo-dir}/glossary.asciidoc[tag=ccr-def]
+include::{es-glossary}[tag=ccr-def]
 --
 
 endif::xpack-terms[]
@@ -175,7 +175,7 @@ ifdef::elasticsearch-terms[]
 [[glossary-ccs]] {ccs} (CCS)::
 +
 --
-include::{es-repo-dir}/glossary.asciidoc[tag=ccs-def]
+include::{es-glossary}[tag=ccs-def]
 --
 
 endif::elasticsearch-terms[]
@@ -215,7 +215,7 @@ ifdef::elasticsearch-terms[]
 [[glossary-document]] document ::
 +
 --
-include::{es-repo-dir}/glossary.asciidoc[tag=document-def]
+include::{es-glossary}[tag=document-def]
 --
 
 endif::elasticsearch-terms[]
@@ -242,7 +242,7 @@ ifdef::elasticsearch-terms,logstash-terms[]
 [[glossary-field]] field ::
 +
 --
-include::{es-repo-dir}/glossary.asciidoc[tag=field-def]
+include::{es-glossary}[tag=field-def]
 
 
 ifdef::elasticsearch-terms,logstash-terms[]
@@ -274,7 +274,7 @@ ifdef::elasticsearch-terms[]
 [[glossary-filter]] filter ::
 +
 --
-include::{es-repo-dir}/glossary.asciidoc[tag=filter-def]
+include::{es-glossary}[tag=filter-def]
 --
 
 endif::elasticsearch-terms[]
@@ -295,7 +295,7 @@ ifdef::xpack-terms[]
 [[glossary-follower-index]] follower index ::  
 +
 --
-include::{es-repo-dir}/glossary.asciidoc[tag=follower-index-def]
+include::{es-glossary}[tag=follower-index-def]
 --
 
 endif::xpack-terms[]
@@ -324,7 +324,7 @@ ifdef::elasticsearch-terms[]
 [[glossary-id]] ID ::
 +
 --
-include::{es-repo-dir}/glossary.asciidoc[tag=id-def]
+include::{es-glossary}[tag=id-def]
 --
 
 endif::elasticsearch-terms[]
@@ -333,7 +333,7 @@ ifdef::elasticsearch-terms[]
 [[glossary-index]] index ::
 +
 --
-include::{es-repo-dir}/glossary.asciidoc[tag=index-def]
+include::{es-glossary}[tag=index-def]
 --
 
 endif::elasticsearch-terms[]
@@ -342,7 +342,7 @@ ifdef::elasticsearch-terms[]
 [[glossary-index-alias]] index alias ::
 +
 --
-include::{es-repo-dir}/glossary.asciidoc[tag=index-alias-def]
+include::{es-glossary}[tag=index-alias-def]
 --
 
 endif::elasticsearch-terms[]
@@ -380,7 +380,7 @@ ifdef::xpack-terms[]
 [[glossary-leader-index]] leader index ::  
 +
 --
-include::{es-repo-dir}/glossary.asciidoc[tag=leader-index-def]
+include::{es-glossary}[tag=leader-index-def]
 --
 
 endif::xpack-terms[]
@@ -401,7 +401,7 @@ ifdef::elasticsearch-terms[]
 [[glossary-mapping]] mapping ::
 +
 --
-include::{es-repo-dir}/glossary.asciidoc[tag=mapping-def]
+include::{es-glossary}[tag=mapping-def]
 --
 
 endif::elasticsearch-terms[]
@@ -432,7 +432,7 @@ ifdef::elasticsearch-terms,cloud-terms[]
 [[glossary-node]] node ::
 +
 --
-include::{es-repo-dir}/glossary.asciidoc[tag=node-def]
+include::{es-glossary}[tag=node-def]
 --
 
 endif::elasticsearch-terms,cloud-terms[]
@@ -505,7 +505,7 @@ ifdef::elasticsearch-terms[]
 [[glossary-primary-shard]] primary shard ::
 +
 --
-include::{es-repo-dir}/glossary.asciidoc[tag=primary-shard-def]
+include::{es-glossary}[tag=primary-shard-def]
 --
 
 endif::elasticsearch-terms[]
@@ -523,7 +523,7 @@ ifdef::elasticsearch-terms[]
 [[glossary-query]] query ::
 +
 --
-include::{es-repo-dir}/glossary.asciidoc[tag=query-def]
+include::{es-glossary}[tag=query-def]
 --
 
 endif::elasticsearch-terms[]
@@ -532,7 +532,7 @@ ifdef::elasticsearch-terms[]
 [[glossary-recovery]] recovery ::
 +
 --
-include::{es-repo-dir}/glossary.asciidoc[tag=recovery-def]
+include::{es-glossary}[tag=recovery-def]
 --
 
 endif::elasticsearch-terms[]
@@ -541,7 +541,7 @@ ifdef::elasticsearch-terms[]
 [[glossary-reindex]] reindex ::
 +
 --
-include::{es-repo-dir}/glossary.asciidoc[tag=reindex-def]
+include::{es-glossary}[tag=reindex-def]
 --
 
 endif::elasticsearch-terms[]
@@ -550,7 +550,7 @@ ifdef::elasticsearch-terms[]
 [[glossary-replica-shard]] replica shard ::
 +
 --
-include::{es-repo-dir}/glossary.asciidoc[tag=replica-shard-def]
+include::{es-glossary}[tag=replica-shard-def]
 --
 
 endif::elasticsearch-terms[]
@@ -570,7 +570,7 @@ ifdef::elasticsearch-terms[]
 [[glossary-routing]] routing ::
 +
 --
-include::{es-repo-dir}/glossary.asciidoc[tag=routing-def]
+include::{es-glossary}[tag=routing-def]
 --
 
 endif::elasticsearch-terms[]
@@ -597,7 +597,7 @@ ifdef::elasticsearch-terms[]
 [[glossary-shard]] shard ::
 +
 --
-include::{es-repo-dir}/glossary.asciidoc[tag=shard-def]
+include::{es-glossary}[tag=shard-def]
 --
 
 endif::elasticsearch-terms[]
@@ -615,7 +615,7 @@ ifdef::elasticsearch-terms[]
 [[glossary-shrink]] shrink ::
 +
 --
-include::{es-repo-dir}/glossary.asciidoc[tag=shrink-def]
+include::{es-glossary}[tag=shrink-def]
 --
 
 endif::elasticsearch-terms[]
@@ -624,7 +624,7 @@ ifdef::elasticsearch-terms[]
 [[glossary-source_field]] source field ::
 +
 --
-include::{es-repo-dir}/glossary.asciidoc[tag=source-field-def]
+include::{es-glossary}[tag=source-field-def]
 --
 
 endif::elasticsearch-terms[]
@@ -633,7 +633,7 @@ ifdef::elasticsearch-terms[]
 [[glossary-split]] split ::
 +
 --
-include::{es-repo-dir}/glossary.asciidoc[tag=split-def]
+include::{es-glossary}[tag=split-def]
 --
 
 endif::elasticsearch-terms[]
@@ -650,7 +650,7 @@ ifdef::elasticsearch-terms[]
 [[glossary-term]] term ::
 +
 --
-include::{es-repo-dir}/glossary.asciidoc[tag=term-def]
+include::{es-glossary}[tag=term-def]
 --
 
 endif::elasticsearch-terms[]
@@ -659,7 +659,7 @@ ifdef::elasticsearch-terms[]
 [[glossary-text]] text ::
 +
 --
-include::{es-repo-dir}/glossary.asciidoc[tag=text-def]
+include::{es-glossary}[tag=text-def]
 --
 
 endif::elasticsearch-terms[]
@@ -668,7 +668,7 @@ ifdef::elasticsearch-terms[]
 [[glossary-type]] type ::
 +
 --
-include::{es-repo-dir}/glossary.asciidoc[tag=type-def]
+include::{es-glossary}[tag=type-def]
 --
 
 endif::elasticsearch-terms[]

--- a/docs/en/glossary/index.asciidoc
+++ b/docs/en/glossary/index.asciidoc
@@ -6,10 +6,10 @@
 :logstash-terms:       true
 :xpack-terms:          true
 
-include::{asciidoc-dir}/../../shared/versions/stack/{source_branch}.asciidoc[]
-include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
+include::{docs-root}/shared/versions/stack/{source_branch}.asciidoc[]
+include::{docs-root}/shared/attributes.asciidoc[]
 
-:es-repo-dir:          {docdir}/../../../../elasticsearch/docs/reference
+:es-glossary:          {elasticsearch-reference}/glossary.asciidoc
 
 include::intro.asciidoc[]
 include::glossary.asciidoc[]

--- a/docs/en/infraops/index.asciidoc
+++ b/docs/en/infraops/index.asciidoc
@@ -5,9 +5,8 @@
 
 = Infrastructure Monitoring Guide
 
-include::{asciidoc-dir}/../../shared/versions/stack/{source_branch}.asciidoc[]
-
-include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
+include::{docs-root}/shared/versions/stack/{source_branch}.asciidoc[]
+include::{docs-root}/shared/attributes.asciidoc[]
 
 include::overview.asciidoc[]
 

--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -33,7 +33,7 @@ coming[8.0.0]
 This list summarizes the most important breaking changes in APM. 
 For the complete list, go to {apm-get-started-ref}/apm-breaking-changes.html[APM breaking changes].
 
-include::{apm-repo-dir}/apm-breaking-changes.asciidoc[tag=notable-v8-breaking-changes]
+include::{apm-server-root}/docs/guide/apm-breaking-changes.asciidoc[tag=notable-v8-breaking-changes]
 
 [[beats-breaking-changes]]
 === Beats breaking changes
@@ -46,7 +46,7 @@ coming[8.0.0]
 This list summarizes the most important breaking changes in Beats. 
 For the complete list, go to {beats-ref}/breaking-changes.html[Beats breaking changes].
 
-include::{beats-repo-dir}/breaking-8.0.asciidoc[tag=notable-breaking-changes]
+include::{beats-root}/libbeat/docs/breaking-8.0.asciidoc[tag=notable-breaking-changes]
 
 
 [[elasticsearch-breaking-changes]]
@@ -61,18 +61,18 @@ coming[8.0.0]
 This list summarizes the most important breaking changes in {es} {version}. For
 the complete list, go to {ref}/breaking-changes.html[{es} breaking changes].
 
-include::{es-repo-dir}/reference/migration/migrate_8_0.asciidoc[tag=notable-breaking-changes]
-include::{es-repo-dir}/reference/migration/migrate_8_0/analysis.asciidoc[tag=notable-breaking-changes]
-include::{es-repo-dir}/reference/migration/migrate_8_0/discovery.asciidoc[tag=notable-breaking-changes]
-include::{es-repo-dir}/reference/migration/migrate_8_0/http.asciidoc[tag=notable-breaking-changes]
-include::{es-repo-dir}/reference/migration/migrate_8_0/ilm.asciidoc[tag=notable-breaking-changes]
-include::{es-repo-dir}/reference/migration/migrate_8_0/java.asciidoc[tag=notable-breaking-changes]
-include::{es-repo-dir}/reference/migration/migrate_8_0/mappings.asciidoc[tag=notable-breaking-changes]
-include::{es-repo-dir}/reference/migration/migrate_8_0/network.asciidoc[tag=notable-breaking-changes]
-include::{es-repo-dir}/reference/migration/migrate_8_0/packaging.asciidoc[tag=notable-breaking-changes]
-include::{es-repo-dir}/reference/migration/migrate_8_0/security.asciidoc[tag=notable-breaking-changes]
-include::{es-repo-dir}/reference/migration/migrate_8_0/snapshots.asciidoc[tag=notable-breaking-changes]
-include::{es-repo-dir}/reference/migration/migrate_8_0/transport.asciidoc[tag=notable-breaking-changes]
+include::{elasticsearch-reference}/migration/migrate_8_0.asciidoc[tag=notable-breaking-changes]
+include::{elasticsearch-reference}/migration/migrate_8_0/analysis.asciidoc[tag=notable-breaking-changes]
+include::{elasticsearch-reference}/migration/migrate_8_0/discovery.asciidoc[tag=notable-breaking-changes]
+include::{elasticsearch-reference}/migration/migrate_8_0/http.asciidoc[tag=notable-breaking-changes]
+include::{elasticsearch-reference}/migration/migrate_8_0/ilm.asciidoc[tag=notable-breaking-changes]
+include::{elasticsearch-reference}/migration/migrate_8_0/java.asciidoc[tag=notable-breaking-changes]
+include::{elasticsearch-reference}/migration/migrate_8_0/mappings.asciidoc[tag=notable-breaking-changes]
+include::{elasticsearch-reference}/migration/migrate_8_0/network.asciidoc[tag=notable-breaking-changes]
+include::{elasticsearch-reference}/migration/migrate_8_0/packaging.asciidoc[tag=notable-breaking-changes]
+include::{elasticsearch-reference}/migration/migrate_8_0/security.asciidoc[tag=notable-breaking-changes]
+include::{elasticsearch-reference}/migration/migrate_8_0/snapshots.asciidoc[tag=notable-breaking-changes]
+include::{elasticsearch-reference}/migration/migrate_8_0/transport.asciidoc[tag=notable-breaking-changes]
 
 [[elasticsearch-hadoop-breaking-changes]]
 === {es} Hadoop breaking changes
@@ -87,7 +87,7 @@ This list summarizes the most important breaking changes in {es} Hadoop {version
 For the complete list, go to
 {hadoop-ref}/breaking-changes.html[Elasticsearch Hadoop breaking changes].
 
-include::{hadoop-repo-dir}/appendix/breaking.adoc[tag=notable-v8-breaking-changes]
+include::{elasticsearch-hadoop-root}/docs/src/reference/asciidoc/appendix/breaking.adoc[tag=notable-v8-breaking-changes]
 
 [[kibana-breaking-changes]]
 === {kib} breaking changes
@@ -101,7 +101,7 @@ coming[8.0.0]
 This list summarizes the most important breaking changes in {kib} {version}. For
 the complete list, go to {kibana-ref}/breaking-changes.html[{kib} breaking changes].
 
-include::{kib-repo-dir}/migration/migrate_8_0.asciidoc[tag=notable-breaking-changes]
+include::{kibana-root}/docs/migration/migrate_8_0.asciidoc[tag=notable-breaking-changes]
 
 [[logstash-breaking-changes]]
 === {ls} breaking changes
@@ -116,5 +116,5 @@ This list summarizes the most important breaking changes in {ls} {version}. For
 the complete list, go to
 {logstash-ref}/breaking-changes.html[Logstash breaking changes].
 
-include::{ls-repo-dir}/static/breaking-changes.asciidoc[tag=notable-breaking-changes]
+include::{logstash-root}/docs/static/breaking-changes.asciidoc[tag=notable-breaking-changes]
 

--- a/docs/en/install-upgrade/highlights.asciidoc
+++ b/docs/en/install-upgrade/highlights.asciidoc
@@ -21,7 +21,7 @@ This list summarizes the most important enhancements in APM.
 For the complete list, go to
 {apm-get-started-ref}/apm-release-notes.html[APM release highlights].
 
-include::{apm-repo-dir}/apm-release-notes.asciidoc[tag=notable-v8-highlights]
+include::{apm-server-root}/docs/guide/apm-release-notes.asciidoc[tag=notable-v8-highlights]
 
 
 [[beats-highlights]]
@@ -35,7 +35,7 @@ coming[8.0.0]
 This list summarizes the most important enhancements in Beats.
 For the complete list, go to {beats-ref}/release-highlights.html[Beats release highlights].
 
-//include::{beats-repo-dir}/highlights-8.0.0.asciidoc[tag=notable-highlights]
+//include::{beats-root}/libbeat/docs/highlights-8.0.0.asciidoc[tag=notable-highlights]
 
 [[elasticsearch-highlights]]
 === {es} highlights
@@ -51,7 +51,7 @@ For the complete list, go to {ref}/release-highlights.html[{es} release highligh
 
 :leveloffset: +1
 
-include::{es-repo-dir}/reference/release-notes/highlights-8.0.0.asciidoc[tag=notable-highlights]
+include::{elasticsearch-reference}/release-notes/highlights-8.0.0.asciidoc[tag=notable-highlights]
 
 :leveloffset: -1
 
@@ -68,6 +68,6 @@ This list summarizes the most important enhancements in {kib} {version}.
 
 :leveloffset: +1
 
-include::{kib-repo-dir}/release-notes/highlights-8.0.0.asciidoc[tag=notable-highlights]
+include::{kibana-root}/docs/release-notes/highlights-8.0.0.asciidoc[tag=notable-highlights]
 
 :leveloffset: -1

--- a/docs/en/install-upgrade/index.asciidoc
+++ b/docs/en/install-upgrade/index.asciidoc
@@ -1,15 +1,8 @@
 [[elastic-stack]]
 = Installation and Upgrade Guide
 
-:apm-repo-dir:       {docdir}/../../../../apm-server/docs/guide
-:beats-repo-dir:     {docdir}/../../../../beats/libbeat/docs
-:es-repo-dir:        {docdir}/../../../../elasticsearch/docs
-:hadoop-repo-dir:    {docdir}/../../../../elasticsearch-hadoop/docs/src/reference/asciidoc
-:kib-repo-dir:       {docdir}/../../../../kibana/docs
-:ls-repo-dir:        {docdir}/../../../../logstash/docs
-
-include::{asciidoc-dir}/../../shared/versions/stack/{source_branch}.asciidoc[]
-include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
+include::{docs-root}/shared/versions/stack/{source_branch}.asciidoc[]
+include::{docs-root}/shared/attributes.asciidoc[]
 
 include::overview.asciidoc[]
 

--- a/docs/en/siem/index.asciidoc
+++ b/docs/en/siem/index.asciidoc
@@ -6,9 +6,8 @@
 
 = SIEM Guide (Beta)
 
-include::{asciidoc-dir}/../../shared/versions/stack/{source_branch}.asciidoc[]
-
-include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
+include::{docs-root}/shared/versions/stack/{source_branch}.asciidoc[]
+include::{docs-root}/shared/attributes.asciidoc[]
 
 include::overview.asciidoc[]
 

--- a/docs/en/stack/index.asciidoc
+++ b/docs/en/stack/index.asciidoc
@@ -10,13 +10,8 @@
 :blog-ref:          https://www.elastic.co/blog/
 :wikipedia:         https://en.wikipedia.org/wiki
 
-:kib-repo-dir:      {docdir}/../../../../kibana/docs
-:xes-repo-dir:      {docdir}/../../../../elasticsearch/x-pack/docs/en
-:es-repo-dir:       {docdir}/../../../../elasticsearch/docs/reference
-:stack-repo-dir:    {docdir}
-:beats-repo-dir:    {docdir}/../../../../beats/libbeat/docs
-include::{asciidoc-dir}/../../shared/versions/stack/{source_branch}.asciidoc[]
-include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
+include::{docs-root}/shared/versions/stack/{source_branch}.asciidoc[]
+include::{docs-root}/shared/attributes.asciidoc[]
 
 include::introduction.asciidoc[]
 

--- a/docs/en/stack/ml/anomaly-detection/examples.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/examples.asciidoc
@@ -19,17 +19,17 @@ The scenarios in this section describe some best practices for generating useful
 * <<ml-configuring-transform>>
 * <<ml-delayed-data-detection>>
 
-include::{es-repo-dir}/ml/anomaly-detection/customurl.asciidoc[]
+include::{elasticsearch-reference}/ml/anomaly-detection/customurl.asciidoc[]
 
-include::{es-repo-dir}/ml/anomaly-detection/aggregations.asciidoc[]
+include::{elasticsearch-reference}/ml/anomaly-detection/aggregations.asciidoc[]
 
-include::{es-repo-dir}/ml/anomaly-detection/detector-custom-rules.asciidoc[]
+include::{elasticsearch-reference}/ml/anomaly-detection/detector-custom-rules.asciidoc[]
 
-include::{es-repo-dir}/ml/anomaly-detection/categories.asciidoc[]
+include::{elasticsearch-reference}/ml/anomaly-detection/categories.asciidoc[]
 
-include::{es-repo-dir}/ml/anomaly-detection/populations.asciidoc[]
+include::{elasticsearch-reference}/ml/anomaly-detection/populations.asciidoc[]
 
-include::{es-repo-dir}/ml/anomaly-detection/transforms.asciidoc[]
+include::{elasticsearch-reference}/ml/anomaly-detection/transforms.asciidoc[]
 
-include::{es-repo-dir}/ml/anomaly-detection/delayed-data-detection.asciidoc[]
+include::{elasticsearch-reference}/ml/anomaly-detection/delayed-data-detection.asciidoc[]
 

--- a/docs/en/stack/ml/anomaly-detection/index.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/index.asciidoc
@@ -30,7 +30,7 @@ include::ml-configuration.asciidoc[]
 
 include::api-quickref.asciidoc[]
 
-include::{es-repo-dir}/ml/anomaly-detection/functions.asciidoc[]
+include::{elasticsearch-reference}/ml/anomaly-detection/functions.asciidoc[]
 
 include::examples.asciidoc[]
 

--- a/docs/en/stack/ml/anomaly-detection/troubleshooting.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/troubleshooting.asciidoc
@@ -13,7 +13,7 @@ answers for frequently asked questions.
 * <<ml-jobnames>>
 * <<ml-upgradedf>>
 
-include::{stack-repo-dir}/help.asciidoc[tag=get-help]
+include::{stack-docs-root}/stack/help.asciidoc[tag=get-help]
 
 [[ml-rollingupgrade]]
 === Machine learning features unavailable after rolling upgrade

--- a/docs/en/stack/monitoring/esms.asciidoc
+++ b/docs/en/stack/monitoring/esms.asciidoc
@@ -22,7 +22,7 @@ To use {metricbeat}:
 . Enable the collection of monitoring data on your cluster.
 +
 --
-include::{es-repo-dir}/monitoring/configuring-metricbeat.asciidoc[tag=enable-collection]
+include::{elasticsearch-reference}/monitoring/configuring-metricbeat.asciidoc[tag=enable-collection]
 
 For more information about these settings, see
 {ref}/monitoring-settings.html[Monitoring settings in {es}].
@@ -31,7 +31,7 @@ For more information about these settings, see
 . Disable the default collection of {es} monitoring metrics.
 +
 --
-include::{es-repo-dir}/monitoring/configuring-metricbeat.asciidoc[tag=disable-default-collection]
+include::{elasticsearch-reference}/monitoring/configuring-metricbeat.asciidoc[tag=disable-default-collection]
 --
 
 . {metricbeat-ref}/metricbeat-installation.html[Install {metricbeat}] on each
@@ -40,21 +40,21 @@ node.
 . Enable the {es} {xpack} module in {metricbeat} on each node. +
 +
 --
-include::{es-repo-dir}/monitoring/configuring-metricbeat.asciidoc[tag=enable-es-module]
+include::{elasticsearch-reference}/monitoring/configuring-metricbeat.asciidoc[tag=enable-es-module]
 --
 
 . Configure the {es} {xpack} module in {metricbeat} on each node. +
 +
 --
-include::{es-repo-dir}/monitoring/configuring-metricbeat.asciidoc[tag=configure-es-module]
+include::{elasticsearch-reference}/monitoring/configuring-metricbeat.asciidoc[tag=configure-es-module]
 
-include::{es-repo-dir}/monitoring/configuring-metricbeat.asciidoc[tag=remote-monitoring-user]
+include::{elasticsearch-reference}/monitoring/configuring-metricbeat.asciidoc[tag=remote-monitoring-user]
 --
 
 . Optional: Disable the system module in {metricbeat}. +
 +
 --
-include::{es-repo-dir}/monitoring/configuring-metricbeat.asciidoc[tag=disable-system-module]
+include::{elasticsearch-reference}/monitoring/configuring-metricbeat.asciidoc[tag=disable-system-module]
 --
 
 . Identify where to send the {es} monitoring data and supply the necessary
@@ -107,7 +107,7 @@ To use {metricbeat}:
 . Disable the default collection of {kib} monitoring metrics. +
 +
 --
-include::{kib-repo-dir}/user/monitoring/monitoring-metricbeat.asciidoc[tag=disable-kibana-collection]
+include::{kibana-root}/docs/user/monitoring/monitoring-metricbeat.asciidoc[tag=disable-kibana-collection]
 
 For more information, see 
 {kibana-ref}/monitoring-settings-kb.html[Monitoring settings in {kib}].
@@ -124,21 +124,21 @@ same server as {kib}.
 . Enable the {kib} {xpack} module in {metricbeat}. +
 +
 --
-include::{kib-repo-dir}/user/monitoring/monitoring-metricbeat.asciidoc[tag=enable-kibana-module]
+include::{kibana-root}/docs/user/monitoring/monitoring-metricbeat.asciidoc[tag=enable-kibana-module]
 --
 
 . Configure the {kib} {xpack} module in {metricbeat}. +
 +
 --
-include::{kib-repo-dir}/user/monitoring/monitoring-metricbeat.asciidoc[tag=configure-kibana-module]
+include::{kibana-root}/docs/user/monitoring/monitoring-metricbeat.asciidoc[tag=configure-kibana-module]
 
-include::{kib-repo-dir}/user/monitoring/monitoring-metricbeat.asciidoc[tag=remote-monitoring-user]
+include::{kibana-root}/docs/user/monitoring/monitoring-metricbeat.asciidoc[tag=remote-monitoring-user]
 --
 
 . Optional: Disable the system module in {metricbeat}. +
 +
 --
-include::{kib-repo-dir}/user/monitoring/monitoring-metricbeat.asciidoc[tag=disable-system-module]
+include::{kibana-root}/docs/user/monitoring/monitoring-metricbeat.asciidoc[tag=disable-system-module]
 --
 
 . Identify where to send the {kib} monitoring data and supply the necessary
@@ -177,13 +177,13 @@ For example, to use {metricbeat} to monitor {beatname_uc}:
 . Enable the HTTP endpoint to allow external collection of monitoring data:
 +
 --
-include::{beats-repo-dir}/monitoring/monitoring-metricbeat.asciidoc[tag=enable-http-endpoint]
+include::{beats-root}/libbeat/docs/monitoring/monitoring-metricbeat.asciidoc[tag=enable-http-endpoint]
 --
 
 . Disable the default collection of {beatname_uc} monitoring metrics. +
 +
 --
-include::{beats-repo-dir}/monitoring/monitoring-metricbeat.asciidoc[tag=disable-beat-collection]
+include::{beats-root}/libbeat/docs/monitoring/monitoring-metricbeat.asciidoc[tag=disable-beat-collection]
 --
 
 . Start {beatname_uc}.
@@ -195,21 +195,21 @@ server, skip this step.
 . Enable the `beat-xpack` module in {metricbeat}.
 +
 --
-include::{beats-repo-dir}/monitoring/monitoring-metricbeat.asciidoc[tag=enable-beat-module]
+include::{beats-root}/libbeat/docs/monitoring/monitoring-metricbeat.asciidoc[tag=enable-beat-module]
 --
 
 . Configure the `beat-xpack` module in {metricbeat}. +
 +
 --
-include::{beats-repo-dir}/monitoring/monitoring-metricbeat.asciidoc[tag=configure-beat-module]
+include::{beats-root}/libbeat/docs/monitoring/monitoring-metricbeat.asciidoc[tag=configure-beat-module]
 
-include::{beats-repo-dir}/monitoring/monitoring-metricbeat.asciidoc[tag=remote-monitoring-user]
+include::{beats-root}/libbeat/docs/monitoring/monitoring-metricbeat.asciidoc[tag=remote-monitoring-user]
 --
 
 . Optional: Disable the system module in the {metricbeat}.
 +
 --
-include::{beats-repo-dir}/monitoring/monitoring-metricbeat.asciidoc[tag=disable-system-module]
+include::{beats-root}/libbeat/docs/monitoring/monitoring-metricbeat.asciidoc[tag=disable-system-module]
 --
 
 . Identify where to send the monitoring data and supply the necessary security

--- a/docs/en/stack/monitoring/troubleshooting.asciidoc
+++ b/docs/en/stack/monitoring/troubleshooting.asciidoc
@@ -8,7 +8,7 @@ Use the information in this section to troubleshoot common problems and find
 answers for frequently asked questions. See also
 {logstash-ref}/monitoring-troubleshooting.html[Troubleshooting monitoring in {ls}].
 
-include::{stack-repo-dir}/help.asciidoc[tag=get-help]
+include::{stack-docs-root}/stack/help.asciidoc[tag=get-help]
 
 *Symptoms*:
 There is no information about your cluster on the *Stack Monitoring* page in

--- a/docs/en/stack/xpack-settings.asciidoc
+++ b/docs/en/stack/xpack-settings.asciidoc
@@ -2,4 +2,4 @@
 [[xpack-settings]]
 === {xpack} Settings
 
-include::{asciidoc-dir}/../../shared/settings.asciidoc[]
+include::{docs-root}/shared/settings.asciidoc[]


### PR DESCRIPTION
Mostly uses `{repname-root}` instead of `../../reponame` to find the
root of repositories. Because `../../` is confusing.