### PR TITLE
[DOCS] Adds Kibana 7.5 breaking changes

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -87,8 +87,7 @@ include::{hadoop-repo-dir}/appendix/breaking.adoc[tag=notable-v7-breaking-change
 
 coming[7.5.0]
 
-This list summarizes the most important breaking changes in {kib} {version}. For
-the complete list, go to {kibana-ref}/breaking-changes.html[{kib} breaking changes].
+This page lists the breaking changes in {kib} {version}.
 
 include::{kib-repo-dir}/migration/migrate_7_5.asciidoc[tag=notable-breaking-changes]
 

--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -90,7 +90,7 @@ coming[7.5.0]
 This list summarizes the most important breaking changes in {kib} {version}. For
 the complete list, go to {kibana-ref}/breaking-changes.html[{kib} breaking changes].
 
-//include::{kib-repo-dir}/migration/migrate_7_2.asciidoc[tag=notable-breaking-changes]
+include::{kib-repo-dir}/migration/migrate_7_5.asciidoc[tag=notable-breaking-changes]
 
 [[logstash-breaking-changes]]
 === {ls} breaking changes


### PR DESCRIPTION
This PR makes the Kibana 7.5 breaking changes (https://www.elastic.co/guide/en/kibana/7.5/breaking-changes-7.5.html) appear successfully in the Installation and Upgrade Guide (https://www.elastic.co/guide/en/elastic-stack/7.5/kibana-breaking-changes.html).

Preview: http://stack-docs_684.docs-preview.app.elstc.co/guide/en/elastic-stack/7.5/kibana-breaking-changes.html
