### PR TITLE
Removes unnecessary repo dependencies

### DIFF
--- a/docs/en/stack/index.asciidoc
+++ b/docs/en/stack/index.asciidoc
@@ -9,12 +9,8 @@
 
 :blog-ref:          https://www.elastic.co/blog/
 :wikipedia:         https://en.wikipedia.org/wiki
-
-:kib-repo-dir:      {docdir}/../../../../kibana/docs
-:xes-repo-dir:      {docdir}/../../../../elasticsearch/x-pack/docs/en
 :es-repo-dir:       {docdir}/../../../../elasticsearch/docs/reference
 :stack-repo-dir:    {docdir}
-:beats-repo-dir:    {docdir}/../../../../beats/libbeat/docs
 include::{asciidoc-dir}/../../shared/versions/stack/{source_branch}.asciidoc[]
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 


### PR DESCRIPTION
This PR removes references to the Kibana and Beats repos from the Stack Overview, since those dependencies are no longer required.