### PR TITLE
[DOCS] Adds Jupyter notebook links to the example page

### DIFF
--- a/docs/en/stack/ml/df-analytics/examples.asciidoc
+++ b/docs/en/stack/ml/df-analytics/examples.asciidoc
@@ -15,7 +15,7 @@ insights from your data.
 * https://github.com/elastic/examples/tree/master/Machine%20Learning/Outlier%20Detection/Introduction[{oldetection-cap} example (Jupyter notebook)]
 * <<flightdata-regression>>
 * <<flightdata-classification>>
-* https://github.com/elastic/examples/tree/master/Machine%20Learning/Analytics%20Jupyter%20Notebooks[Predicting delayed flights with {classanalysis} (Jupyter notebook)]
+* https://github.com/elastic/examples/tree/master/Machine%20Learning/Analytics%20Jupyter%20Notebooks[{classanalysis-cap} example (Jupyter notebook)]
 
 
 include::ecommerce-outliers.asciidoc[]

--- a/docs/en/stack/ml/df-analytics/examples.asciidoc
+++ b/docs/en/stack/ml/df-analytics/examples.asciidoc
@@ -12,8 +12,10 @@ These examples demonstrate how to use {dfanalytics} to derive useful
 insights from your data.
 
 * <<ecommerce-outliers>>
+* https://github.com/elastic/examples/tree/master/Machine%20Learning/Outlier%20Detection/Introduction[{oldetection-cap} example (Jupyter notebook)]
 * <<flightdata-regression>>
 * <<flightdata-classification>>
+* https://github.com/elastic/examples/tree/master/Machine%20Learning/Analytics%20Jupyter%20Notebooks[Predicting delayed flights with {classanalysis} (Jupyter notebook)]
 
 
 include::ecommerce-outliers.asciidoc[]


### PR DESCRIPTION
This PR adds two links pointing to Jupyter notebook to the DFA example page.

Preview: http://stack-docs_765.docs-preview.app.elstc.co/guide/en/elastic-stack-overview/master/dfanalytics-examples.html