### PR TITLE
[DOCS] Adds a Jupyter notebook link to the outlier detection example

### DIFF
--- a/docs/en/stack/ml/df-analytics/ecommerce-outliers.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ecommerce-outliers.asciidoc
@@ -269,4 +269,4 @@ can delete them in {kib} or use the
 you delete {transforms} and {dfanalytics-jobs}, the destination indices and
 {kib} index patterns remain.
 
-TIP: https://github.com/blaklaybul/examples/tree/8cff86bce1a05d8bcf1239aab8033490b7c76f2d/Machine%20Learning/Outlier%20Detection/Introduction[If you want to see another example of {oldetection} in a Jupyter notebook, click here.]
+TIP: https://github.com/elastic/examples/tree/master/Machine%20Learning/Outlier%20Detection/Introduction[If you want to see another example of {oldetection} in a Jupyter notebook, click here.]

--- a/docs/en/stack/ml/df-analytics/ecommerce-outliers.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ecommerce-outliers.asciidoc
@@ -268,3 +268,6 @@ can delete them in {kib} or use the
 {ref}/delete-dfanalytics.html[delete {dfanalytics-job} API]. When
 you delete {transforms} and {dfanalytics-jobs}, the destination indices and
 {kib} index patterns remain.
+
+TIP: https://github.com/blaklaybul/examples/tree/8cff86bce1a05d8bcf1239aab8033490b7c76f2d/Machine%20Learning/Outlier%20Detection/Introduction[If you want to see another example for {oldetection} in a Jupyter notebook, click here.]
+

--- a/docs/en/stack/ml/df-analytics/ecommerce-outliers.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ecommerce-outliers.asciidoc
@@ -269,5 +269,4 @@ can delete them in {kib} or use the
 you delete {transforms} and {dfanalytics-jobs}, the destination indices and
 {kib} index patterns remain.
 
-TIP: https://github.com/blaklaybul/examples/tree/8cff86bce1a05d8bcf1239aab8033490b7c76f2d/Machine%20Learning/Outlier%20Detection/Introduction[If you want to see another example for {oldetection} in a Jupyter notebook, click here.]
-
+TIP: https://github.com/blaklaybul/examples/tree/8cff86bce1a05d8bcf1239aab8033490b7c76f2d/Machine%20Learning/Outlier%20Detection/Introduction[If you want to see another example of {oldetection} in a Jupyter notebook, click here.]


### PR DESCRIPTION
This PR adds a link to the outlier detection example that points to a Jupyter notebook on GitHub.