### PR TITLE
[DOCS] Fine-tunes regression docs section titles

### DIFF
--- a/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
@@ -55,7 +55,7 @@ Arrays are not supported.
 
 [discrete]
 [[dfa-regression-supervised]]
-==== Training the {regression} algorithm
+==== Training the {regression} model
 
 {regression-cap} is a supervised machine learning process, which means that you 
 need to supply a labeled training dataset that has some {feature-vars} and a 


### PR DESCRIPTION
This PR changes a section title in the regression conceptual doc to be in line with the classification doc structure. See https://github.com/elastic/stack-docs/pull/727