### PR TITLE
[DOCS] [FOR 7.5] Remove temporary "future docs" banner from 7.5 release docs

### DIFF
--- a/docs/en/logs/page_header.html
+++ b/docs/en/logs/page_header.html
@@ -1,3 +1,0 @@
-You are looking at documentation for a future release.
-Not what you want?
-See the <a href="https://www.elastic.co/guide/en/infrastructure/guide/current/index.html">current release documentation</a>.

--- a/docs/en/metrics/page_header.html
+++ b/docs/en/metrics/page_header.html
@@ -1,3 +1,0 @@
-You are looking at documentation for a future release.
-Not what you want?
-See the <a href="https://www.elastic.co/guide/en/infrastructure/guide/current/index.html">current release documentation</a>.


### PR DESCRIPTION
DO NOT MERGE UNTIL 7.5 RELEASE DAY!

https://github.com/elastic/stack-docs/pull/655 added a "docs for a future release" banner to the new v7.5 docs, Logs Monitoring Guide and Metrics Monitoring Guide (on branches master, 7.5 and 7.x)

When v7.5 docs are published, this banner needs to be removed from all three branches. This PR removes the headers from the master branch. It also needs to be back ported to 7.5 and 7.x.