### PR TITLE
[DOCS] Puts regression model info into a separated section

### DIFF
--- a/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
@@ -75,7 +75,7 @@ predictions are combined.
 
 [discrete]
 [[dfa-regression-model]]
-===== {regression-cap} models
+===== {regression-cap} algorithms
 
 The ensemble learning technique that we use in the {stack} is a type of boosting 
 called extreme gradient boost (XGboost) which combines decision trees with 

--- a/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
@@ -71,14 +71,20 @@ the {depvar} by combining the predictions from multiple base learners –
 algorithms that generalize from the dataset. The performance of an ensemble is 
 usually better than the performance of each individual base learner because the 
 individual learners will make different errors. These average out when their 
-predictions are combined. The ensemble learning technique that we use in the 
-{stack} is a type of boosting called extreme gradient boost (XGboost) which 
-combines decision trees with gradient boosting methodologies.
+predictions are combined.
+
+[discrete]
+[[dfa-regression-model]]
+===== {regression-cap} models
+
+The ensemble learning technique that we use in the {stack} is a type of boosting 
+called extreme gradient boost (XGboost) which combines decision trees with 
+gradient boosting methodologies.
 
 {regression-cap} works as a batch analysis. If new data comes into your index, 
 you must restart the {dfanalytics-job}.
 
- 
+
 [discrete]
 [[dfa-regression-evaluation]]
 ==== Measuring model performance

--- a/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
@@ -73,16 +73,17 @@ usually better than the performance of each individual base learner because the
 individual learners will make different errors. These average out when their 
 predictions are combined.
 
+{regression-cap} works as a batch analysis. If new data comes into your index, 
+you must restart the {dfanalytics-job}.
+
+
 [discrete]
-[[dfa-regression-model]]
+[[dfa-regression-algorithm]]
 ===== {regression-cap} algorithms
 
 The ensemble learning technique that we use in the {stack} is a type of boosting 
 called extreme gradient boost (XGboost) which combines decision trees with 
 gradient boosting methodologies.
-
-{regression-cap} works as a batch analysis. If new data comes into your index, 
-you must restart the {dfanalytics-job}.
 
 
 [discrete]


### PR DESCRIPTION
This PR adds a section title to the paragraph about regression models in the regression conceptual documentation. This makes it easier to link directly to the section about the used model.

Preview: http://stack-docs_723.docs-preview.app.elstc.co/guide/en/elastic-stack-overview/master/dfa-regression.html