### PR TITLE
[DOCS] Expands DFA limitations section with runtime paragraph

### DIFF
--- a/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
@@ -41,6 +41,17 @@ dedicated for {ml} processes. For general {ml} settings, see
 {ref}/ml-settings.html[{ml-cap} settings in {es}].
 
 [float]
+[[dfa-time-limitations]]
+=== {dfanalytics-jobs-cap} runtime may be vary
+
+The runtime of the {dfanalytics-jobs} depends on numerous factors, such as the 
+size of the dataset, the analytics type, the number of fields that are included 
+in the analysis, the used hyperparameters, and so on. For this reason, a 
+general runtime value that applies to all or most of the situations does not 
+exist. The runtime of a {dfanalytics-job} may take from a couple of minutes up 
+to tens of hours in extreme cases.
+
+[float]
 [[dfa-missing-fields-limitations]]
 === Documents with missing values in analyzed fields are skipped
 

--- a/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
@@ -45,11 +45,20 @@ dedicated for {ml} processes. For general {ml} settings, see
 === {dfanalytics-jobs-cap} runtime may be vary
 
 The runtime of the {dfanalytics-jobs} depends on numerous factors, such as the 
-size of the dataset, the analytics type, the number of fields that are included 
-in the analysis, the used hyperparameters, and so on. For this reason, a 
-general runtime value that applies to all or most of the situations does not 
-exist. The runtime of a {dfanalytics-job} may take from a couple of minutes up 
-to tens of hours in extreme cases.
+number of data points in the dataset, the analytics type, the number of fields 
+that are included in the analysis, the supplied hyperparameters, the type of 
+analyzed fields and so on. For example, running an analysis on a dataset with 
+many numerical fields will take longer than running an analysis on a dataset 
+that contains mainly categorical fields. Hyperparameters specified by the user 
+also lower the runtime. For this reason, a general runtime value that applies to 
+all or most of the situations does not exist. The runtime of a {dfanalytics-job} 
+may take from a couple of minutes up to 35 hours in extreme cases.
+
+The runtime increases with the increasing number of analyzed fields in a nearly 
+linear fashion. For datasets of more than 100 000 points, we recommend to start 
+with a low training percent and run a few {dfanalytics-jobs} to see how the 
+runtime scales with the increased number of data points and how the quality of 
+results scales with increased training percentage.
 
 [float]
 [[dfa-missing-fields-limitations]]


### PR DESCRIPTION
This PR adds a new limitation item to the data frame analytics limitation section about the possible runtime of the analytics jobs.