### PR TITLE
Adds OOM banners in stack books

### DIFF
--- a/docs/en/getting-started/page_header.html
+++ b/docs/en/getting-started/page_header.html
@@ -1,5 +1,5 @@
 <p>
-  <strong>IMPORTANT</strong>: Version {version} of the {stack} has passed its 
+  <strong>IMPORTANT</strong>: Version 7.4 of the Elastic Stack has passed its 
   <a href="https://www.elastic.co/support/eol">maintenance date</a>. 
 </p>  
 <p>

--- a/docs/en/getting-started/page_header.html
+++ b/docs/en/getting-started/page_header.html
@@ -1,0 +1,9 @@
+<p>
+  <strong>IMPORTANT</strong>: Version {version} of the {stack} has passed its 
+  <a href="https://www.elastic.co/support/eol">maintenance date</a>. 
+</p>  
+<p>
+  This documentation is no longer being updated. 
+  For the latest information, see the 
+  <a href="../current/index.html">current release documentation</a>. 
+</p>

--- a/docs/en/install-upgrade/page_header.html
+++ b/docs/en/install-upgrade/page_header.html
@@ -1,5 +1,5 @@
 <p>
-  <strong>IMPORTANT</strong>: Version {version} of the {stack} has passed its 
+  <strong>IMPORTANT</strong>: Version 7.4 of the Elastic Stack has passed its 
   <a href="https://www.elastic.co/support/eol">maintenance date</a>. 
 </p>  
 <p>

--- a/docs/en/install-upgrade/page_header.html
+++ b/docs/en/install-upgrade/page_header.html
@@ -1,0 +1,9 @@
+<p>
+  <strong>IMPORTANT</strong>: Version {version} of the {stack} has passed its 
+  <a href="https://www.elastic.co/support/eol">maintenance date</a>. 
+</p>  
+<p>
+  This documentation is no longer being updated. 
+  For the latest information, see the 
+  <a href="../current/index.html">current release documentation</a>. 
+</p>

--- a/docs/en/stack/page_header.html
+++ b/docs/en/stack/page_header.html
@@ -1,5 +1,5 @@
 <p>
-  <strong>IMPORTANT</strong>: Version {version} of the {stack} has passed its 
+  <strong>IMPORTANT</strong>: Version 7.4 of the Elastic Stack has passed its 
   <a href="https://www.elastic.co/support/eol">maintenance date</a>. 
 </p>  
 <p>

--- a/docs/en/stack/page_header.html
+++ b/docs/en/stack/page_header.html
@@ -1,0 +1,9 @@
+<p>
+  <strong>IMPORTANT</strong>: Version {version} of the {stack} has passed its 
+  <a href="https://www.elastic.co/support/eol">maintenance date</a>. 
+</p>  
+<p>
+  This documentation is no longer being updated. 
+  For the latest information, see the 
+  <a href="../current/index.html">current release documentation</a>. 
+</p>


### PR DESCRIPTION
Related to https://github.com/elastic/docs/pull/1426

This PR adds a banner to the Stack Overview, Installation and Upgrade Guide, and Getting Started Guide. 

NOTE: This PR should not be merged until after 7.5.0 is released.

Preview:
http://stack-docs_694.docs-preview.app.elstc.co/guide/en/elastic-stack-overview/7.4/index.html
http://stack-docs_694.docs-preview.app.elstc.co/guide/en/elastic-stack-get-started/7.4/index.html
http://stack-docs_694.docs-preview.app.elstc.co/guide/en/elastic-stack/7.4/index.html