### PR TITLE
[7.5] Renaming references to Infrastructure app to Metrics where appropriate. (#661)

### DIFF
--- a/docs/en/getting-started/get-started-stack.asciidoc
+++ b/docs/en/getting-started/get-started-stack.asciidoc
@@ -1023,7 +1023,7 @@ how, read:
 * {stack-ov}/elasticsearch-security.html[Securing the {stack}]
 * {stack-ov}/license-management.html[License Management]
 
-Want to get up and running quickly with infrastructure metrics monitoring and
+Want to get up and running quickly with metrics monitoring and
 centralized log analytics? Try out the Metrics app and the Logs app in {kib}.
 For more details, see the {metrics-guide}[Metrics Monitoring Guide]
 and the {logs-guide}[Logs Monitoring Guide].

--- a/docs/en/logs/index.asciidoc
+++ b/docs/en/logs/index.asciidoc
@@ -1,6 +1,6 @@
 :doctype: book
-:metrics: infrastructure
-:metrics-app: Infrastructure app
+:metrics: metrics
+:metrics-app: Metrics app
 :logs: logs
 :logs-app: Logs app
 

--- a/docs/en/logs/logs-overview.asciidoc
+++ b/docs/en/logs/logs-overview.asciidoc
@@ -4,9 +4,8 @@
 
 Logs monitoring enables you to view logs from your infrastructure and identify problems in near real time.
 You can view logs from servers, containers, services, and so on.
-Then you can drill down to view more detailed information about an individual log entry, or you can seamlessly switch to view corresponding metrics, uptime information or APM traces where available.
+Then you can drill down to view more detailed information about an individual log entry, or you can seamlessly switch to view corresponding metrics, uptime information or APM traces where available. You can also use machine learning to automatically detect some kinds of log anomalies.
 
-// Add one-sentence description of the Analysis tab functionality.
 // Add links to metrics, uptime and APM when I have good places to link to.
 
 [float]

--- a/docs/en/metrics/index.asciidoc
+++ b/docs/en/metrics/index.asciidoc
@@ -1,10 +1,10 @@
 :doctype: book
-:metrics: infrastructure
-:metrics-app: Infrastructure app
+:metrics: metrics
+:metrics-app: Metrics app
 :logs: logs
 :logs-app: Logs app
 
-= Infrastructure Monitoring Guide
+= Metrics Monitoring Guide
 
 include::{asciidoc-dir}/../../shared/versions/stack/{source_branch}.asciidoc[]
 

--- a/docs/en/metrics/infra-ui-intro.asciidoc
+++ b/docs/en/metrics/infra-ui-intro.asciidoc
@@ -2,7 +2,8 @@
 [role="xpack"]
 == {metrics-app}
 
-After you have <<install-infrastructure-monitoring, set up infrastructure monitoring>> and data is streaming to {es}, you can use the {metrics-app} to view metrics from your infrastructure and identify problems in real time.
+After you have <<install-infrastructure-monitoring, started monitoring metrics>> and data is streaming to {es},
+you can use the {metrics-app} to view metrics from your infrastructure and identify problems in real time.
 You can also seamlessly switch to view the corresponding logs, application traces or uptime information for a component.
 
 For more information see {kibana-ref}/xpack-infra.html[{metrics-app}].

--- a/docs/en/metrics/metrics-overview.asciidoc
+++ b/docs/en/metrics/metrics-overview.asciidoc
@@ -1,27 +1,27 @@
 [[infrastructure-monitoring-overview]]
 [role="xpack"]
-== Infrastructure monitoring overview
+== Metrics monitoring overview
 
-The {metrics-app} enables you to view metrics for your infrastructure and identify problems in real time.
+The {metrics-app} enables you to monitor metrics for your infrastructure and identify problems in real time.
 You can view basic metrics for servers, containers, services, and so on.
 Then you can drill down to view more detailed metrics, or you can seamlessly switch to view corresponding logs, uptime information or APM traces where available.
 // Add links to logs, uptime and APM when I have good places to link to.
 
 [float]
-=== Infrastructure monitoring components
+=== Metrics monitoring components
 
 image::images/metrics-monitoring-architecture.png[]
 
 // redo for metrics and logs separately.
 
-Infrastructure monitoring requires the following {stack} components.
+Metrics monitoring requires the following {stack} components.
 
 *https://www.elastic.co/products/elasticsearch[{es}]* is a real-time,
 distributed storage, search, and analytics engine. {es} can store, search, and analyze large volumes of data in near real-time.
 The {metrics-app} uses {es} to store metrics data in {es} documents which are queried on demand.
 
 *https://www.elastic.co/products/beats[{beats}]* are open source data shippers that you install as agents on your servers to send data to {es}.
-The {metrics-app} uses Metricbeat to collect metrics from the servers, containers, and other services in your infrastructure.
+The {metrics-app} uses metrics collected by Metricbeat from the servers, containers, and other services in your infrastructure.
 Metricbeat modules are available for most common servers, containers and services.
 
 *https://www.elastic.co/products/kibana[{kib}]* is an open source analytics and visualization platform designed to work with {es}.


### PR DESCRIPTION
Backports the following commits to 7.5:
 - Renaming references to Infrastructure app to Metrics where appropriate. (#661)