### PR TITLE
[DOCS] Adds inference conceptual documentation

### DIFF
--- a/docs/en/stack/ml/df-analytics/ml-dfa-concepts.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-concepts.asciidoc
@@ -8,9 +8,11 @@ feature and the corresponding {evaluatedf-api}.
 * <<dfa-outlier-detection>>
 * <<dfa-regression>>
 * <<dfa-classification>>
+* <<ml-inference>>
 * <<ml-dfanalytics-evaluate>>
 
 include::dfa-outlierdetection.asciidoc[]
 include::dfa-regression.asciidoc[]
 include::dfa-classification.asciidoc[]
+include::ml-inference.asciidoc[]
 include::evaluatedf-api.asciidoc[]

--- a/docs/en/stack/ml/df-analytics/ml-inference.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-inference.asciidoc
@@ -42,6 +42,6 @@ model and provides a prediction. After the process, the pipeline continues
 executing (if there is any other processor in the pipeline), finally the new 
 data together with the results are indexed into the destination index.
 
-Check the {ref}/ingest/processors/inference.asciidoc[{infer} processor] and 
+Check the {ref}/inference-processor.html[{infer} processor] and 
 {ref}/ml-df-analytics-apis.html[the {ml} {dfanalytics} API documentation] to 
 learn more about the feature.

--- a/docs/en/stack/ml/df-analytics/ml-inference.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-inference.asciidoc
@@ -42,7 +42,6 @@ model and provides a prediction. After the process, the pipeline continues
 executing (if there is any other processor in the pipeline), finally the new 
 data together with the results are indexed into the destination index.
 
-Check the {infer} processor and the {infer} API documentation to learn more 
-about the feature.
-
-// Links to be added.
+Check the {ref}/ingest/processors/inference.asciidoc[{infer} processor] and 
+{ref}/ml-df-analytics-apis.html[the {ml} {dfanalytics} API documentation] to 
+learn more about the feature.

--- a/docs/en/stack/ml/df-analytics/ml-inference.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-inference.asciidoc
@@ -1,0 +1,48 @@
+[role="xpack"]
+[[ml-inference]]
+=== {infer-cap}
+
+experimental[]
+
+{infer-cap} is a {ml} feature that enables you to use supervised {ml} processes 
+– like <<dfa-regression>> or <<dfa-classification>> – not only as a batch 
+analysis but in a continuous fashion. This means that {infer} makes it possible 
+to use trained {ml} models against incoming data.
+
+For instance, suppose you have an online service and you would like to predict 
+whether a customer is likely to churn. You have an index with historical data – 
+information on the customer behavior throughout the years in your business – and 
+a {classification} model that is trained on this data. The new information comes 
+into a destination index of a {ctransform}. With {infer}, you can perform the 
+{classanalysis} against the new data with the same input fields that you've 
+trained the model on, and get a prediction.
+
+Let's take a closer look at the machinery behind {infer}.
+
+
+[discrete]
+==== Trained {ml} models as functions
+
+When you create a {dfanalytics-job} that executes a supervised process, you need 
+to train a {ml} model on a training dataset to be able to make predictions on 
+data points that the model has never seen. The models that are created by 
+{dfanalytics} are stored as {es} documents in internal indices. In other words, 
+the characteristics of your trained models are saved and ready to be used as 
+functions.
+
+
+[discrete]
+==== {infer-cap} processor
+
+{infer-cap} is a processor specified in an {ref}/pipeline.html[ingest pipeline]. 
+It uses a stored {dfanalytics} model to infer against the data that is being 
+ingested in the pipeline. The model is used on the 
+{ref}/ingest.html[ingest node]. {infer-cap} pre-processes the data by using the 
+model and provides a prediction. After the process, the pipeline continues 
+executing (if there is any other processor in the pipeline), finally the new 
+data together with the results are indexed into the destination index.
+
+Check the {infer} processor and the {infer} API documentation to learn more 
+about the feature.
+
+// Links to be added.


### PR DESCRIPTION
This PR adds the conceptual documentation of the inference feature to the machine learning book.

Preview: http://stack-docs_758.docs-preview.app.elstc.co/guide/en/elastic-stack-overview/master/ml-inference.html
Related issue: https://github.com/elastic/stack-docs/issues/691
PR for new attributes: https://github.com/elastic/docs/pull/1616

**NOTE**
Only merge this PR after https://github.com/elastic/elasticsearch/pull/50204 is merged. This PR contains a link pointing to the processor documentation. The CI here will pass after the processor docs are merged.