### PR TITLE
[DOCS] Adding temporary banner to mark Logs and Metrics docs as "future"

### DIFF
--- a/docs/en/logs/page_header.html
+++ b/docs/en/logs/page_header.html
@@ -1,0 +1,3 @@
+You are looking at documentation for a future release.
+Not what you want?
+See the <a href="https://www.elastic.co/guide/en/infrastructure/guide/current/index.html">current release documentation</a>.

--- a/docs/en/metrics/page_header.html
+++ b/docs/en/metrics/page_header.html
@@ -1,0 +1,3 @@
+You are looking at documentation for a future release.
+Not what you want?
+See the <a href="https://www.elastic.co/guide/en/infrastructure/guide/current/index.html">current release documentation</a>.


### PR DESCRIPTION
Due to the way the build process works, the new Logs Monitoring Guide and Metrics monitoring Guide docs are included as current docs at v7.5. 

This PR adds a banner pointing readers to the actual current doc (the V7.4 infrastructure Monitoring Guide).

This needs to be back ported to the 7.5 and 7.x branches and reverted in all these branches when 7.5 docs are released.
- [ ]  raise PR to revert 