### PR TITLE
[DOCS] Adds how DFA jobs work section

### DIFF
--- a/docs/en/stack/ml/df-analytics/ml-dfa-overview.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-overview.asciidoc
@@ -11,7 +11,8 @@ data points.
 
 The process leaves the source index intact, it creates a new index that contains 
 a copy of the source data and the annotated data. You can slice and dice the 
-data extended with the results as you normally do with any other data set.
+data extended with the results as you normally do with any other data set. Read 
+<<ml-dfa-phases>> for more information.
 
 You can evaluate the {dfanalytics} performance by using the {evaluatedf-api} 
 against a marked up data set. It helps you understand error distributions and 
@@ -32,3 +33,6 @@ table below.
 | {classification}          | supervised    | {classification}
 |===
 
+--
+
+include::ml-dfa-phases.asciidoc[]

--- a/docs/en/stack/ml/df-analytics/ml-dfa-overview.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-overview.asciidoc
@@ -33,6 +33,5 @@ table below.
 | {classification}          | supervised    | {classification}
 |===
 
---
 
 include::ml-dfa-phases.asciidoc[]

--- a/docs/en/stack/ml/df-analytics/ml-dfa-phases.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-phases.asciidoc
@@ -24,7 +24,7 @@ Let's take a look at the phases one-by-one.
 ==== Reindexing
 
 During the reindexing phase the documents from the source index or indices are 
-copied to the destination index. If the destination index does not exist, then 
+copied to the destination index. If you want to define settings or mappings, create the index before you start the job. Otherwise,
 the job creates it using default settings.
 This provides flexibility for 
 you to create the destination index and define any settings or mappings that you 

--- a/docs/en/stack/ml/df-analytics/ml-dfa-phases.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-phases.asciidoc
@@ -43,7 +43,7 @@ expects, then sends it to the analysis process.
 
 
 [discrete]
-===== Analyzing
+==== Analyzing
 
 When all the required data is loaded, the analyzing phase begins. The exact 
 process always depends on the type of {dfanalytics} – for example, 

--- a/docs/en/stack/ml/df-analytics/ml-dfa-phases.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-phases.asciidoc
@@ -1,0 +1,69 @@
+[role="xpack"]
+[[ml-dfa-phases]]
+=== How a {dfanalytics-job} works
+
+This page provides high-level background information on how {dfanalytics-jobs} 
+work, what kind of phases the jobs have, and what happens during the individual 
+phases.
+
+
+[discrete]
+==== The phases of a {dfanalytics-job}
+
+A {dfanalytics-job} has two states: started and stopped. Until its state 
+switches from started to stopped, the job goes through four phases regardless of 
+the {dfanalytics} type it performs. The phases are discrete steps of the 
+{dfanalytics-job} that is essentially a persistent {es} task. The four phases 
+are the following:
+
+* reindexing,
+* loading data,
+* analyzing,
+* writing results.
+
+Let's take a look at the phases one-by-one.
+
+
+[discrete]
+===== Reindexing
+
+During the reindexing phase the documents from the source index or indices are 
+copied to the destination index. If the destination index does not exist, then 
+the job creates it before reindexing by using default settings. If it is already 
+created, then the job will use the existing index. This provides flexibility for 
+you to create the destination index and define any settings or mappings that you 
+want to have in it. 
+
+If the destination index is built, the {dfanalytics-job} task calls the {es} 
+{ref}/docs-reindex.html[Reindex API] to launch the reindexing task. When you 
+call the {ref}/get-dfanalytics-stats.html[Get {dfanalytics-job} statistics API] 
+to check the progress and the job is in the reindexing phase, then the job calls 
+the {ref}/tasks.html[Task management API] to report back the state of the phase.
+
+
+[discrete]
+===== Loading data
+
+After the reindexing is finished, the job fetches the needed data from the 
+destination index, converts it into the format that the analysis process 
+expects, then sends it to the analysis process.
+
+
+[discrete]
+===== Analyzing
+
+When all the required data is loaded, the analyzing phase begins. The exact 
+process always depends on the type of {dfanalytics} – for example, 
+{classification} or {oldetection} – that is executed.
+
+
+[discrete]
+==== Writing results
+
+After the loaded data is analyzed, the analysis process sends back the results. 
+Only the additional fields that the analysis calculated are written back, the 
+ones that have been loaded in the loading data phase are not. The 
+{dfanalytics-job} matches the results with the data rows in the destination 
+index, merges them, and indexes them back to the destination index. When the 
+process is complete, the task is marked as completed and the {dfanalytics-job} 
+stops. Your data is ready to be evaluated.

--- a/docs/en/stack/ml/df-analytics/ml-dfa-phases.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-phases.asciidoc
@@ -38,7 +38,7 @@ Once the destination index is built, the {dfanalytics-job} task calls the {es}
 ==== Loading data
 
 After the reindexing is finished, the job fetches the needed data from the 
-destination index, converts it into the format that the analysis process 
+destination index. It converts the data into the format that the analysis process 
 expects, then sends it to the analysis process.
 
 

--- a/docs/en/stack/ml/df-analytics/ml-dfa-phases.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-phases.asciidoc
@@ -10,7 +10,7 @@ phases.
 [discrete]
 ==== The phases of a {dfanalytics-job}
 
-During its life cycle, a {dfanalytics-job} goes through four phases regardless 
+During its life cycle, it goes through four phases:
 of the {dfanalytics} type it performs. The phases are discrete steps of the 
 {dfanalytics-job} that is essentially a persistent {es} task. The four phases 
 are the following:

--- a/docs/en/stack/ml/df-analytics/ml-dfa-phases.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-phases.asciidoc
@@ -25,7 +25,7 @@ Let's take a look at the phases one-by-one.
 
 During the reindexing phase the documents from the source index or indices are 
 copied to the destination index. If the destination index does not exist, then 
-the job creates it before reindexing by using default settings. If it is already 
+the job creates it using default settings.
 created, then the job will use the existing index. This provides flexibility for 
 you to create the destination index and define any settings or mappings that you 
 want to have in it. 

--- a/docs/en/stack/ml/df-analytics/ml-dfa-phases.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-phases.asciidoc
@@ -21,7 +21,7 @@ Let's take a look at the phases one-by-one.
 
 
 [discrete]
-===== Reindexing
+==== Reindexing
 
 During the reindexing phase the documents from the source index or indices are 
 copied to the destination index. If the destination index does not exist, then 

--- a/docs/en/stack/ml/df-analytics/ml-dfa-phases.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-phases.asciidoc
@@ -67,3 +67,10 @@ ones that have been loaded in the loading data phase are not. The
 index, merges them, and indexes them back to the destination index. When the 
 process is complete, the task is marked as completed and the {dfanalytics-job} 
 stops. Your data is ready to be evaluated.
+
+
+Check the <<ml-dfa-concepts>> section if you'd like to know more about the 
+various {dfanalytics} types.
+
+Check the <<ml-dfanalytics-evaluate>> section if you are interested in the 
+evaluation of the {dfanalytics} results.

--- a/docs/en/stack/ml/df-analytics/ml-dfa-phases.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-phases.asciidoc
@@ -2,15 +2,8 @@
 [[ml-dfa-phases]]
 === How a {dfanalytics-job} works
 
-This page provides high-level background information on how {dfanalytics-jobs} 
-work, what kind of phases the jobs have, and what happens during the individual 
-phases.
-
-
-[discrete]
-==== The phases of a {dfanalytics-job}
-A {dfanalytics-job} is essentially a persistent {es} task.
-During its life cycle, it goes through four phases:
+A {dfanalytics-job} is essentially a persistent {es} task. During its life 
+cycle, it goes through four phases:
 
 * reindexing,
 * loading data,
@@ -24,11 +17,9 @@ Let's take a look at the phases one-by-one.
 ==== Reindexing
 
 During the reindexing phase the documents from the source index or indices are 
-copied to the destination index. If you want to define settings or mappings, create the index before you start the job. Otherwise,
-the job creates it using default settings.
-This provides flexibility for 
-you to create the destination index and define any settings or mappings that you 
-want to have in it. 
+copied to the destination index. If you want to define settings or mappings, 
+create the index before you start the job. Otherwise, the job creates it using 
+default settings.
 
 Once the destination index is built, the {dfanalytics-job} task calls the {es} 
 {ref}/docs-reindex.html[Reindex API] to launch the reindexing task.
@@ -47,7 +38,8 @@ expects, then sends it to the analysis process.
 
 When all the required data is loaded, the analyzing phase begins. The exact 
 process always depends on the type of {dfanalytics} – for example, 
-{classification} or {oldetection} – that is executed.
+{classification} or {oldetection} – that is executed. This is the phase when the 
+job generates a {ml} model for analyzing the dataset.
 
 
 [discrete]

--- a/docs/en/stack/ml/df-analytics/ml-dfa-phases.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-phases.asciidoc
@@ -35,7 +35,7 @@ Once the destination index is built, the {dfanalytics-job} task calls the {es}
 
 
 [discrete]
-===== Loading data
+==== Loading data
 
 After the reindexing is finished, the job fetches the needed data from the 
 destination index, converts it into the format that the analysis process 

--- a/docs/en/stack/ml/df-analytics/ml-dfa-phases.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-phases.asciidoc
@@ -11,7 +11,6 @@ phases.
 ==== The phases of a {dfanalytics-job}
 A {dfanalytics-job} is essentially a persistent {es} task.
 During its life cycle, it goes through four phases:
-of the {dfanalytics} type it performs. The phases are discrete steps of the 
 {dfanalytics-job} that is essentially a persistent {es} task. The four phases 
 are the following:
 

--- a/docs/en/stack/ml/df-analytics/ml-dfa-phases.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-phases.asciidoc
@@ -26,7 +26,7 @@ Let's take a look at the phases one-by-one.
 During the reindexing phase the documents from the source index or indices are 
 copied to the destination index. If the destination index does not exist, then 
 the job creates it using default settings.
-created, then the job will use the existing index. This provides flexibility for 
+This provides flexibility for 
 you to create the destination index and define any settings or mappings that you 
 want to have in it. 
 

--- a/docs/en/stack/ml/df-analytics/ml-dfa-phases.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-phases.asciidoc
@@ -11,7 +11,6 @@ phases.
 ==== The phases of a {dfanalytics-job}
 A {dfanalytics-job} is essentially a persistent {es} task.
 During its life cycle, it goes through four phases:
-are the following:
 
 * reindexing,
 * loading data,

--- a/docs/en/stack/ml/df-analytics/ml-dfa-phases.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-phases.asciidoc
@@ -10,9 +10,8 @@ phases.
 [discrete]
 ==== The phases of a {dfanalytics-job}
 
-A {dfanalytics-job} has two states: started and stopped. Until its state 
-switches from started to stopped, the job goes through four phases regardless of 
-the {dfanalytics} type it performs. The phases are discrete steps of the 
+During its life cycle, a {dfanalytics-job} goes through four phases regardless 
+of the {dfanalytics} type it performs. The phases are discrete steps of the 
 {dfanalytics-job} that is essentially a persistent {es} task. The four phases 
 are the following:
 
@@ -34,11 +33,8 @@ created, then the job will use the existing index. This provides flexibility for
 you to create the destination index and define any settings or mappings that you 
 want to have in it. 
 
-If the destination index is built, the {dfanalytics-job} task calls the {es} 
-{ref}/docs-reindex.html[Reindex API] to launch the reindexing task. When you 
-call the {ref}/get-dfanalytics-stats.html[Get {dfanalytics-job} statistics API] 
-to check the progress and the job is in the reindexing phase, then the job calls 
-the {ref}/tasks.html[Task management API] to report back the state of the phase.
+Once the destination index is built, the {dfanalytics-job} task calls the {es} 
+{ref}/docs-reindex.html[Reindex API] to launch the reindexing task.
 
 
 [discrete]

--- a/docs/en/stack/ml/df-analytics/ml-dfa-phases.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-phases.asciidoc
@@ -9,7 +9,7 @@ phases.
 
 [discrete]
 ==== The phases of a {dfanalytics-job}
-
+A {dfanalytics-job} is essentially a persistent {es} task.
 During its life cycle, it goes through four phases:
 of the {dfanalytics} type it performs. The phases are discrete steps of the 
 {dfanalytics-job} that is essentially a persistent {es} task. The four phases 

--- a/docs/en/stack/ml/df-analytics/ml-dfa-phases.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-phases.asciidoc
@@ -11,7 +11,6 @@ phases.
 ==== The phases of a {dfanalytics-job}
 A {dfanalytics-job} is essentially a persistent {es} task.
 During its life cycle, it goes through four phases:
-{dfanalytics-job} that is essentially a persistent {es} task. The four phases 
 are the following:
 
 * reindexing,


### PR DESCRIPTION
This PR adds a "how it works" piece to the DFA overview section that explains the four phases of a data frame analytics job. 
(approx. 500 words)

Preview available here: http://stack-docs_754.docs-preview.app.elstc.co/guide/en/elastic-stack-overview/master/ml-dfa-phases.html