### PR TITLE
[7.2][DOCS] Remove CCR docs from Stack Overview (#464)

### DIFF
--- a/docs/en/stack/index.asciidoc
+++ b/docs/en/stack/index.asciidoc
@@ -19,8 +19,6 @@ include::introduction.asciidoc[]
 
 include::ml/anomaly-detection/index.asciidoc[]
 
-include::{es-repo-dir}/ccr/index.asciidoc[]
-
 include::troubleshooting.asciidoc[]
 
 include::limitations.asciidoc[]

--- a/docs/en/stack/redirects.asciidoc
+++ b/docs/en/stack/redirects.asciidoc
@@ -938,3 +938,40 @@ See {ref}/monitor-elasticsearch-cluster.html[Monitor a cluster].
 
 This page has moved.
 See {ref}/esms.html[{esms}].
+
+[role="exclude",id="xpack-ccr"]
+=== Cross-cluster replication
+
+See {ref}/xpack-ccr.html[{ccr-cap}].
+
+[role="exclude",id="ccr-overview"]
+=== {ccr-cap} overview
+
+See {ref}/ccr-overview.html[{ccr-cap} overview].
+
+[role="exclude",id="ccr-requirements"]
+=== Requirements for leader indices
+[[ccr-overview-beats]]
+
+See {ref}/ccr-requirements.html[Requirements for leader indices].
+
+[role="exclude",id="ccr-auto-follow"]
+=== Automatically following indices
+
+See {ref}/ccr-auto-follow.html[Automatically following indices].
+
+[role="exclude",id="ccr-getting-started"]
+=== Getting started with {ccr}
+
+See {ref}/ccr-getting-started.html[Getting started with {ccr}].
+
+[role="exclude",id="remote-recovery"]
+=== Remote recovery
+
+See {ref}/remote-recovery.html[Remote recovery].
+
+[role="exclude",id="ccr-upgrading"]
+=== Upgrading clusters
+
+See {ref}/ccr-upgrading.html[Upgrading clusters].
+


### PR DESCRIPTION
Backports https://github.com/elastic/stack-docs/pull/464