### PR TITLE
[7.5] Removes temporary "future docs" page headers (#658)

### DIFF
--- a/docs/en/logs/page_header.html
+++ b/docs/en/logs/page_header.html
@@ -1,3 +1,0 @@
-You are looking at documentation for a future release.
-Not what you want?
-See the <a href="https://www.elastic.co/guide/en/infrastructure/guide/current/index.html">current release documentation</a>.

--- a/docs/en/metrics/page_header.html
+++ b/docs/en/metrics/page_header.html
@@ -1,3 +1,0 @@
-You are looking at documentation for a future release.
-Not what you want?
-See the <a href="https://www.elastic.co/guide/en/infrastructure/guide/current/index.html">current release documentation</a>.


### PR DESCRIPTION
Backports the following commits to 7.5:
 - DO NOT CHECK IN BEFORE v7.5 RELEASE DAY. Removing temporary "future docs" page headers, ready for v7.5 docs. (#658)