### PR TITLE
[DOCS] Fixes machine learning links

### DIFF
--- a/docs/60_upgrade_guide.html
+++ b/docs/60_upgrade_guide.html
@@ -861,7 +861,7 @@ Do you have TLS enabled?
 [[Upgrade Elasticsearch for Hadoop to 5.6.|https://www.elastic.co/guide/en/elasticsearch/hadoop/5.6/install.html]]\
 &lt;&lt;endif&gt;&gt;\</tw-passagedata><tw-passagedata pid="12" name="rolling-upgrade-60" tags="" position="1401,476">!!!Upgrade to 6.3
 &lt;&lt;if $xpack_ml&gt;&gt;\
-[[Stop any running Machine Learning jobs.|https://www.elastic.co/guide/en/elastic-stack-overview/6.3/stopping-ml.html]]
+[[Stop any running Machine Learning jobs.|https://www.elastic.co/guide/en/machine-learning/6.3/stopping-ml.html]]
 &lt;&lt;endif&gt;&gt;\
 &lt;&lt;if $hadoop&gt;&gt;\
 &lt;span class=&quot;pseudo-link&quot;&gt;Disable ingestion from Hadoop while you upgrade the stack.&lt;/span&gt;

--- a/docs/en/siem/machine-learning.asciidoc
+++ b/docs/en/siem/machine-learning.asciidoc
@@ -53,7 +53,7 @@ anomaly results to reduce the number of false positive, see <<tuning-anomaly-res
 To view the `Anomalies` table widget and `Max Anomaly Score By Job` details,
 the user must have the `ml_admin` or `ml_user` role.
 
-NOTE: To adjust the `score` threshold for which {stack-ov}/xpack-ml.html[anomalies]
+NOTE: To adjust the `score` threshold for which {ml-docs}/xpack-ml.html[anomalies]
 are shown, you can modify {kib} -> Management -> Advanced Settings -> `siem:defaultAnomalyScore`.
 
 [[prebuilt-ml-jobs]]

--- a/docs/en/siem/tune-anomaly-results.asciidoc
+++ b/docs/en/siem/tune-anomaly-results.asciidoc
@@ -59,7 +59,7 @@ example).
 .. The filter you created as part of the <<create-fiter-list>> procedure.
 +
 TIP: For more information about detectors, see
-{stack-ov}/ml-jobs.html[Anomaly detection jobs].
+{ml-docs}/ml-jobs.html[Anomaly detection jobs].
 
 . Click *Save*.
 

--- a/docs/en/stack/ml/anomaly-detection/create-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/create-jobs.asciidoc
@@ -22,7 +22,7 @@ than running multiple jobs against the same data.
 
 A _population job_ detects activity that is unusual compared to the behavior of
 the population. For more information, see
-{stack-ov}/ml-configuring-pop.html[Performing population analysis].
+{ml-docs}/ml-configuring-pop.html[Performing population analysis].
 
 An _advanced job_ can contain multiple detectors and enables you to configure all
 job settings.
@@ -73,7 +73,7 @@ create and manage jobs and post data to them. For more information, see
 
 ////
 Ready to get some hands-on experience? See
-{stack-ov}/ml-getting-started.html[Getting Started with Machine Learning].
+{ml-docs}/ml-getting-started.html[Getting Started with Machine Learning].
 
 The following video tutorials also demonstrate single metric, multi-metric, and
 advanced jobs:


### PR DESCRIPTION
Related to elastic/stack-docs#777

This PR updates links to machine learning content so that they point to the appropriate book (https://www.elastic.co/guide/en/machine-learning/master/index.html instead of https://www.elastic.co/guide/en/elastic-stack-overview/master/index.html).