### PR TITLE
[DOCS] [FOR 7.5] Add superseded banner to older versions of Infrastructure Monitoring Guide

### DIFF
--- a/docs/en/infraops/page_header.html
+++ b/docs/en/infraops/page_header.html
@@ -1,5 +1,5 @@
 You are looking at documentation for an older release.
-Not what you want?
-In the current release, the Infrastructure monitoring guide has been replaced by two documents, the
+Starting in version 7.5, see the
 <a href="https://www.elastic.co/guide/en/logs/guide/current/index.html"> Logs monitoring guide</a>
-and the <a href="https://www.elastic.co/guide/en/metrics/guide/current/index.html"> Metrics monitoring guide</a>.
+and the <a href="https://www.elastic.co/guide/en/metrics/guide/current/index.html"> Metrics monitoring guide</a>
+for information about infrastructure monitoring.

--- a/docs/en/infraops/page_header.html
+++ b/docs/en/infraops/page_header.html
@@ -1,0 +1,5 @@
+You are looking at documentation for an older release.
+Not what you want?
+In the current release, the Infrastructure monitoring guide has been replaced by two documents, the
+<a href="https://www.elastic.co/guide/en/logs/guide/current/index.html"> Logs monitoring guide</a>
+and the <a href="https://www.elastic.co/guide/en/metrics/guide/current/index.html"> Metrics monitoring guide</a>.


### PR DESCRIPTION
DO NOT MERGE UNTIL 7.4 IS NO LONGER THE CURRENT RELEASE!

At the same time, also needs to be back ported to all earlier branches in which this doc exists (7.3 down to 6.5)