### PR TITLE
[7.x] Update Beats BC and highlights links

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -41,12 +41,12 @@ For the complete list, go to {apm-server-ref-70}/breaking-changes.html[APM Serve
 <titleabbrev>Beats</titleabbrev>
 ++++
 
-coming[7.5.0]
+coming[7.6.0]
 
 This list summarizes the most important breaking changes in Beats. For the
 complete list, go to {beats-ref}/breaking-changes.html[Beats breaking changes].
 
-include::{beats-repo-dir}/breaking-7.0.asciidoc[tag=notable-breaking-changes]
+//include::{beats-repo-dir}/release-notes/breaking/breaking-7.6.asciidoc[tag=notable-breaking-changes]
 
 
 [[elasticsearch-breaking-changes]]

--- a/docs/en/install-upgrade/highlights.asciidoc
+++ b/docs/en/install-upgrade/highlights.asciidoc
@@ -31,12 +31,12 @@ include::{apm-repo-dir}/apm-release-notes.asciidoc[tag=notable-v7-highlights]
 <titleabbrev>Beats</titleabbrev>
 ++++
 
-coming[7.5.0]
+coming[7.6.0]
 
 This list summarizes the most important enhancements in Beats.
 For the complete list, go to {beats-ref}/release-highlights.html[Beats release highlights].
 
-//include::{beats-repo-dir}/highlights-7.3.0.asciidoc[tag=notable-highlights]
+//include::{beats-repo-dir}/release-notes/highlights/highlights-7.6.0.asciidoc[tag=notable-highlights]
 
 [[elasticsearch-highlights]]
 === {es} highlights


### PR DESCRIPTION
Updates the placeholder links to reflect the new path to Beats breaking changes and highlights.

commented-out for now.