### PR TITLE
[DOCS] Adds regression example

### DIFF
--- a/docs/en/stack/ml/df-analytics/examples.asciidoc
+++ b/docs/en/stack/ml/df-analytics/examples.asciidoc
@@ -12,6 +12,7 @@ These examples demonstrate how to use {dfanalytics} to derive useful
 insights from your data.
 
 * <<ecommerce-outliers>>
+* <<flightdata-regression>>
 
 
 include::ecommerce-outliers.asciidoc[]

--- a/docs/en/stack/ml/df-analytics/examples.asciidoc
+++ b/docs/en/stack/ml/df-analytics/examples.asciidoc
@@ -16,3 +16,4 @@ insights from your data.
 
 
 include::ecommerce-outliers.asciidoc[]
+include::flightdata-regression.asciidoc[]

--- a/docs/en/stack/ml/df-analytics/flightdata-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/flightdata-regression.asciidoc
@@ -18,7 +18,7 @@ Nonetheless, the use case
 is relevant and it is a good example of how the quality of input data will 
 affect the quality of results.
 
-We will create an {dfanalytics-job} to predict the minutes that flights are 
+We will create a {dfanalytics-job} to predict the flights delays in minutes. 
 delayed by. Each document in the dataset contains details for a single flight, 
 so this data is ready for analysis as it is already in a two-dimensional 
 entity-based data structure that we call a {dataframe}. Depending on your source 

--- a/docs/en/stack/ml/df-analytics/flightdata-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/flightdata-regression.asciidoc
@@ -4,19 +4,17 @@
 === Predicting flight delays with {reganalysis}
 
 Let's try to predict flight delays by using the 
-{kibana-ref}/add-sample-data.html[sample flight data]. We use this data to learn 
-a {regression} model that allows us to predict flight delays based on 
+{kibana-ref}/add-sample-data.html[sample flight data]. We want to be able to use 
 information such as weather and location of the destination and origin, flight 
-distance and carrier. For example, we can predict the number of minutes delayed 
-for each flight. As it is a continuous numeric variable, we'll use {reganalysis} 
-to make the prediction.
+distance and carrier to predict the number of minutes delayed for each flight. 
+As it is a continuous numeric variable, we'll use {reganalysis} to make the 
+prediction.
 
 This dataset consists of sample data that has been manually created and it 
 contains inconsistencies. For example, a flight can be both delayed and 
 canceled. Nonetheless, the use case is relevant and it is a good example of how 
 the quality of input data will affect the quality of results.
 
-We will create a {dfanalytics-job} to predict the flights delays in minutes. 
 Each document in the dataset contains details for a single flight, so this data 
 is ready for analysis as it is already in a two-dimensional entity-based data 
 structure (_{dataframe}_). In general, you often need to 
@@ -76,7 +74,10 @@ This is an example source document from the dataset:
 {regression-cap} is a supervised machine learning analysis and therefore needs 
 to train on data that contains the ground truth for the `dependent_variable` 
 that we want to predict. In this example, the ground truth is available in each 
-document as the actual value of `FlightDelayMins`.
+document as the actual value of `FlightDelayMins`. In order to be analyzed, a 
+document must contain at least one field with a supported data type (`numeric`, 
+`boolean`, `text`, `keyword` or `ip`) and must not contain arrays with more than 
+one item.
 
 If your source data consists of some documents that contain a 
 `dependent_variable` and some that do not, the model is trained on the 
@@ -85,6 +86,11 @@ predictions are made against all of the data. The current implementation of
 {reganalysis} supports a single batch analysis for both training and 
 predictions.
 
+
+[[flightdata-regression-model]]
+==== Creating a {regression} model
+
+To predict the number of minutes delayed for each flight:
 . Create a {dfanalytics-job}.
 +
 --
@@ -145,50 +151,6 @@ exclude fields that either contain erroneous data or describe the
 <7> Specifies a memory limit for the job. If the job requires more than this 
 amount of memory, it fails to start. This makes it possible to prevent job 
 execution if the available memory on the node is limited.
-
-
-The API returns the following response:
-
-[source,console-result]
---------------------------------------------------  
-{
-  "id" : "model-flight-delays",
-  "source" : {
-    "index" : [
-      "kibana_sample_data_flights"
-    ],
-    "query" : {
-      "range" : {
-        "DistanceKilometers" : {
-          "gt" : 0
-        }
-      }
-    }
-  },
-  "dest" : {
-    "index" : "df-flight-delays",
-    "results_field" : "ml"
-  },
-  "analysis" : {
-    "regression" : {
-      "dependent_variable" : "FlightDelayMin",
-      "training_percent" : 90.0
-    }
-  },
-  "analyzed_fields" : {
-    "includes" : [ ],
-    "excludes" : [
-      "Cancelled",
-      "FlightDelay",
-      "FlightDelayType"
-    ]
-  },
-  "model_memory_limit" : "100mb",
-  "create_time" : 1571918329132,
-  "version" : "7.5.0",
-  "allow_lazy_start" : false
-}
---------------------------------------------------
 --
 
 . Start the job.
@@ -207,7 +169,7 @@ POST _ml/data_frame/analytics/model-flight-delays/_start
 
 The job takes a few minutes to run. Runtime depends on the local hardware and 
 also on the number of documents and fields that analyzed. The more fields and 
-documents, the longer the job to run.
+documents, the longer the job runs.
 --
 
 . Check the job stats to follow the progress by using the 
@@ -257,18 +219,17 @@ The API call returns the following response:
 ----  
 
 
-The job has four phases. When all the phases have completed, the job 
-state becomes `stopped` and the results are ready to view and evaluate.
+The job has four phases. When all the phases have completed, the job stops and 
+the results are ready to view and evaluate.
 --
 
 
 [[flightdata-regression-results]]
-==== Viewing results
+==== Viewing {regression} results
 
-. Use the standard {es} search command to view the results in the destination 
-index:
-+
---
+Now you have a new index that contains a copy of your source data with 
+predictions for your dependent variable. Use the standard {es} search command to 
+view the results in the destination index:
 
 [source,console]
 --------------------------------------------------
@@ -298,13 +259,6 @@ The snippet below shows a part of a document with the annotated results:
 trying to predict with the {reganalysis}.
 <2> The prediction. The field name is suffixed with `_prediction`.
 <3> Indicates that this document was not used in the training set.
-
-
-If a document doesn't contain a prediction field, then it is excluded from the 
-analysis. In order to be analyzed, a document must contain at least one field 
-with a supported data type (`numeric`, `boolean`, `text`, `keyword` or `ip`) and 
-must not contain arrays with more than one item.
---
 
 
 [[flightdata-regression-evaluate]]
@@ -375,9 +329,7 @@ POST _ml/data_frame/_evaluate
 }
 --------------------------------------------------
 // TEST[skip:TBD]
-<1> By only evaluating the data that was not used in training, we can 
-calculate the generalization error which shows the algorithm accuracy in making 
-predictions for previously unseen data.
+<1> We evaluate only the documents that are not part of the training data.
 
 
 The evaluate {dfanalytics} API returns the following response:

--- a/docs/en/stack/ml/df-analytics/flightdata-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/flightdata-regression.asciidoc
@@ -13,7 +13,7 @@ make the prediction.
 
 This dataset consists of sample data that has been manually created and it 
 contains inconsistencies. For example, a flight can be both delayed and 
-canceled. Despite the data inconsistencies, flight delays can be used to 
+canceled. 
 demonstrate {reganalysis} because it is easy to set up in Kibana, the use case 
 is relevant and it is a good example of how the quality of input data will 
 affect the quality of results.

--- a/docs/en/stack/ml/df-analytics/flightdata-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/flightdata-regression.asciidoc
@@ -228,7 +228,7 @@ state becomes `stopped` and the results are ready to view and evaluate.
 [[flightdata-regression-results]]
 ==== Viewing results
 
-.Run the following command to view the results in the destination index:
+. Run the following command to view the results in the destination index:
 +
 --
 

--- a/docs/en/stack/ml/df-analytics/flightdata-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/flightdata-regression.asciidoc
@@ -81,7 +81,7 @@ that we want to predict. In this example, the ground truth is available in each
 document as the actual value of `FlightDelayMins`.
 
 If your source data consists of some documents that contain a `dependent_variable` 
-and some that does not contain a `dependent_variable`, then training is 
+and some that do not, the model is trained
 performed on the `training_percent` of the documents that contain ground truth 
 and predictions will be made against all of the data. The current implementation 
 of {reganalysis} supports a single batch analysis for both training and 

--- a/docs/en/stack/ml/df-analytics/flightdata-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/flightdata-regression.asciidoc
@@ -22,7 +22,7 @@ We will create a {dfanalytics-job} to predict the flights delays in minutes.
 Each document in the dataset contains details for a single flight, 
 so this data is ready for analysis as it is already in a two-dimensional 
 entity-based data structure (_{dataframe}_).
-data, it may be required to first {ref}/transforms.html[transform] your source 
+In general, you often need to {ref}/transforms.html[transform] the
 data into an entity-centric index before you could setup and start the analysis.
 
 This is an example source document from the dataset:

--- a/docs/en/stack/ml/df-analytics/flightdata-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/flightdata-regression.asciidoc
@@ -16,9 +16,9 @@ We'd like to predict the number of minutes delayed for each flight. As it is a
 continuous numeric variable, we'll use {reganalysis} to make the prediction.
 
 This dataset consists of sample data that has been manually created and it 
-contains inconsistencies. For example a flight can be both delayed and 
-cancelled. However, it is easy to setup in Kibana and the use case is 
-applicable, so it is suitable to be an example. Still don't forget this is only 
+contains inconsistencies. For example, a flight can be both delayed and 
+canceled. However, it is easy to set up in Kibana and the use case is 
+applicable, so it is suitable to be an example. Still, don't forget this is only 
 sample data, do not expect adequate results.
 
 We will create an {dfanalytics-job} to predict the minutes that flights are 

--- a/docs/en/stack/ml/df-analytics/flightdata-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/flightdata-regression.asciidoc
@@ -83,7 +83,7 @@ document as the actual value of `FlightDelayMins`.
 If your source data consists of some documents that contain a `dependent_variable` 
 and some that do not, the model is trained
 on the `training_percent` of the documents that contain ground truth. However,
-and predictions will be made against all of the data. The current implementation 
+predictions are made against all of the data. The current implementation 
 of {reganalysis} supports a single batch analysis for both training and 
 predictions. Future versions will allow a learned model to be incorporated at 
 index time.

--- a/docs/en/stack/ml/df-analytics/flightdata-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/flightdata-regression.asciidoc
@@ -14,7 +14,7 @@ make the prediction.
 This dataset consists of sample data that has been manually created and it 
 contains inconsistencies. For example, a flight can be both delayed and 
 canceled. 
-demonstrate {reganalysis} because it is easy to set up in Kibana, the use case 
+Nonetheless, the use case 
 is relevant and it is a good example of how the quality of input data will 
 affect the quality of results.
 

--- a/docs/en/stack/ml/df-analytics/flightdata-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/flightdata-regression.asciidoc
@@ -80,7 +80,7 @@ to train on data that contains the ground truth for the `dependent_variable`
 that we want to predict. In this example, the ground truth is available in each 
 document as the actual value of `FlightDelayMins`.
 
-If your source data consisted of documents that contains a `dependent_variable` 
+If your source data consists of some documents that contain a `dependent_variable` 
 and some that does not contain a `dependent_variable`, then training is 
 performed on the `training_percent` of the documents that contain ground truth 
 and predictions will be made against all of the data. The current implementation 

--- a/docs/en/stack/ml/df-analytics/flightdata-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/flightdata-regression.asciidoc
@@ -1,7 +1,7 @@
 [role="xpack"]
 [testenv="platinum"]
 [[flightdata-regression]]
-=== Predicting delays with {reganalysis} by using Kibana sample flight data
+=== Predicting flight delays with {reganalysis}
 
 Let's try to predict flight delays by using the 
 {kibana-ref}/add-sample-data.html[sample flight data]. We use this data to learn 

--- a/docs/en/stack/ml/df-analytics/flightdata-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/flightdata-regression.asciidoc
@@ -1,0 +1,354 @@
+[role="xpack"]
+[testenv="platinum"]
+[[flightdata-regression]]
+=== Predicting delays with {reganalysis} by using Kibana sampe flight data
+
+
+The goal of <<dfa-regression,{reganalysis}>> is to find relationships among 
+different features of your data, then make predictions on the new data points 
+based on the previously found relationships. 
+
+Let's try to predict flight delays by using the 
+{kibana-ref}/add-sample-data.html[sample flight data]. We use this data to learn 
+a model that allows us to predict flight delays based on information such as 
+weather and location of the destination and origin, flight distance and carrier. 
+We'd like to predict the number of minutes delayed for each flight. As it is a 
+continuous numeric variable, we'll use {reganalysis} to make the prediction.
+
+This dataset consists of sample data that has been manually created and it 
+contains inconsistencies. For example a flight can be both delayed and 
+cancelled. However, it is easy to setup in Kibana and the use case is 
+applicable, so it is suitable to be an example. Still don't forget this is only 
+sample data, do not expect adequate results.
+
+We will create an {dfanalytics-job} to predict the minutes that flights are 
+delayed by. Each document in the dataset contains details for a single flight, 
+so this data is ready for analysis as it is already in a two-dimensional 
+entity-based data structure that we call a {dataframe}. Depending on your source 
+data, it may be required to first {ref}/transforms.html[transform] your source 
+data into an entity-centric index before you could setup and start the analysis.
+
+This is an example source document from the dataset:
+
+```
+{"_index":"kibana_sample_data_flights","_type":"_doc","_id":"S-JS1W0BJ7wufFIaPAHe","_version":1,"_seq_no":3356,"_primary_term":1,"found":true,"_source":{"FlightNum":"N32FE9T","DestCountry":"JP","OriginWeather":"Thunder & Lightning","OriginCityName":"Adelaide","AvgTicketPrice":499.08518599798685,"DistanceMiles":4802.864932998549,"FlightDelay":false,"DestWeather":"Sunny","Dest":"Chubu Centrair International Airport","FlightDelayType":"No Delay","OriginCountry":"AU","dayOfWeek":3,"DistanceKilometers":7729.461862731618,"timestamp":"2019-10-17T11:12:29","DestLocation":{"lat":"34.85839844","lon":"136.8049927"},"DestAirportID":"NGO","Carrier":"ES-Air","Cancelled":false,"FlightTimeMin":454.6742272195069,"Origin":"Adelaide International Airport","OriginLocation":{"lat":"-34.945","lon":"138.531006"},"DestRegion":"SE-BD","OriginAirportID":"ADL","OriginRegion":"SE-BD","DestCityName":"Tokoname","FlightTimeHour":7.577903786991782,"FlightDelayMin":0}}
+```
+
+
+{regression-cap} is a supervised machine learning analysis and therefore needs 
+to train on data that contains the ground truth for the `dependent_variable` 
+that we want to predict. In this example, the ground truth is available in each 
+document as the actual value of `FlightDelayMins`.
+
+If your source data consisted of documents that contains a `dependent_variable` 
+and some that does not contain a `dependent_variable`, then training is 
+performed on the `training_percent` of the documents that contain ground truth 
+and predictions will be made against all of the data. The current implementation 
+of {reganalysis} supports a single batch analysis for both training and 
+predictions. Future versions will allow a learned model to be incorporated at 
+index time.
+
+1. Create a {dfanalytics-job}.
+Use the {ref}/put-dfanalytics.html[create {dfanalytics-jobs}] API as you can see 
+in the following example:
+
+[source,console]
+--------------------------------------------------
+PUT _ml/data_frame/analytics/model-flight-delays
+{
+  "source": {
+    "index": [
+      "kibana_sample_data_flights" <1>
+    ],
+    "query": { <2>
+      "range": {
+        "DistanceKilometers": { 
+          "gt": 0
+        }
+      }
+    }
+  },
+  "dest": {
+    "index": "df-flight-delays",  <3>
+    "results_field": "ml" 
+  },
+  "analysis": {
+    "regression": {
+      "dependent_variable": "FlightDelayMin",  <4>
+      "training_percent": 90  <5>
+    }
+  },
+  "analyzed_fields": {
+    "includes": [],
+    "excludes": [    <6>
+      "Cancelled",
+      "FlightDelay",
+      "FlightDelayType"
+    ]
+  },
+  "model_memory_limit": "100mb" <7>
+}
+--------------------------------------------------
+// TEST[skip:setup kibana sample data]
+
+<1> The source index to analyze.
+<2> This query removes erroneous data from the analysis to improve its quality.
+<3> The index that contains the results of the analysis; it consists of a copy 
+of the source index data where each document is annotated with the results.
+<4> Specifies the continuous variable we want to predict with the {reganalysis}.
+<5> Specifies the proportion of data that is used for training the model. In 
+this example we use 90% of the source data. The training data is randomly 
+selected and provide predictions from the remaining 10%. These percentages are 
+approximate.
+<6> Specifies fields to be excluded from the analysis. It is recommended to 
+exclude fields that either contain erroneous data or describe the 
+`dependent_variable`.
+<7> Specifies a memory limit for the job. If the job requires more than this 
+amount of memory, it fails to start. This makes it possible to prevent job 
+execution if the available memory on the node is limited.
+
+
+The API returns the following response:
+
+[source,console-result]
+----  
+{
+  "id" : "model-flight-delays",
+  "source" : {
+    "index" : [
+      "kibana_sample_data_flights"
+    ],
+    "query" : {
+      "range" : {
+        "DistanceKilometers" : {
+          "gt" : 0
+        }
+      }
+    }
+  },
+  "dest" : {
+    "index" : "df-flight-delays",
+    "results_field" : "ml"
+  },
+  "analysis" : {
+    "regression" : {
+      "dependent_variable" : "FlightDelayMin",
+      "training_percent" : 90.0
+    }
+  },
+  "analyzed_fields" : {
+    "includes" : [ ],
+    "excludes" : [
+      "Cancelled",
+      "FlightDelay",
+      "FlightDelayType"
+    ]
+  },
+  "model_memory_limit" : "100mb",
+  "create_time" : 1571918329132,
+  "version" : "7.5.0",
+  "allow_lazy_start" : false
+}
+----
+
+
+2. Start the job.
+Use the {ref}/start-dfanalytics.html[start {dfanalytics-jobs}] and 
+{ref}/stop-dfanalytics.html[stop {dfanalytics-jobs}] APIs to start and stop 
+jobs. 
+
+[source,console]
+--------------------------------------------------
+POST _ml/data_frame/analytics/model-flight-delays/_start
+--------------------------------------------------
+// TEST[skip:TBD]
+
+
+The job takes a few minutes to run. Runtime depends on the local hardware and 
+also on the number of documents and fields that analyzed. The more fields and 
+documents, the longer the job to run.
+
+3. Check the job stats to follow the progress by using the 
+{ref}/get-dfanalytics-stats.html[get {dfanalytics-jobs} statistics API].
+
+
+[source,console]
+--------------------------------------------------
+GET _ml/data_frame/analytics/model-flight-delays/_stats
+--------------------------------------------------
+// TEST[skip:TBD]
+
+
+The API call returns the following response: 
+
+[source,console-result]
+----  
+{
+  "count" : 1,
+  "data_frame_analytics" : [
+    {
+      "id" : "model-flight-delays",
+      "state" : "stopped",
+      "progress" : [
+        {
+          "phase" : "reindexing",
+          "progress_percent" : 100
+        },
+        {
+          "phase" : "loading_data",
+          "progress_percent" : 100
+        },
+        {
+          "phase" : "analyzing",
+          "progress_percent" : 100
+        },
+        {
+          "phase" : "writing_results",
+          "progress_percent" : 100
+        }
+      ]
+    }
+  ]
+}
+----  
+
+
+The job has four phases. When all the phases have completed, the job 
+state becomes `stopped` and the results are ready to view and evaluate.
+
+
+[[flightdata-regression-results]]
+==== Viewing results
+
+4. Run the following command to view the results in the destination index:
+
+[source,console]
+--------------------------------------------------
+GET df-flight-delays/_search
+--------------------------------------------------
+// TEST[skip:TBD]
+
+
+The snippet below shows a part of a document with the annotated results:
+
+[source,console-result]
+----  
+          ...
+          "DestRegion" : "UK",
+          "OriginAirportID" : "LHR",
+          "DestCityName" : "London",
+          "FlightDelayMin" : 66,      <1>
+          "ml" : {
+            "FlightDelayMin_prediction" : 62.527,   <2>
+            "is_training" : false   <3>
+          }
+          ...
+----
+
+<1> The `dependent_variable` with the ground truth value. This is what we are 
+trying to predict with the {reganalysis}.
+<2> The prediction. The field name is suffixed with `_prediction`.
+<3> Indicates that this document was not used in the training set.
+
+
+If a document doesn't contain a prediction field, then it is excluded from the 
+analysis. In order to be analyzed, a document must contain at least one field 
+with a supported data type (i.e. `numeric`, `boolean`, `text`, `keyword` or 
+`ip`) and must not contain arrays with more than one item.
+
+
+[[flightdata-regression-evaluate]]
+==== Evaluating results
+
+The results can be evaluated for documents which contain both the ground truth 
+field and the prediction. In the example below, `FlightDelayMins` contains the 
+ground truth and the prediction is stored as `ml.FlightDelayMin_prediction`.
+
+5. Use the {dfanalytics} evaluate API to evaluate the results.
+
+First, we want to know the training error that represents how well the model 
+performed on the training dataset:
+
+[source,console]
+--------------------------------------------------
+POST _ml/data_frame/_evaluate
+{
+ "index": "df-flight-delays",   <1>
+  "query": {
+      "bool": {
+        "filter": [{ "term":  { "ml.is_training": true } }]  <2>
+      }
+    },
+ "evaluation": {
+   "regression": {
+     "actual_field": "FlightDelayMin",   <3>
+     "predicted_field": "ml.FlightDelayMin_prediction", <4>
+     "metrics": {  
+       "r_squared": {},
+       "mean_squared_error": {}                            
+     }
+   }
+ }
+}
+--------------------------------------------------
+// TEST[skip:TBD]
+
+<1> The destination index which is the output of the analysis job.
+<2> We calculate the training error by only evaluating the training data.
+<3> The ground truth label.
+<4> Predicted value.
+
+
+You can also evaluate the data that has not been used to train the model, the 
+quantity you get this way is the model generalization error.
+
+[source,console]
+--------------------------------------------------
+POST _ml/data_frame/_evaluate
+{
+ "index": "df-flight-delays",
+  "query": {
+      "bool": {
+        "filter": [{ "term":  { "ml.is_training": false } }] <1>
+      }
+    },
+ "evaluation": {
+   "regression": {
+     "actual_field": "FlightDelayMin",
+     "predicted_field": "ml.FlightDelayMin_prediction",
+     "metrics": {  
+       "r_squared": {},
+       "mean_squared_error": {}                            
+     }
+   }
+ }
+}
+--------------------------------------------------
+// TEST[skip:TBD]
+<1> By only evaluating the data that was not used in training, we can 
+calculate the generalization error which shows the algorithm accuracy in making 
+predictions for previously unseen data.
+
+
+The evaluate {dfanalytics} API returns the following response:
+
+[source,console-result]
+----  
+{
+  "regression" : {
+    "mean_squared_error" : {
+      "error" : 3759.7242253334207
+    },
+    "r_squared" : {
+      "value" : 0.5853159777330623
+    }
+  }
+}
+----
+
+For more information about the evaluation metrics, see 
+<<dfa-regression-evaluation>>.
+
+If you don't want to keep the {dfanalytics-job}, you can delete it by using the 
+{ref}/delete-dfanalytics.html[delete {dfanalytics-job} API]. When you delete 
+{dfanalytics-jobs}, the destination indices remain intact.

--- a/docs/en/stack/ml/df-analytics/flightdata-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/flightdata-regression.asciidoc
@@ -10,10 +10,11 @@ distance and carrier to predict the number of minutes delayed for each flight.
 As it is a continuous numeric variable, we'll use {reganalysis} to make the 
 prediction.
 
-This dataset consists of sample data that has been manually created and it 
-contains inconsistencies. For example, a flight can be both delayed and 
-canceled. Nonetheless, the use case is relevant and it is a good example of how 
-the quality of input data will affect the quality of results.
+We have chosen this dataset as an example because it is easily accessible for 
+{kib} users and the use case is relevant. However, the data has been manually 
+created and contains some inconsistencies. For example, a flight can be both 
+delayed and canceled. Please remember that the quality of your input data will 
+affect the quality of results.
 
 Each document in the dataset contains details for a single flight, so this data 
 is ready for analysis as it is already in a two-dimensional entity-based data 
@@ -91,6 +92,7 @@ predictions.
 ==== Creating a {regression} model
 
 To predict the number of minutes delayed for each flight:
+
 . Create a {dfanalytics-job}.
 +
 --
@@ -141,10 +143,8 @@ PUT _ml/data_frame/analytics/model-flight-delays
 a copy of the source index data where each document is annotated with the 
 results.
 <4> Specifies the continuous variable we want to predict with the {reganalysis}.
-<5> Specifies the proportion of data that is used for training the model. In 
-this example we use 90% of the source data. The training data is randomly 
-selected and provide predictions from the remaining 10%. These percentages are 
-approximate.
+<5> Specifies the approximate proportion of data that is used for training. In 
+this example we randomly select 90% of the source data for training.
 <6> Specifies fields to be excluded from the analysis. It is recommended to 
 exclude fields that either contain erroneous data or describe the 
 `dependent_variable`.
@@ -157,8 +157,7 @@ execution if the available memory on the node is limited.
 +
 --
 Use the {ref}/start-dfanalytics.html[start {dfanalytics-jobs}] API to start the 
-job. It will stop automatically when the analysis is complete, you don't need to 
-stop it manually.
+job. It will stop automatically when the analysis is complete.
 
 [source,console]
 --------------------------------------------------

--- a/docs/en/stack/ml/df-analytics/flightdata-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/flightdata-regression.asciidoc
@@ -23,7 +23,7 @@ Each document in the dataset contains details for a single flight,
 so this data is ready for analysis as it is already in a two-dimensional 
 entity-based data structure (_{dataframe}_).
 In general, you often need to {ref}/transforms.html[transform] the
-data into an entity-centric index before you could setup and start the analysis.
+data into an entity-centric index before you analyze the data.
 
 This is an example source document from the dataset:
 

--- a/docs/en/stack/ml/df-analytics/flightdata-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/flightdata-regression.asciidoc
@@ -48,7 +48,9 @@ of {reganalysis} supports a single batch analysis for both training and
 predictions. Future versions will allow a learned model to be incorporated at 
 index time.
 
-1. Create a {dfanalytics-job}.
+. Create a {dfanalytics-job}.
++
+--
 Use the {ref}/put-dfanalytics.html[create {dfanalytics-jobs}] API as you can see 
 in the following example:
 
@@ -111,7 +113,7 @@ execution if the available memory on the node is limited.
 The API returns the following response:
 
 [source,console-result]
-----  
+--------------------------------------------------  
 {
   "id" : "model-flight-delays",
   "source" : {
@@ -149,10 +151,12 @@ The API returns the following response:
   "version" : "7.5.0",
   "allow_lazy_start" : false
 }
-----
+--------------------------------------------------
+--
 
-
-2. Start the job.
+. Start the job.
++
+--
 Use the {ref}/start-dfanalytics.html[start {dfanalytics-jobs}] and 
 {ref}/stop-dfanalytics.html[stop {dfanalytics-jobs}] APIs to start and stop 
 jobs. 
@@ -167,9 +171,12 @@ POST _ml/data_frame/analytics/model-flight-delays/_start
 The job takes a few minutes to run. Runtime depends on the local hardware and 
 also on the number of documents and fields that analyzed. The more fields and 
 documents, the longer the job to run.
+--
 
-3. Check the job stats to follow the progress by using the 
+. Check the job stats to follow the progress by using the 
 {ref}/get-dfanalytics-stats.html[get {dfanalytics-jobs} statistics API].
++
+--
 
 
 [source,console]
@@ -215,12 +222,15 @@ The API call returns the following response:
 
 The job has four phases. When all the phases have completed, the job 
 state becomes `stopped` and the results are ready to view and evaluate.
+--
 
 
 [[flightdata-regression-results]]
 ==== Viewing results
 
-4. Run the following command to view the results in the destination index:
+.Run the following command to view the results in the destination index:
++
+--
 
 [source,console]
 --------------------------------------------------
@@ -255,6 +265,7 @@ If a document doesn't contain a prediction field, then it is excluded from the
 analysis. In order to be analyzed, a document must contain at least one field 
 with a supported data type (i.e. `numeric`, `boolean`, `text`, `keyword` or 
 `ip`) and must not contain arrays with more than one item.
+--
 
 
 [[flightdata-regression-evaluate]]
@@ -264,8 +275,9 @@ The results can be evaluated for documents which contain both the ground truth
 field and the prediction. In the example below, `FlightDelayMins` contains the 
 ground truth and the prediction is stored as `ml.FlightDelayMin_prediction`.
 
-5. Use the {dfanalytics} evaluate API to evaluate the results.
-
+. Use the {dfanalytics} evaluate API to evaluate the results.
++
+--
 First, we want to know the training error that represents how well the model 
 performed on the training dataset:
 
@@ -352,3 +364,4 @@ For more information about the evaluation metrics, see
 If you don't want to keep the {dfanalytics-job}, you can delete it by using the 
 {ref}/delete-dfanalytics.html[delete {dfanalytics-job} API]. When you delete 
 {dfanalytics-jobs}, the destination indices remain intact.
+--

--- a/docs/en/stack/ml/df-analytics/flightdata-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/flightdata-regression.asciidoc
@@ -82,7 +82,7 @@ document as the actual value of `FlightDelayMins`.
 
 If your source data consists of some documents that contain a `dependent_variable` 
 and some that do not, the model is trained
-performed on the `training_percent` of the documents that contain ground truth 
+on the `training_percent` of the documents that contain ground truth. However,
 and predictions will be made against all of the data. The current implementation 
 of {reganalysis} supports a single batch analysis for both training and 
 predictions. Future versions will allow a learned model to be incorporated at 

--- a/docs/en/stack/ml/df-analytics/flightdata-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/flightdata-regression.asciidoc
@@ -21,7 +21,7 @@ affect the quality of results.
 We will create a {dfanalytics-job} to predict the flights delays in minutes. 
 Each document in the dataset contains details for a single flight, 
 so this data is ready for analysis as it is already in a two-dimensional 
-entity-based data structure that we call a {dataframe}. Depending on your source 
+entity-based data structure (_{dataframe}_).
 data, it may be required to first {ref}/transforms.html[transform] your source 
 data into an entity-centric index before you could setup and start the analysis.
 

--- a/docs/en/stack/ml/df-analytics/flightdata-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/flightdata-regression.asciidoc
@@ -19,7 +19,7 @@ is relevant and it is a good example of how the quality of input data will
 affect the quality of results.
 
 We will create a {dfanalytics-job} to predict the flights delays in minutes. 
-delayed by. Each document in the dataset contains details for a single flight, 
+Each document in the dataset contains details for a single flight, 
 so this data is ready for analysis as it is already in a two-dimensional 
 entity-based data structure that we call a {dataframe}. Depending on your source 
 data, it may be required to first {ref}/transforms.html[transform] your source 

--- a/docs/en/stack/ml/df-analytics/flightdata-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/flightdata-regression.asciidoc
@@ -1,7 +1,7 @@
 [role="xpack"]
 [testenv="platinum"]
 [[flightdata-regression]]
-=== Predicting delays with {reganalysis} by using Kibana sampe flight data
+=== Predicting delays with {reganalysis} by using Kibana sample flight data
 
 
 The goal of <<dfa-regression,{reganalysis}>> is to find relationships among 

--- a/docs/en/stack/ml/df-analytics/flightdata-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/flightdata-regression.asciidoc
@@ -7,23 +7,21 @@ Let's try to predict flight delays by using the
 {kibana-ref}/add-sample-data.html[sample flight data]. We use this data to learn 
 a {regression} model that allows us to predict flight delays based on 
 information such as weather and location of the destination and origin, flight 
-distance and carrier. For example, we can predict the number of minutes delayed for 
-each flight. As it is a continuous numeric variable, we'll use {reganalysis} to 
-make the prediction.
+distance and carrier. For example, we can predict the number of minutes delayed 
+for each flight. As it is a continuous numeric variable, we'll use {reganalysis} 
+to make the prediction.
 
 This dataset consists of sample data that has been manually created and it 
 contains inconsistencies. For example, a flight can be both delayed and 
-canceled. 
-Nonetheless, the use case 
-is relevant and it is a good example of how the quality of input data will 
-affect the quality of results.
+canceled. Nonetheless, the use case is relevant and it is a good example of how 
+the quality of input data will affect the quality of results.
 
 We will create a {dfanalytics-job} to predict the flights delays in minutes. 
-Each document in the dataset contains details for a single flight, 
-so this data is ready for analysis as it is already in a two-dimensional 
-entity-based data structure (_{dataframe}_).
-In general, you often need to {ref}/transforms.html[transform] the
-data into an entity-centric index before you analyze the data.
+Each document in the dataset contains details for a single flight, so this data 
+is ready for analysis as it is already in a two-dimensional entity-based data 
+structure (_{dataframe}_). In general, you often need to 
+{ref}/transforms.html[transform] the data into an entity-centric index before 
+you analyze the data.
 
 This is an example source document from the dataset:
 
@@ -80,13 +78,12 @@ to train on data that contains the ground truth for the `dependent_variable`
 that we want to predict. In this example, the ground truth is available in each 
 document as the actual value of `FlightDelayMins`.
 
-If your source data consists of some documents that contain a `dependent_variable` 
-and some that do not, the model is trained
-on the `training_percent` of the documents that contain ground truth. However,
-predictions are made against all of the data. The current implementation 
-of {reganalysis} supports a single batch analysis for both training and 
-predictions. Future versions will allow a learned model to be incorporated at 
-index time.
+If your source data consists of some documents that contain a 
+`dependent_variable` and some that do not, the model is trained on the 
+`training_percent` of the documents that contain ground truth. However, 
+predictions are made against all of the data. The current implementation of 
+{reganalysis} supports a single batch analysis for both training and 
+predictions.
 
 . Create a {dfanalytics-job}.
 +

--- a/docs/en/stack/ml/df-analytics/flightdata-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/flightdata-regression.asciidoc
@@ -7,7 +7,7 @@ Let's try to predict flight delays by using the
 {kibana-ref}/add-sample-data.html[sample flight data]. We use this data to learn 
 a {regression} model that allows us to predict flight delays based on 
 information such as weather and location of the destination and origin, flight 
-distance and carrier. We'd like to predict the number of minutes delayed for 
+distance and carrier. For example, we can predict the number of minutes delayed for 
 each flight. As it is a continuous numeric variable, we'll use {reganalysis} to 
 make the prediction.
 

--- a/docs/en/stack/ml/df-analytics/flightdata-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/flightdata-regression.asciidoc
@@ -3,23 +3,20 @@
 [[flightdata-regression]]
 === Predicting delays with {reganalysis} by using Kibana sample flight data
 
-
-The goal of <<dfa-regression,{reganalysis}>> is to find relationships among 
-different features of your data, then make predictions on the new data points 
-based on the previously found relationships. 
-
 Let's try to predict flight delays by using the 
 {kibana-ref}/add-sample-data.html[sample flight data]. We use this data to learn 
-a model that allows us to predict flight delays based on information such as 
-weather and location of the destination and origin, flight distance and carrier. 
-We'd like to predict the number of minutes delayed for each flight. As it is a 
-continuous numeric variable, we'll use {reganalysis} to make the prediction.
+a {regression} model that allows us to predict flight delays based on 
+information such as weather and location of the destination and origin, flight 
+distance and carrier. We'd like to predict the number of minutes delayed for 
+each flight. As it is a continuous numeric variable, we'll use {reganalysis} to 
+make the prediction.
 
 This dataset consists of sample data that has been manually created and it 
 contains inconsistencies. For example, a flight can be both delayed and 
-canceled. However, it is easy to set up in Kibana and the use case is 
-applicable, so it is suitable to be an example. Still, don't forget this is only 
-sample data, do not expect adequate results.
+canceled. Despite the data inconsistencies, flight delays can be used to 
+demonstrate {reganalysis} because it is easy to set up in Kibana, the use case 
+is relevant and it is a good example of how the quality of input data will 
+affect the quality of results.
 
 We will create an {dfanalytics-job} to predict the minutes that flights are 
 delayed by. Each document in the dataset contains details for a single flight, 
@@ -31,7 +28,50 @@ data into an entity-centric index before you could setup and start the analysis.
 This is an example source document from the dataset:
 
 ```
-{"_index":"kibana_sample_data_flights","_type":"_doc","_id":"S-JS1W0BJ7wufFIaPAHe","_version":1,"_seq_no":3356,"_primary_term":1,"found":true,"_source":{"FlightNum":"N32FE9T","DestCountry":"JP","OriginWeather":"Thunder & Lightning","OriginCityName":"Adelaide","AvgTicketPrice":499.08518599798685,"DistanceMiles":4802.864932998549,"FlightDelay":false,"DestWeather":"Sunny","Dest":"Chubu Centrair International Airport","FlightDelayType":"No Delay","OriginCountry":"AU","dayOfWeek":3,"DistanceKilometers":7729.461862731618,"timestamp":"2019-10-17T11:12:29","DestLocation":{"lat":"34.85839844","lon":"136.8049927"},"DestAirportID":"NGO","Carrier":"ES-Air","Cancelled":false,"FlightTimeMin":454.6742272195069,"Origin":"Adelaide International Airport","OriginLocation":{"lat":"-34.945","lon":"138.531006"},"DestRegion":"SE-BD","OriginAirportID":"ADL","OriginRegion":"SE-BD","DestCityName":"Tokoname","FlightTimeHour":7.577903786991782,"FlightDelayMin":0}}
+{
+  "_index": "kibana_sample_data_flights",
+  "_type": "_doc",
+  "_id": "S-JS1W0BJ7wufFIaPAHe",
+  "_version": 1,
+  "_seq_no": 3356,
+  "_primary_term": 1,
+  "found": true,
+  "_source": {
+    "FlightNum": "N32FE9T",
+    "DestCountry": "JP",
+    "OriginWeather": "Thunder & Lightning",
+    "OriginCityName": "Adelaide",
+    "AvgTicketPrice": 499.08518599798685,
+    "DistanceMiles": 4802.864932998549,
+    "FlightDelay": false,
+    "DestWeather": "Sunny",
+    "Dest": "Chubu Centrair International Airport",
+    "FlightDelayType": "No Delay",
+    "OriginCountry": "AU",
+    "dayOfWeek": 3,
+    "DistanceKilometers": 7729.461862731618,
+    "timestamp": "2019-10-17T11:12:29",
+    "DestLocation": {
+      "lat": "34.85839844",
+      "lon": "136.8049927"
+    },
+    "DestAirportID": "NGO",
+    "Carrier": "ES-Air",
+    "Cancelled": false,
+    "FlightTimeMin": 454.6742272195069,
+    "Origin": "Adelaide International Airport",
+    "OriginLocation": {
+      "lat": "-34.945",
+      "lon": "138.531006"
+    },
+    "DestRegion": "SE-BD",
+    "OriginAirportID": "ADL",
+    "OriginRegion": "SE-BD",
+    "DestCityName": "Tokoname",
+    "FlightTimeHour": 7.577903786991782,
+    "FlightDelayMin": 0
+  }
+}
 ```
 
 
@@ -71,8 +111,7 @@ PUT _ml/data_frame/analytics/model-flight-delays
     }
   },
   "dest": {
-    "index": "df-flight-delays",  <3>
-    "results_field": "ml" 
+    "index": "df-flight-delays"  <3>
   },
   "analysis": {
     "regression": {
@@ -95,8 +134,9 @@ PUT _ml/data_frame/analytics/model-flight-delays
 
 <1> The source index to analyze.
 <2> This query removes erroneous data from the analysis to improve its quality.
-<3> The index that contains the results of the analysis; it consists of a copy 
-of the source index data where each document is annotated with the results.
+<3> The index that will contain the results of the analysis; it will consist of 
+a copy of the source index data where each document is annotated with the 
+results.
 <4> Specifies the continuous variable we want to predict with the {reganalysis}.
 <5> Specifies the proportion of data that is used for training the model. In 
 this example we use 90% of the source data. The training data is randomly 
@@ -157,9 +197,9 @@ The API returns the following response:
 . Start the job.
 +
 --
-Use the {ref}/start-dfanalytics.html[start {dfanalytics-jobs}] and 
-{ref}/stop-dfanalytics.html[stop {dfanalytics-jobs}] APIs to start and stop 
-jobs. 
+Use the {ref}/start-dfanalytics.html[start {dfanalytics-jobs}] API to start the 
+job. It will stop automatically when the analysis is complete, you don't need to 
+stop it manually.
 
 [source,console]
 --------------------------------------------------
@@ -228,7 +268,8 @@ state becomes `stopped` and the results are ready to view and evaluate.
 [[flightdata-regression-results]]
 ==== Viewing results
 
-. Run the following command to view the results in the destination index:
+. Use the standard {es} search command to view the results in the destination 
+index:
 +
 --
 
@@ -237,6 +278,7 @@ state becomes `stopped` and the results are ready to view and evaluate.
 GET df-flight-delays/_search
 --------------------------------------------------
 // TEST[skip:TBD]
+
 
 
 The snippet below shows a part of a document with the annotated results:
@@ -263,8 +305,8 @@ trying to predict with the {reganalysis}.
 
 If a document doesn't contain a prediction field, then it is excluded from the 
 analysis. In order to be analyzed, a document must contain at least one field 
-with a supported data type (i.e. `numeric`, `boolean`, `text`, `keyword` or 
-`ip`) and must not contain arrays with more than one item.
+with a supported data type (`numeric`, `boolean`, `text`, `keyword` or `ip`) and 
+must not contain arrays with more than one item.
 --
 
 
@@ -310,9 +352,8 @@ POST _ml/data_frame/_evaluate
 <3> The ground truth label.
 <4> Predicted value.
 
-
-You can also evaluate the data that has not been used to train the model, the 
-quantity you get this way is the model generalization error.
+Next, we calculate the generalization error that represents how well the model 
+performed on previously unseen data:
 
 [source,console]
 --------------------------------------------------


### PR DESCRIPTION
This PR adds a regression example to the data frame analytics documentation section.

Related issue: https://github.com/elastic/ml-team/issues/237