### PR TITLE
[DOCS] Adds Jupyter noetbook link to the classification example

### DIFF
--- a/docs/en/stack/ml/df-analytics/flightdata-classification.asciidoc
+++ b/docs/en/stack/ml/df-analytics/flightdata-classification.asciidoc
@@ -10,6 +10,8 @@ destination to predict flight delays. There are only two possible outcome
 values: the flight is either delayed or not, therefore we use binary 
 {classification} to make the prediction.
 
+TIP: https://github.com/elastic/examples/tree/master/Machine%20Learning/Analytics%20Jupyter%20Notebooks[If you want to view this example in a Jupyter notebook, click here.]
+
 We have chosen this dataset as an example because it is easily accessible for 
 {kib} users and the use case is relevant. However, the data has been manually 
 created and contains some inconsistencies. For example, a flight can be both 


### PR DESCRIPTION
This PR adds a link to the classification example that points to the companion Jupyter notebook on GitHub.

Related issue: https://github.com/elastic/ml-team/issues/187#issuecomment-566532097