### PR TITLE
[DOCS] Changes section title in classification conceptual docs

### DIFF
--- a/docs/en/stack/ml/df-analytics/dfa-classification.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-classification.asciidoc
@@ -42,7 +42,7 @@ supported in the {feature-var} fields.
 
 [discrete]
 [[dfa-classification-supervised]]
-==== Training the {classification} algorithm
+==== Training the {classification} model
 
 {classification-cap} – just like {regression} – is a supervised {ml} process. It 
 means that you need to supply a labeled training dataset that has some 

--- a/docs/en/stack/ml/df-analytics/dfa-classification.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-classification.asciidoc
@@ -53,8 +53,8 @@ learned about the relationships between the data points to classify new data.
 
 
 [discrete]
-[[dfa-classification-model]]
-===== {classification-cap} models
+[[dfa-classification-algorithm]]
+===== {classification-cap} algorithms
 
 The ensemble algorithm that we use in the {stack} is a type of boosting called 
 boosted tree regression model which combines multiple weak models into a 


### PR DESCRIPTION
This PR changes the title of the section about algorithms in the classification docs to be in line with the same section of the regression docs.

Related PR: https://github.com/elastic/stack-docs/pull/723