### PR TITLE
[DOCS] Added older release notice.

### DIFF
--- a/docs/en/getting-started/page_header.html
+++ b/docs/en/getting-started/page_header.html
@@ -1,0 +1,5 @@
+<p>
+  <strong>NOTE</strong>: You are looking at documentation for an older release. 
+  For the latest information, see the 
+  <a href="../current/index.html">current release documentation</a>. 
+</p>  

--- a/docs/en/install-upgrade/page_header.html
+++ b/docs/en/install-upgrade/page_header.html
@@ -1,0 +1,5 @@
+<p>
+  <strong>NOTE</strong>: You are looking at documentation for an older release. 
+  For the latest information, see the 
+  <a href="../current/index.html">current release documentation</a>. 
+</p>  

--- a/docs/en/stack/page_header.html
+++ b/docs/en/stack/page_header.html
@@ -1,0 +1,5 @@
+<p>
+  <strong>NOTE</strong>: You are looking at documentation for an older release. 
+  For the latest information, see the 
+  <a href="../current/index.html">current release documentation</a>. 
+</p>  


### PR DESCRIPTION
Explicitly set page_header.html for 6.8 so that the default notice can be updated for OOM versions. 

Prerequisite for:  https://github.com/elastic/docs/pull/1528

