### PR TITLE
[6.5] [DOCS] [FOR 7.5] Add superseded banner to older versions of Infrastructure Monitoring Guide (#654)

### DIFF
--- a/docs/en/infraops/page_header.html
+++ b/docs/en/infraops/page_header.html
@@ -1,0 +1,5 @@
+You are looking at documentation for an older release.
+Starting in version 7.5, see the
+<a href="https://www.elastic.co/guide/en/logs/guide/current/index.html"> Logs monitoring guide</a>
+and the <a href="https://www.elastic.co/guide/en/metrics/guide/current/index.html"> Metrics monitoring guide</a>
+for information about infrastructure monitoring.


### PR DESCRIPTION
Backports the following commits to 6.5:
 - [DOCS] [FOR 7.5] Add superseded banner to older versions of Infrastructure Monitoring Guide (#654)