### PR TITLE
[7.x] Adding temporary banner to mark current version of logs monitoring guide as "future" (#655)

### DIFF
--- a/docs/en/logs/page_header.html
+++ b/docs/en/logs/page_header.html
@@ -1,0 +1,3 @@
+You are looking at documentation for a future release.
+Not what you want?
+See the <a href="https://www.elastic.co/guide/en/infrastructure/guide/current/index.html">current release documentation</a>.

--- a/docs/en/metrics/page_header.html
+++ b/docs/en/metrics/page_header.html
@@ -1,0 +1,3 @@
+You are looking at documentation for a future release.
+Not what you want?
+See the <a href="https://www.elastic.co/guide/en/infrastructure/guide/current/index.html">current release documentation</a>.


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Adding temporary banner to mark current version of logs monitoring guide as "future" (#655)