### PR TITLE
[DOCS] Removes ML content from Stack Overview

### DIFF
--- a/docs/en/stack/index.asciidoc
+++ b/docs/en/stack/index.asciidoc
@@ -16,10 +16,6 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
 include::introduction.asciidoc[]
 
-include::ml/anomaly-detection/index.asciidoc[]
-
-include::ml/df-analytics/index.asciidoc[]
-
 include::license.asciidoc[]
 
 include::redirects.asciidoc[]

--- a/docs/en/stack/redirects.asciidoc
+++ b/docs/en/stack/redirects.asciidoc
@@ -24,6 +24,7 @@ This page has moved.
 === Overview
 
 This page has moved.
+[[ml-forecasting]]
 //TBD
 
 [role="exclude",id="ml-concepts"]

--- a/docs/en/stack/redirects.asciidoc
+++ b/docs/en/stack/redirects.asciidoc
@@ -17,255 +17,266 @@ See {ref}/oidc-guide-authentication.html[Configure {es} for OpenID Connect authe
 
 [role="exclude",id="xpack-ml"]
 === Machine learning anomaly detection
+
 This page has moved.
-//TBD
+See {ml-docs}/xpack-ml.html[Machine learning {anomaly-detect}].
 
 [role="exclude",id="ml-overview"]
 === Overview
 
 This page has moved.
 [[ml-forecasting]]
-//TBD
+See {ml-docs}/ml-overview.html[Overview]. 
 
 [role="exclude",id="ml-concepts"]
 === Concepts
 
 This page has moved.
-//TBD
+See {ml-docs}/ml-concepts.html[Concepts].
 
 [role="exclude",id="ml-jobs"]
 === Anomaly detection jobs
 
 This page has moved.
-//TBD
+See {ml-docs}/ml-jobs.html[{anomaly-jobs-cap}].
 
 [role="exclude",id="ml-dfeeds"]
 === Datafeeds
 
 This page has moved.
-//TBD
+See {ml-docs}/ml-dfeeds.html[Datafeeds].
 
 [role="exclude",id="ml-buckets"]
 === Buckets
 
 This page has moved.
+See {ml-docs}/ml-buckets.html[Buckets].
 
 [role="exclude",id="ml-calendars"]
 === Calendars and scheduled events
 
 This page has moved.
+See {ml-docs}/ml-calendars.html[Calendars and scheduled events].
 
 [role="exclude",id="ml-rules"]
 === Custom rules
 
 This page has moved.
+See {ml-docs}/ml-rules.html[Custom rules].
 
 [role="exclude",id="ml-nodes"]
 === Machine learning nodes
 
 This page has moved.
+See {ml-docs}/ml-nodes.html[{ml-cap} nodes].
 
 [role="exclude",id="ml-model-snapshots"]
 === Model snapshots
 
 This page has moved.
+See {ml-docs}/ml-model-snapshots.html[Model snapshots].
 
 [role="exclude",id="ml-configuration"]
 === Configure anomaly detection
 
 This page has moved.
+See {ml-docs}/ml-configuration.html[Configure {anomaly-detect}].
 
 [role="exclude",id="create-jobs"]
 === Create anomaly detection jobs
 
 This page has moved.
+See {ml-docs}/create-jobs.html[Create {anomaly-jobs}].
 
 [role="exclude",id="stopping-ml"]
 === Stop machine learning anomaly detection
 
 This page has moved.
+See {ml-docs}/stopping-ml.html[Stop {ml} {anomaly-detect}].
 
 [role="exclude",id="ml-api-quickref"]
 === API quick reference
 
 This page has moved.
+See {ml-docs}/ml-api-quickref.html[API quick reference].
 
 [role="exclude",id="ml-functions"]
 === Function reference
 
 This page has moved.
+See {ml-docs}/ml-functions.html[Function reference].
 
 [role="exclude",id="ml-count-functions"]
 === Count functions
+
 This page has moved.
+See {ml-docs}/ml-count-functions.html[Count functions].
 
 [role="exclude",id="ml-geo-functions"]
 === Geographic functions
 
 This page has moved.
+See {ml-docs}/ml-geo-functions.html[Geographic functions].
 
 [role="exclude",id="ml-info-functions"]
 === Information content functions
 
 This page has moved.
+See {ml-docs}/ml-info-functions.html[Information content functions].
 
 [role="exclude",id="ml-metric-functions"]
 === Metric functions
 
 This page has moved.
+See {ml-docs}/ml-metric-functions.html[Metric functions].
 
 [role="exclude",id="ml-rare-functions"]
 === Rare functions
 
 This page has moved.
+See {ml-docs}/ml-rare-functions.html[Rare functions].
 
 [role="exclude",id="ml-sum-functions"]
 === Sum functions
 
 This page has moved.
+See {ml-docs}/ml-sum-functions.html[Sum functions].
 
 [role="exclude",id="ml-time-functions"]
 === Time functions
 
 This page has moved.
+See {ml-docs}/ml-time-functions.html[Time functions].
 
 [role="exclude",id="anomaly-examples"]
 === Anomaly detection examples
 
 This page has moved.
+See {ml-docs}/anomaly-examples.html[{anomaly-detect-cap} examples].
 
 [role="exclude",id="ml-configuring-url"]
 === Adding custom URLs to machine learning results
+
 This page has moved.
+See {ml-docs}/ml-configuring-url.html[Adding custom URLs to {ml} results].
 
 [role="exclude",id="ml-configuring-aggregation"]
 === Aggregating data for faster performance
 
 This page has moved.
+See {ml-docs}/ml-configuring-aggregation.html[Aggregating data for faster performance].
 
 [role="exclude",id="ml-configuring-detector-custom-rules"]
 === Customizing detectors with custom rules
+
 This page has moved.
+See {ml-docs}/ml-configuring-detector-custom-rules.html[Customizing detectors with custom rules].
 
 [role="exclude",id="ml-configuring-categories"]
 === Categorizing log messages
 
 This page has moved.
+See {ml-docs}/ml-configuring-categories.html[Categorizing log messages].
 
 [role="exclude",id="ml-configuring-pop"]
 === Performing population analysis
 
 This page has moved.
-//See {ml-docs}/ml-configuring-pop.html[Performing population analysis].
+See {ml-docs}/ml-configuring-pop.html[Performing population analysis].
 
 [role="exclude",id="ml-configuring-transform"]
 === Transforming data with script fields
 
 This page has moved.
-// See {ml-docs}/ml-configuring-transform.html[Transforming data with script fields].
+/See {ml-docs}/ml-configuring-transform.html[Transforming data with script fields].
 
 [role="exclude",id="ml-delayed-data-detection"]
 === Handling delayed data
 
 This page has moved.
-
-// See {ml-docs}/ml-delayed-data-detection.html[Handling delayed data].
+See {ml-docs}/ml-delayed-data-detection.html[Handling delayed data].
 
 [role="exclude",id="ml-limitations"]
 === Machine learning anomaly detection limitations
 
 This page has moved.
-
-// See {ml-docs}/ml-limitations.html[{ml-cap} {anomaly-detect} limitations].
+See {ml-docs}/ml-limitations.html[{ml-cap} {anomaly-detect} limitations].
 
 [role="exclude",id="ml-dfanalytics"]
 === Machine learning data frame analytics
 
 This page has moved.
-
-// See {ml-docs}/ml-dfanalytics.html[{ml-cap} {dfanalytics}].
+See {ml-docs}/ml-dfanalytics.html[{ml-cap} {dfanalytics}].
 
 [role="exclude",id="ml-dfa-overview"]
 === Overview
 
 This page has moved.
-
-// See {ml-docs}/ml-dfa-overview.html[Overview].
+See {ml-docs}/ml-dfa-overview.html[Overview].
 
 [role="exclude",id="ml-dfa-concepts"]
 === Concepts
 
 This page has moved.
-
-// See {ml-docs}/ml-dfa-concepts.html[Concepts].
+See {ml-docs}/ml-dfa-concepts.html[Concepts].
 
 [role="exclude",id="dfa-outlier-detection"]
 === Outlier detection
 
 This page has moved.
-
-// See {ml-docs}/dfa-outlier-detection.html[{oldetection-cap}].
+See {ml-docs}/dfa-outlier-detection.html[{oldetection-cap}].
 
 [role="exclude",id="dfa-regression"]
 === Regression
 
 This page has moved.
-
-// See {ml-docs}/dfa-regression.html[Regression].
+See {ml-docs}/dfa-regression.html[Regression].
 
 [role="exclude",id="dfa-classification"]
 === Classification
 
 This page has moved.
-
-// See {ml-docs}/dfa-classification.html[Classification].
+See {ml-docs}/dfa-classification.html[Classification].
 
 [role="exclude",id="ml-dfanalytics-evaluate"]
 === Evaluating data frame analytics
 
 This page has moved.
-
-// See {ml-docs}/ml-dfanalytics-evaluate.html[Evaluating {dfanalytics}].
+See {ml-docs}/ml-dfanalytics-evaluate.html[Evaluating {dfanalytics}].
 
 [role="exclude",id="ml-dfanalytics-apis"]
 === API quick reference
 
 This page has moved.
-
-// See {ml-docs}/ml-dfanalytics-apis.html[API quick reference].
+See {ml-docs}/ml-dfanalytics-apis.html[API quick reference].
 
 [role="exclude",id="dfanalytics-examples"]
 === Data frame analytics examples
 
 This page has moved.
-
-// See {ml-docs}/dfanalytics-examples.html[{dfanalytics-cap} examples].
+See {ml-docs}/dfanalytics-examples.html[{dfanalytics-cap} examples].
 
 [role="exclude",id="ecommerce-outliers"]
 === Finding outliers in the eCommerce sample data
 
 This page has moved.
-
-// See {ml-docs}/ecommerce-outliers.html[Finding outliers in the eCommerce sample data].
+See {ml-docs}/ecommerce-outliers.html[Finding outliers in the eCommerce sample data].
 
 [role="exclude",id="flightdata-regression"]
 === Predicting flight delays with regression analysis
 
 This page has moved.
-
-// See {ml-docs}/flightdata-regression.html[Predicting flight delays with regression analysis].
+See {ml-docs}/flightdata-regression.html[Predicting flight delays with regression analysis].
 
 [role="exclude",id="flightdata-classification"]
 === Predicting delayed flights with classification analysis
 
 This page has moved.
-
-// See {ml-docs}/flightdata-classification.html[Predicting delayed flights with classification analysis].
+See {ml-docs}/flightdata-classification.html[Predicting delayed flights with classification analysis].
 
 [role="exclude",id="ml-dfa-limitations"]
 === Data frame analytics limitations
 
 This page has moved.
-
-// See {ml-docs}/ml-dfa-limitations.html[{dfanalytics-cap} limitations].
+See {ml-docs}/ml-dfa-limitations.html[{dfanalytics-cap} limitations].
 

--- a/docs/en/stack/redirects.asciidoc
+++ b/docs/en/stack/redirects.asciidoc
@@ -15,3 +15,256 @@ This page has moved.
 [[oidc-claims-mapping]]
 See {ref}/oidc-guide-authentication.html[Configure {es} for OpenID Connect authentication].
 
+[role="exclude",id="xpack-ml"]
+=== Machine learning anomaly detection
+This page has moved.
+//TBD
+
+[role="exclude",id="ml-overview"]
+=== Overview
+
+This page has moved.
+//TBD
+
+[role="exclude",id="ml-concepts"]
+=== Concepts
+
+This page has moved.
+//TBD
+
+[role="exclude",id="ml-jobs"]
+=== Anomaly detection jobs
+
+This page has moved.
+//TBD
+
+[role="exclude",id="ml-dfeeds"]
+=== Datafeeds
+
+This page has moved.
+//TBD
+
+[role="exclude",id="ml-buckets"]
+=== Buckets
+
+This page has moved.
+
+[role="exclude",id="ml-calendars"]
+=== Calendars and scheduled events
+
+This page has moved.
+
+[role="exclude",id="ml-rules"]
+=== Custom rules
+
+This page has moved.
+
+[role="exclude",id="ml-nodes"]
+=== Machine learning nodes
+
+This page has moved.
+
+[role="exclude",id="ml-model-snapshots"]
+=== Model snapshots
+
+This page has moved.
+
+[role="exclude",id="ml-configuration"]
+=== Configure anomaly detection
+
+This page has moved.
+
+[role="exclude",id="create-jobs"]
+=== Create anomaly detection jobs
+
+This page has moved.
+
+[role="exclude",id="stopping-ml"]
+=== Stop machine learning anomaly detection
+
+This page has moved.
+
+[role="exclude",id="ml-api-quickref"]
+=== API quick reference
+
+This page has moved.
+
+[role="exclude",id="ml-functions"]
+=== Function reference
+
+This page has moved.
+
+[role="exclude",id="ml-count-functions"]
+=== Count functions
+This page has moved.
+
+[role="exclude",id="ml-geo-functions"]
+=== Geographic functions
+
+This page has moved.
+
+[role="exclude",id="ml-info-functions"]
+=== Information content functions
+
+This page has moved.
+
+[role="exclude",id="ml-metric-functions"]
+=== Metric functions
+
+This page has moved.
+
+[role="exclude",id="ml-rare-functions"]
+=== Rare functions
+
+This page has moved.
+
+[role="exclude",id="ml-sum-functions"]
+=== Sum functions
+
+This page has moved.
+
+[role="exclude",id="ml-time-functions"]
+=== Time functions
+
+This page has moved.
+
+[role="exclude",id="anomaly-examples"]
+=== Anomaly detection examples
+
+This page has moved.
+
+[role="exclude",id="ml-configuring-url"]
+=== Adding custom URLs to machine learning results
+This page has moved.
+
+[role="exclude",id="ml-configuring-aggregation"]
+=== Aggregating data for faster performance
+
+This page has moved.
+
+[role="exclude",id="ml-configuring-detector-custom-rules"]
+=== Customizing detectors with custom rules
+This page has moved.
+
+[role="exclude",id="ml-configuring-categories"]
+=== Categorizing log messages
+
+This page has moved.
+
+[role="exclude",id="ml-configuring-pop"]
+=== Performing population analysis
+
+This page has moved.
+//See {ml-docs}/ml-configuring-pop.html[Performing population analysis].
+
+[role="exclude",id="ml-configuring-transform"]
+=== Transforming data with script fields
+
+This page has moved.
+// See {ml-docs}/ml-configuring-transform.html[Transforming data with script fields].
+
+[role="exclude",id="ml-delayed-data-detection"]
+=== Handling delayed data
+
+This page has moved.
+
+// See {ml-docs}/ml-delayed-data-detection.html[Handling delayed data].
+
+[role="exclude",id="ml-limitations"]
+=== Machine learning anomaly detection limitations
+
+This page has moved.
+
+// See {ml-docs}/ml-limitations.html[{ml-cap} {anomaly-detect} limitations].
+
+[role="exclude",id="ml-dfanalytics"]
+=== Machine learning data frame analytics
+
+This page has moved.
+
+// See {ml-docs}/ml-dfanalytics.html[{ml-cap} {dfanalytics}].
+
+[role="exclude",id="ml-dfa-overview"]
+=== Overview
+
+This page has moved.
+
+// See {ml-docs}/ml-dfa-overview.html[Overview].
+
+[role="exclude",id="ml-dfa-concepts"]
+=== Concepts
+
+This page has moved.
+
+// See {ml-docs}/ml-dfa-concepts.html[Concepts].
+
+[role="exclude",id="dfa-outlier-detection"]
+=== Outlier detection
+
+This page has moved.
+
+// See {ml-docs}/dfa-outlier-detection.html[{oldetection-cap}].
+
+[role="exclude",id="dfa-regression"]
+=== Regression
+
+This page has moved.
+
+// See {ml-docs}/dfa-regression.html[Regression].
+
+[role="exclude",id="dfa-classification"]
+=== Classification
+
+This page has moved.
+
+// See {ml-docs}/dfa-classification.html[Classification].
+
+[role="exclude",id="ml-dfanalytics-evaluate"]
+=== Evaluating data frame analytics
+
+This page has moved.
+
+// See {ml-docs}/ml-dfanalytics-evaluate.html[Evaluating {dfanalytics}].
+
+[role="exclude",id="ml-dfanalytics-apis"]
+=== API quick reference
+
+This page has moved.
+
+// See {ml-docs}/ml-dfanalytics-apis.html[API quick reference].
+
+[role="exclude",id="dfanalytics-examples"]
+=== Data frame analytics examples
+
+This page has moved.
+
+// See {ml-docs}/dfanalytics-examples.html[{dfanalytics-cap} examples].
+
+[role="exclude",id="ecommerce-outliers"]
+=== Finding outliers in the eCommerce sample data
+
+This page has moved.
+
+// See {ml-docs}/ecommerce-outliers.html[Finding outliers in the eCommerce sample data].
+
+[role="exclude",id="flightdata-regression"]
+=== Predicting flight delays with regression analysis
+
+This page has moved.
+
+// See {ml-docs}/flightdata-regression.html[Predicting flight delays with regression analysis].
+
+[role="exclude",id="flightdata-classification"]
+=== Predicting delayed flights with classification analysis
+
+This page has moved.
+
+// See {ml-docs}/flightdata-classification.html[Predicting delayed flights with classification analysis].
+
+[role="exclude",id="ml-dfa-limitations"]
+=== Data frame analytics limitations
+
+This page has moved.
+
+// See {ml-docs}/ml-dfa-limitations.html[{dfanalytics-cap} limitations].
+


### PR DESCRIPTION
Depends on https://github.com/elastic/docs/pull/1662

This PR creates redirects for all of the machine learning pages in the Stack Overview. 
