### PR TITLE
[DOCS] Adds classification field type description to the DFA limitations

### DIFF
--- a/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
@@ -75,7 +75,7 @@ that don't contain a results field are not included in the {reganalysis}.
 [[dfa-classification-field-type-docs-limitations]]
 === {classification-cap} field types
 
-{classification-cap} supports fields that are numeric, boolean, text, keyword 
+{classification-cap} supports fields that have numeric, boolean, text, keyword, 
 and ip. It is also tolerant of missing values. Fields that are supported are 
 included in the analysis, other fields are ignored. Documents where included 
 fields contain an array are also ignored. Documents in the destination index 

--- a/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
@@ -76,7 +76,7 @@ that don't contain a results field are not included in the {reganalysis}.
 === {classification-cap} field types
 
 {classification-cap} supports fields that have numeric, boolean, text, keyword, 
-and ip. It is also tolerant of missing values. Fields that are supported are 
+or ip data types. It is also tolerant of missing values. Fields that are supported are 
 included in the analysis, other fields are ignored. Documents where included 
 fields contain an array are also ignored. Documents in the destination index 
 that don't contain a results field are not included in the {classanalysis}.

--- a/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
@@ -70,3 +70,13 @@ ip. It is also tolerant of missing values. Fields that are supported are
 included in the analysis, other fields are ignored. Documents where included 
 fields contain an array are also ignored. Documents in the destination index 
 that don't contain a results field are not included in the {reganalysis}.
+
+[float]
+[[dfa-classification-field-type-docs-limitations]]
+=== {classification-cap} field types
+
+{classification-cap} supports fields that are numeric, boolean, text, keyword 
+and ip. It is also tolerant of missing values. Fields that are supported are 
+included in the analysis, other fields are ignored. Documents where included 
+fields contain an array are also ignored. Documents in the destination index 
+that don't contain a results field are not included in the {classanalysis}.


### PR DESCRIPTION
This PR expands the data frame analytics limitation sections with the supported field types for classification.