### PR TITLE
[SIEM] [Docs] Adds note about map connection lines

### DIFF
--- a/docs/en/siem/siem-ui.asciidoc
+++ b/docs/en/siem/siem-ui.asciidoc
@@ -192,6 +192,9 @@ might need to:
 * <<private-network>>
 * <<map-links, Format index fields as URL links>>
 
+NOTE: To see source and destination connections lines on the map, you must
+configure `source.geo` and `dest.geo` ECS fields for your indices.
+
 [float]
 [[geoip-data]]
 ==== Add geoIP data


### PR DESCRIPTION
Adds a short note about displaying connection lines on the SIEM map.

[Preview](http://stack-docs_648.docs-preview.app.elstc.co/guide/en/siem/guide/master/conf-map-ui.html)