### PR TITLE
Adds EOL banner in Installation and Upgrade Guide

### DIFF
--- a/docs/en/install-upgrade/page_header.html
+++ b/docs/en/install-upgrade/page_header.html
@@ -1,0 +1,10 @@
+<p>
+  <strong>WARNING</strong>: Version {version} of the {stack} has passed its 
+  <a href="https://www.elastic.co/support/eol">EOL date</a>. 
+</p>  
+<p>
+  This documentation is no longer being maintained and may be removed. 
+  If you are running this version, we strongly advise you to upgrade. 
+  For the latest information, see the 
+  <a href="../current/index.html">current release documentation</a>. 
+</p>

--- a/docs/en/install-upgrade/page_header.html
+++ b/docs/en/install-upgrade/page_header.html
@@ -1,5 +1,5 @@
 <p>
-  <strong>WARNING</strong>: Version {version} of the {stack} has passed its 
+  <strong>WARNING</strong>: Version 6.2 of the Elastic Stack has passed its 
   <a href="https://www.elastic.co/support/eol">EOL date</a>. 
 </p>  
 <p>


### PR DESCRIPTION
Related to elastic/docs#1426

This PR adds a banner to the Installation and Upgrade Guide.

Preview: http://stack-docs_695.docs-preview.app.elstc.co/guide/en/elastic-stack/6.2/index.html