### PR TITLE
Adds ecs fields for ml jobs

### DIFF
--- a/docs/en/siem/machine-learning.asciidoc
+++ b/docs/en/siem/machine-learning.asciidoc
@@ -33,15 +33,17 @@ the job's `Group` field ({kib} -> {ml-cap} -> Create/Edit job -> Job details).
 
 The SIEM app comes with prebuilt {ml} {anomaly-jobs} for automatically detecting
 host and network anomalies. The jobs are displayed in the `Anomaly Detection`
-interface. They are available if you ship data using 
-https://www.elastic.co/products/beats[Beats] and {kib} is configured with the required
-index patterns (`auditbeat-*`, `filebeat-*`, `packetbeat-*`, or `winlogbeat-*`
-via {kib} -> Management -> Index Patterns).
+interface. They are available when:
 
-NOTE: Machine learning jobs look back and analyse two weeks of historical data prior to
-the time they are enabled. After jobs are enabled, they continuously analyse incoming data.
-When jobs are stopped and restarted within the two week timeframe, previously
-analysed data is not processed again.
+* You ship data using https://www.elastic.co/products/beats[Beats] and {kib} is 
+configured with the required index patterns (`auditbeat-*`, `filebeat-*`, `packetbeat-*`, or `winlogbeat-*` via {kib} -> Management -> Index Patterns).
+* Your shipped data is ECS compliant and {kib} is configured with the data's 
+index patterns.
+
+NOTE: Machine learning jobs look back and analyse two weeks of historical data 
+prior to the time they are enabled. After jobs are enabled, they continuously 
+analyse incoming data. When jobs are stopped and restarted within the two week 
+timeframe, previously analysed data is not processed again.
 
 <<prebuilt-ml-jobs>> describes all available {ml} jobs and lists 
 which beats are required on your hosts for each job. For information on tuning
@@ -59,14 +61,18 @@ are shown, you can modify {kib} -> Management -> Advanced Settings -> `siem:defa
 [[prebuilt-ml-jobs]]
 === Prebuilt job reference
 
-Prebuilt jobs automatically detect file system and network anomalies on your hosts:
+Prebuilt jobs automatically detect file system and network anomalies on your 
+hosts. If you use Beats to ship your data, the ECS fields are populated and you 
+do not need to manually map the fields.
+
+The following prebuilt jobs are available:
 
 [horizontal]
 rare_process_by_host_windows_ecs::
 +
-rare_process_by_host_linux_ecs:: Identifies rare processes that do not usually run
-on individual Windows/Linux hosts, which can indicate execution of unauthorized
-services, malware, or persistence mechanisms.
+rare_process_by_host_linux_ecs:: Identifies rare processes that do not usually 
+run on individual Windows/Linux hosts, which can indicate execution of 
+unauthorized services, malware, or persistence mechanisms.
 +
 Processes are considered rare when they only run occasionally as compared with
 other processes running on the host.
@@ -75,6 +81,16 @@ Beats required on hosts:
 
 * Auditbeat (Linux)
 * Winlogbeat (Windows)
+
++
+Required ECS fields:
+
+* host.name
+* process.name
+* user.name
+* event.action
+* agent.type
+
 windows_anomalous_network_activity_ecs::
 +
 linux_anomalous_network_activity_ecs:: Identifies Windows/Linux processes that do
@@ -90,6 +106,17 @@ Beats required on hosts:
 
 * Auditbeat (Linux)
 * Winlogbeat (Windows)
+
++
+Required ECS fields:
+
+* destination.ip
+* host.name
+* process.name
+* user.name
+* event.action
+* agent.type
+
 windows_anomalous_path_activity_ecs:: Identifies processes started from atypical
 folders in the file system, which might indicate malware execution or persistence
 mechanisms.
@@ -102,6 +129,17 @@ directly from the internet or a malicious script/macro executed malware.
 Beats required on hosts:
 
 * Winlogbeat (Windows)
+
++
+Required ECS fields:
+
+* host.name
+* process.name
+* process.working_directory
+* user.name
+* event.action
+* agent.type
+
 windows_anomalous_process_all_hosts_ecs::
 +
 linux_anomalous_process_all_hosts_ecs:: Searches for rare processes running on
@@ -115,6 +153,17 @@ Beats required on hosts:
 
 * Auditbeat (Linux)
 * Winlogbeat (Windows)
+
++
+Required ECS fields:
+
+* host.name
+* process.name
+* process.executable (Windows)
+* user.name
+* event.action
+* agent.type
+
 windows_anomalous_process_creation:: Identifies unusual parent/child process
 relationships that could indicate malware execution or persistence mechanisms.
 +
@@ -130,6 +179,17 @@ new and emerging malware that is not yet recognized by anti-virus scanners.
 Beats required on hosts:
 
 * Winlogbeat (Windows)
+
++
+Required ECS fields:
+
+* host.name
+* process.name
+* process.parent.name
+* user.name
+* event.action
+* agent.type
+
 windows_anomalous_script:: Searches for PowerShell scripts with unusual data
 characteristics, such as obfuscation, that may be a characteristic of malicious
 PowerShell script text blocks.
@@ -137,53 +197,83 @@ PowerShell script text blocks.
 Beats required on hosts:
 
 * Winlogbeat
-windows_anomalous_service:: Searches for unusual Windows services that could indicate
-execution of unauthorized services, malware, or persistence mechanisms.
+
 +
-In corporate Windows environments, hosts do not generally run many rare or unique
-services. This job helps detect malware and persistence mechanisms that have been
-installed and run as a service.
+NOTE: This job is not fully ECS compliant and can only be run when Winlogbeat 
+is used to ships data.
+
+windows_anomalous_service:: Searches for unusual Windows services that could 
+indicate execution of unauthorized services, malware, or persistence mechanisms.
++
+In corporate Windows environments, hosts do not generally run many rare or 
+unique services. This job helps detect malware and persistence mechanisms that 
+have been installed and run as a service.
 +
 Beats required on hosts:
 
 * Winlogbeat (Windows)
+
++
+NOTE: This job is not fully ECS compliant and can only be run when Winlogbeat 
+is used to ships data.
+
 windows_anomalous_user_name_ecs::
 +
-linux_anomalous_user_name_ecs:: Searches for activity from users who are not normally
-active, which could indicate unauthorized changes, activity by unauthorized users,
-lateral movement, and compromised credentials.
+linux_anomalous_user_name_ecs:: Searches for activity from users who are not 
+normally active, which could indicate unauthorized changes, activity by 
+unauthorized users, lateral movement, and compromised credentials.
 +
-In organizations, new usernames are not often created apart from specific types of
-system activities, such as creating new accounts for new employees. These user
-accounts quickly become active and routine.
+In organizations, new usernames are not often created apart from specific types 
+of system activities, such as creating new accounts for new employees. These 
+user accounts quickly become active and routine.
 +
-Events from rarely used usernames can point to suspicious activity. Additionally,
-automated Linux fleets tent to see activity from rarely used usernames only when
-personnel log in to make authorized or unauthorized changes, or threat actors have
-acquired credentials and log in for malicious purposes. Unusual usernames can also
-indicate pivoting, where compromised credentials are used to try and move
-laterally from one host to another.
+Events from rarely used usernames can point to suspicious activity. 
+Additionally, automated Linux fleets tent to see activity from rarely used 
+usernames only when personnel log in to make authorized or unauthorized 
+changes, or threat actors have acquired credentials and log in for malicious 
+purposes. Unusual usernames can also indicate pivoting, where compromised 
+credentials are used to try and move laterally from one host to another.
 +
 Beats required on hosts:
 
 * Auditbeat (Linux)
 * Winlogbeat (Windows)
+
++
+Required ECS fields:
+
+* host.name
+* process.name
+* user.name
+* event.action
+* agent.type
+
 linux_anomalous_network_port_activity_ecs:: Identifies unusual destination port
 activity that could indicate command-and-control, persistence mechanism, or data
 exfiltration activity.
 +
-Rarely used destination port activity is generally unusual in Linux fleets and can
-indicate unauthorized access or threat actor activity.
+Rarely used destination port activity is generally unusual in Linux fleets and 
+can indicate unauthorized access or threat actor activity.
 +
 Beats required on hosts:
 
 * Auditbeat (Linux)
+
++
+NOTE: This job is not fully ECS compliant and can only be run when Auditbeat 
+is used to ships data. 
+
 linux_anomalous_network_service:: Searches for unusual listening ports that
 could indicate execution of unauthorized services, backdoors, or persistence mechanisms.
 +
 Beats required on hosts:
 
 * Auditbeat (Linux)
+
++
+NOTE: This job is not fully ECS compliant and can only be run when Auditbeat 
+is used to ships data.
+
 linux_anomalous_network_url_activity_ecs:: Searches for unusual web URL requests
 from hosts, which could indicate malware delivery and execution.
 +
@@ -197,13 +287,26 @@ indicate unauthorized downloads or threat activity.
 Beats required on hosts:
 
 * Auditbeat (Linux)
-suspicious_login_activity_ecs:: Identifies an unusually high number of 
-authentication attempts.
+
++
+Required ECS fields:
+
+* destination.ip
+* destination.port
+* host.name
+* process.name
+* process.title
+* event.action
+* agent.type
+
+suspicious_login_activity_ecs:: Identifies an unusually high number of authentication
+attempts.
 +
 Beats required on hosts:
 
 * Auditbeat (Windows and Linux)
 * Winlogbeat (Windows)
+
 Packetbeat_dns_tunneling:: Searches for unusually large numbers of DNS queries
 for a single top-level DNS domain, which is often used for DNS tunneling.
 +
@@ -214,6 +317,7 @@ domain (TLD) as it uses the DNS protocol to tunnel data.
 Beats required on hosts:
 
 * Packetbeat (Windows and Linux)
+
 Packetbeat_rare_dns_question:: Searches for rare and unusual DNS queries that
 indicate network activity with unusual domains is about to occur. This can be 
 due
@@ -227,6 +331,7 @@ DNS domain the malware uses for command-and-control communication.
 Beats required on hosts:
 
 * Packetbeat (Windows and Linux)
+
 Packetbeat_rare_server_domain:: Searches for rare and unusual DNS queries that
 indicate network activity with unusual domains is about to occur. This can be due
 to initial access, persistence, command-and-control, or exfiltration activity.
@@ -239,6 +344,7 @@ DNS domain the malware uses for command-and-control communication.
 Beats required on hosts:
 
 * Packetbeat (Windows and Linux)
+
 Packetbeat_rare_urls:: Searches for rare and unusual URLs that indicate unusual web
 browsing activity. This can be due to initial access, persistence,
 command-and-control, or exfiltration activity.
@@ -256,6 +362,7 @@ are part of common Internet background traffic.
 Beats required on hosts:
 
 * Packetbeat (Windows and Linux)
+
 Packetbeat_rare_user_agent:: Searches for rare and unusual user agents that
 indicate web browsing activity by an unusual process other than a web browser.
 This can be due to persistence, command-and-control, or exfiltration activity.

--- a/docs/en/siem/machine-learning.asciidoc
+++ b/docs/en/siem/machine-learning.asciidoc
@@ -71,7 +71,7 @@ do not need to manually map the fields.
 
 The following prebuilt jobs are available:
 
-[horizontal]
+//[horizontal]
 rare_process_by_host_windows_ecs::
 +
 rare_process_by_host_linux_ecs:: Identifies rare processes that do not usually 
@@ -202,7 +202,6 @@ Beats required on hosts:
 
 * Winlogbeat (Windows)
 
-+
 NOTE: You can only run this job when Winlogbeat is used to ship data.
 
 windows_anomalous_service:: Searches for unusual Windows services that could 
@@ -216,7 +215,6 @@ Beats required on hosts:
 
 * Winlogbeat (Windows)
 
-+
 NOTE: You can only run this job when Winlogbeat is used to ship data.
 
 windows_anomalous_user_name_ecs::
@@ -261,7 +259,6 @@ Beats required on hosts:
 
 * Auditbeat (Linux)
 
-+
 NOTE: You can only run this job when Auditbeat is used to ship data. 
 
 linux_anomalous_network_service:: Searches for unusual listening ports that
@@ -271,7 +268,6 @@ Beats required on hosts:
 
 * Auditbeat (Linux)
 
-+
 NOTE: You can only run this job when Auditbeat is used to ship data.
 
 linux_anomalous_network_url_activity_ecs:: Searches for unusual web URL requests
@@ -327,7 +323,20 @@ Beats required on hosts:
 * Packetbeat (Windows and Linux)
 
 +
-NOTE: You can only run this job when Packetbeat is used to ship data.
+Required ECS fields:
+
+* destination.ip
+* dns.question.registered_domain
+* dns.question.name
+* host.name
+* event.dataset
+* agent.type
+
+NOTE: This {ml} job uses the Packetbeat
+{packetbeat-ref}/exported-fields-dns.html[`dns.question.etld_plus_one`] field, 
+which is not defined in ECS. Instead, map your network data to the
+{ecs-ref}/ecs-dns.html[`dns.question.registered_domain`] ECS 
+field.
 
 packetbeat_rare_dns_question:: Searches for rare and unusual DNS queries that
 indicate network activity with unusual domains is about to occur. This can be 
@@ -438,9 +447,7 @@ Beats required on hosts:
 
 * Winlogbeat (Windows)
 
-+
 NOTE: You can only run this job when Winlogbeat is used to ship data.
-
 
 windows_rare_user_runas_event:: Searches for unusual user context switches 
 using the `runas` command or similar techniques, which could indicate account 

--- a/docs/en/siem/machine-learning.asciidoc
+++ b/docs/en/siem/machine-learning.asciidoc
@@ -36,10 +36,10 @@ The SIEM app comes with prebuilt {ml} {anomaly-jobs} for automatically detecting
 host and network anomalies. The jobs are displayed in the `Anomaly Detection`
 interface. They are available when:
 
-* You ship data using https://www.elastic.co/products/beats[Beats] and {kib} is 
-configured with the required index patterns (`auditbeat-*`, `filebeat-*`, 
-`packetbeat-*`, or `winlogbeat-*` via {kib} -> Management -> Index Patterns).
-* Your shipped data is ECS compliant and {kib} is configured with the data's 
+* You ship data using https://www.elastic.co/products/beats[Beats], and
+{kib} is configured with the required index patterns
+(`auditbeat-*`, `filebeat-*`, `packetbeat-*`, or `winlogbeat-*` via {kib} -> Management -> Index Patterns).
+* Your shipped data is ECS-compliant, and {kib} is configured with the data's 
 index patterns.
 
 NOTE: Machine learning jobs look back and analyse two weeks of historical data 

--- a/docs/en/siem/machine-learning.asciidoc
+++ b/docs/en/siem/machine-learning.asciidoc
@@ -200,7 +200,7 @@ Beats required on hosts:
 
 +
 NOTE: This job is not fully ECS compliant and can only be run when Winlogbeat 
-is used to ships data.
+is used to ship data.
 
 windows_anomalous_service:: Searches for unusual Windows services that could 
 indicate execution of unauthorized services, malware, or persistence mechanisms.
@@ -215,7 +215,7 @@ Beats required on hosts:
 
 +
 NOTE: This job is not fully ECS compliant and can only be run when Winlogbeat 
-is used to ships data.
+is used to ship data.
 
 windows_anomalous_user_name_ecs::
 +
@@ -261,7 +261,7 @@ Beats required on hosts:
 
 +
 NOTE: This job is not fully ECS compliant and can only be run when Auditbeat 
-is used to ships data. 
+is used to ship data. 
 
 linux_anomalous_network_service:: Searches for unusual listening ports that
 could indicate execution of unauthorized services, backdoors, or persistence mechanisms.
@@ -272,7 +272,7 @@ Beats required on hosts:
 
 +
 NOTE: This job is not fully ECS compliant and can only be run when Auditbeat 
-is used to ships data.
+is used to ship data.
 
 linux_anomalous_network_url_activity_ecs:: Searches for unusual web URL requests
 from hosts, which could indicate malware delivery and execution.

--- a/docs/en/siem/machine-learning.asciidoc
+++ b/docs/en/siem/machine-learning.asciidoc
@@ -26,7 +26,7 @@ SIEM machine learning jobs.
 
 TIP: To add a custom job to the `Anomaly Detection` interface, add a `SIEM` tag 
 to the job's `Group` field ({kib} -> {ml-cap} -> Create/Edit job -> Job 
-  details).
+details).
 
 [float]
 [[included-jobs]]

--- a/docs/en/siem/machine-learning.asciidoc
+++ b/docs/en/siem/machine-learning.asciidoc
@@ -203,7 +203,7 @@ Beats required on hosts:
 * Winlogbeat (Windows)
 
 +
-NOTE: This job can only be run when Winlogbeat is used to ship data.
+NOTE: You can only run this job when Winlogbeat is used to ship data.
 
 windows_anomalous_service:: Searches for unusual Windows services that could 
 indicate execution of unauthorized services, malware, or persistence mechanisms.
@@ -217,7 +217,7 @@ Beats required on hosts:
 * Winlogbeat (Windows)
 
 +
-NOTE: This job can only be run when Winlogbeat is used to ship data.
+NOTE: You can only run this job when Winlogbeat is used to ship data.
 
 windows_anomalous_user_name_ecs::
 +
@@ -262,7 +262,7 @@ Beats required on hosts:
 * Auditbeat (Linux)
 
 +
-NOTE: This job can only be run when Auditbeat is used to ship data. 
+NOTE: You can only run this job when Auditbeat is used to ship data. 
 
 linux_anomalous_network_service:: Searches for unusual listening ports that
 could indicate execution of unauthorized services, backdoors, or persistence mechanisms.
@@ -272,7 +272,7 @@ Beats required on hosts:
 * Auditbeat (Linux)
 
 +
-NOTE: This job can only be run when Auditbeat is used to ship data.
+NOTE: You can only run this job when Auditbeat is used to ship data.
 
 linux_anomalous_network_url_activity_ecs:: Searches for unusual web URL requests
 from hosts, which could indicate malware delivery and execution.
@@ -327,7 +327,7 @@ Beats required on hosts:
 * Packetbeat (Windows and Linux)
 
 +
-NOTE: This job can only be run when Packetbeat is used to ship data.
+NOTE: You can only run this job when Packetbeat is used to ship data.
 
 packetbeat_rare_dns_question:: Searches for rare and unusual DNS queries that
 indicate network activity with unusual domains is about to occur. This can be 
@@ -439,7 +439,7 @@ Beats required on hosts:
 * Winlogbeat (Windows)
 
 +
-NOTE: This job can only be run when Winlogbeat is used to ship data.
+NOTE: You can only run this job when Winlogbeat is used to ship data.
 
 
 windows_rare_user_runas_event:: Searches for unusual user context switches 

--- a/docs/en/siem/machine-learning.asciidoc
+++ b/docs/en/siem/machine-learning.asciidoc
@@ -24,8 +24,9 @@ For users with the `ml_admin` role, the `Anomaly Detection` interface within
 the main navigation header can be used for for viewing, starting, and stopping
 SIEM machine learning jobs.
 
-TIP: To add a custom job to the `Anomaly Detection` interface, add a `SIEM` tag to
-the job's `Group` field ({kib} -> {ml-cap} -> Create/Edit job -> Job details).
+TIP: To add a custom job to the `Anomaly Detection` interface, add a `SIEM` tag 
+to the job's `Group` field ({kib} -> {ml-cap} -> Create/Edit job -> Job 
+  details).
 
 [float]
 [[included-jobs]]
@@ -36,7 +37,8 @@ host and network anomalies. The jobs are displayed in the `Anomaly Detection`
 interface. They are available when:
 
 * You ship data using https://www.elastic.co/products/beats[Beats] and {kib} is 
-configured with the required index patterns (`auditbeat-*`, `filebeat-*`, `packetbeat-*`, or `winlogbeat-*` via {kib} -> Management -> Index Patterns).
+configured with the required index patterns (`auditbeat-*`, `filebeat-*`, 
+`packetbeat-*`, or `winlogbeat-*` via {kib} -> Management -> Index Patterns).
 * Your shipped data is ECS compliant and {kib} is configured with the data's 
 index patterns.
 
@@ -47,7 +49,8 @@ timeframe, previously analysed data is not processed again.
 
 <<prebuilt-ml-jobs>> describes all available {ml} jobs and lists 
 which beats are required on your hosts for each job. For information on tuning
-anomaly results to reduce the number of false positive, see <<tuning-anomaly-results>>.
+anomaly results to reduce the number of false positive, see
+<<tuning-anomaly-results>>.
 
 [float]
 [[view-anomolies]]
@@ -55,8 +58,9 @@ anomaly results to reduce the number of false positive, see <<tuning-anomaly-res
 To view the `Anomalies` table widget and `Max Anomaly Score By Job` details,
 the user must have the `ml_admin` or `ml_user` role.
 
-NOTE: To adjust the `score` threshold for which {ml-docs}/xpack-ml.html[anomalies]
-are shown, you can modify {kib} -> Management -> Advanced Settings -> `siem:defaultAnomalyScore`.
+NOTE: To adjust the `score` threshold that determines which
+{ml-docs}/xpack-ml.html[anomalies] are shown, you can modify {kib} -> 
+Management -> Advanced Settings -> `siem:defaultAnomalyScore`.
 
 [[prebuilt-ml-jobs]]
 === Prebuilt job reference
@@ -196,11 +200,10 @@ PowerShell script text blocks.
 +
 Beats required on hosts:
 
-* Winlogbeat
+* Winlogbeat (Windows)
 
 +
-NOTE: This job is not fully ECS compliant and can only be run when Winlogbeat 
-is used to ship data.
+NOTE: This job can only be run when Winlogbeat is used to ship data.
 
 windows_anomalous_service:: Searches for unusual Windows services that could 
 indicate execution of unauthorized services, malware, or persistence mechanisms.
@@ -214,8 +217,7 @@ Beats required on hosts:
 * Winlogbeat (Windows)
 
 +
-NOTE: This job is not fully ECS compliant and can only be run when Winlogbeat 
-is used to ship data.
+NOTE: This job can only be run when Winlogbeat is used to ship data.
 
 windows_anomalous_user_name_ecs::
 +
@@ -260,8 +262,7 @@ Beats required on hosts:
 * Auditbeat (Linux)
 
 +
-NOTE: This job is not fully ECS compliant and can only be run when Auditbeat 
-is used to ship data. 
+NOTE: This job can only be run when Auditbeat is used to ship data. 
 
 linux_anomalous_network_service:: Searches for unusual listening ports that
 could indicate execution of unauthorized services, backdoors, or persistence mechanisms.
@@ -271,18 +272,17 @@ Beats required on hosts:
 * Auditbeat (Linux)
 
 +
-NOTE: This job is not fully ECS compliant and can only be run when Auditbeat 
-is used to ship data.
+NOTE: This job can only be run when Auditbeat is used to ship data.
 
 linux_anomalous_network_url_activity_ecs:: Searches for unusual web URL requests
 from hosts, which could indicate malware delivery and execution.
 +
-Wget and cURL are commonly used by Linux programs to download code and data. Most
-of the time, their usage is entirely normal. Generally, because they use a list of
-URLs, they repeatedly download from the same locations. However, Wget and cURL are
-sometimes used to deliver Linux exploit payloads, and threat actors use these tools
-to download additional software and code. For these reasons, unusual URLs can
-indicate unauthorized downloads or threat activity.
+Wget and cURL are commonly used by Linux programs to download code and data. 
+Most of the time, their usage is entirely normal. Generally, because they use a 
+list of URLs, they repeatedly download from the same locations. However, Wget 
+and cURL are sometimes used to deliver Linux exploit payloads, and threat 
+actors use these tools to download additional software and code. For these 
+reasons, unusual URLs can indicate unauthorized downloads or threat activity.
 +
 Beats required on hosts:
 
@@ -296,57 +296,88 @@ Required ECS fields:
 * host.name
 * process.name
 * process.title
-* event.action
 * agent.type
 
-suspicious_login_activity_ecs:: Identifies an unusually high number of authentication
-attempts.
+suspicious_login_activity_ecs:: Identifies an unusually high number of 
+authentication attempts.
 +
 Beats required on hosts:
 
 * Auditbeat (Windows and Linux)
 * Winlogbeat (Windows)
 
-Packetbeat_dns_tunneling:: Searches for unusually large numbers of DNS queries
++
+Required ECS fields:
+
+* source.ip
+* host.name
+* user.name
+* event.category
+* agent.type
+
+packetbeat_dns_tunneling:: Searches for unusually large numbers of DNS queries
 for a single top-level DNS domain, which is often used for DNS tunneling.
 +
-DNS tunneling can be used for command-and-control, persistence, or data exfiltration
-activity. For example, dnscat tends to generate many DNS questions for a top-level
-domain (TLD) as it uses the DNS protocol to tunnel data.
+DNS tunneling can be used for command-and-control, persistence, or data 
+exfiltration activity. For example, dnscat tends to generate many DNS questions 
+for a top-level domain (TLD) as it uses the DNS protocol to tunnel data.
 +
 Beats required on hosts:
 
 * Packetbeat (Windows and Linux)
 
-Packetbeat_rare_dns_question:: Searches for rare and unusual DNS queries that
++
+NOTE: This job can only be run when Packetbeat is used to ship data.
+
+packetbeat_rare_dns_question:: Searches for rare and unusual DNS queries that
 indicate network activity with unusual domains is about to occur. This can be 
-due
-to initial access, persistence, command-and-control, or exfiltration activity.
+due to initial access, persistence, command-and-control, or exfiltration 
+activity.
 +
-For example, when a user clicks on a link in a phishing email or opens a malicious
-document, a request may be sent to an uncommon domain to download and run a payload.
-When malware is already running, it may send requests to an uncommon
-DNS domain the malware uses for command-and-control communication.
-+
-Beats required on hosts:
-
-* Packetbeat (Windows and Linux)
-
-Packetbeat_rare_server_domain:: Searches for rare and unusual DNS queries that
-indicate network activity with unusual domains is about to occur. This can be due
-to initial access, persistence, command-and-control, or exfiltration activity.
-+
-For example, when a user clicks on a link in a phishing email or opens a malicious
-document, a request may be sent to an uncommon HTTP or TLS server to download and
-run a payload. When malware is already running, it may send requests to an uncommon
-DNS domain the malware uses for command-and-control communication.
+For example, when a user clicks on a link in a phishing email or opens a 
+malicious document, a request may be sent to an uncommon domain to download and 
+run a payload. When malware is already running, it may send requests to an
+uncommon DNS domain the malware uses for command-and-control communication.
 +
 Beats required on hosts:
 
 * Packetbeat (Windows and Linux)
 
-Packetbeat_rare_urls:: Searches for rare and unusual URLs that indicate unusual web
-browsing activity. This can be due to initial access, persistence,
++
+Required ECS fields:
+
+* dns.question.name
+* dns.question.type
+* host.name
+* event.dataset
+* agent.type
+
+packetbeat_rare_server_domain:: Searches for rare and unusual DNS queries that
+indicate network activity with unusual domains is about to occur. This can be 
+due to initial access, persistence, command-and-control, or exfiltration 
+activity.
++
+For example, when a user clicks on a link in a phishing email or opens a 
+malicious document, a request may be sent to an uncommon HTTP or TLS server to 
+download and run a payload. When malware is already running, it may send 
+requests to an uncommon DNS domain the malware uses for command-and-control 
+communication.
++
+Beats required on hosts:
+
+* Packetbeat (Windows and Linux)
+
++
+Required ECS fields:
+
+* destination.ip
+* source.ip
+* server.domain
+* host.name
+* agent.type
+
+packetbeat_rare_urls:: Searches for rare and unusual URLs that indicate unusual 
+web browsing activity. This can be due to initial access, persistence,
 command-and-control, or exfiltration activity.
 +
 For example, in a strategic web compromise or watering hole attack, when a
@@ -363,7 +394,15 @@ Beats required on hosts:
 
 * Packetbeat (Windows and Linux)
 
-Packetbeat_rare_user_agent:: Searches for rare and unusual user agents that
++
+Required ECS fields:
+
+* destination.ip
+* url.full
+* host.name
+* agent.type
+
+packetbeat_rare_user_agent:: Searches for rare and unusual user agents that
 indicate web browsing activity by an unusual process other than a web browser.
 This can be due to persistence, command-and-control, or exfiltration activity.
 Uncommon user agents coming from remote sources to local destinations are often
@@ -380,7 +419,17 @@ local sources can also be due to malware or scanning activity.
 Beats required on hosts:
 
 * Packetbeat (Windows and Linux)
-Windows_rare_user_type10_remote_login:: Searches for unusual remote desktop 
+
++
+Required ECS fields:
+
+* destination.ip
+* host.name
+* event.dataset
+* user_agent.original
+* agent.type
+
+windows_rare_user_type10_remote_login:: Searches for unusual remote desktop 
 protocol (RDP) logins, which could indicate account takeover or credentialed 
 persistence using compromised accounts. RDP attacks such as BlueKeep also tend 
 to use unusual usernames.
@@ -388,7 +437,12 @@ to use unusual usernames.
 Beats required on hosts:
 
 * Winlogbeat (Windows)
-Windows_rare_user_runas_event:: Searches for unusual user context switches 
+
++
+NOTE: This job can only be run when Winlogbeat is used to ship data.
+
+
+windows_rare_user_runas_event:: Searches for unusual user context switches 
 using the `runas` command or similar techniques, which could indicate account 
 takeover or privilege escalation using compromised accounts. Privilege 
 elevation using tools like `runas` is more common for domain and network 
@@ -398,3 +452,12 @@ department.
 Beats required on hosts:
 
 * Winlogbeat (Windows)
+
++
+Required ECS fields:
+
+* process.name
+* host.name
+* user.name
+* event.code
+* agent.type


### PR DESCRIPTION
Adds the ECS fields required to run each ML job. When a job uses a beats-specific field, I've added a note stating the job can only be run when data is shipped via beats.

@randomuserid - [here's the preview](http://stack-docs_738.docs-preview.app.elstc.co/guide/en/siem/guide/master/prebuilt-ml-jobs.html).

Resolves #724 