### PR TITLE
[DOCS] Adds nested objects related inference limitation

### DIFF
--- a/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
@@ -108,14 +108,8 @@ destination index that don't contain a results field are not included in the
 [[dfa-inference-nested-limitation]]
 === Deeply nested objects affect {infer} performance
 
-<<<<<<< HEAD
-If the data that you run inference agains contains documents that have a series 
+If the data that you run inference against contains documents that have a series 
 of combinations of dot delimited and nested fields (for example: 
 `{"a.b": "c", "a": {"b": "c"},...}`), the performance of the operation might be 
 slightly slower. Consider using as simple mapping as possible for the best 
 performance profile.
-=======
-If the data that you run inference against contains deeply nested documents, the 
-performance of the operation might be slightly slower. Consider using as simple 
-mapping as possible for the best performance profile.
->>>>>>> a911eade1c09f2dee7318e9c2959b528ef9e44bd

--- a/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
@@ -108,6 +108,8 @@ destination index that don't contain a results field are not included in the
 [[dfa-inference-nested-limitation]]
 === Deeply nested objects affect {infer} performance
 
-If the data that you run inference agains contains deeply nested documents, the 
-performance of the operation might be slightly slower. Consider using as simple 
-mapping as possible for the best performance profile.
+If the data that you run inference agains contains documents that have a series 
+of combinations of dot delimited and nested fields (for example: 
+`{"a.b": "c", "a": {"b": "c"},...}`), the performance of the operation might be 
+slightly slower. Consider using as simple mapping as possible for the best 
+performance profile.

--- a/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
@@ -98,7 +98,16 @@ that don't contain a results field are not included in the {reganalysis}.
 === {classification-cap} field types
 
 {classification-cap} supports fields that have numeric, boolean, text, keyword, 
-or ip data types. It is also tolerant of missing values. Fields that are supported are 
-included in the analysis, other fields are ignored. Documents where included 
-fields contain an array are also ignored. Documents in the destination index 
-that don't contain a results field are not included in the {classanalysis}.
+or ip data types. It is also tolerant of missing values. Fields that are 
+supported are included in the analysis, other fields are ignored. Documents 
+where included fields contain an array are also ignored. Documents in the 
+destination index that don't contain a results field are not included in the 
+{classanalysis}.
+
+[float]
+[[dfa-inference-nested-limitation]]
+=== Deeply nested objects affect {infer} performance
+
+If the data that you run inference agains contains deeply nested documents, the 
+performance of the operation might be slightly slower. Consider using as simple 
+mapping as possible for the best performance profile.


### PR DESCRIPTION
This PR adds a paragraph about the inference limitation regarding nested objects to the limitation pool.

Preview: http://stack-docs_791.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-dfa-limitations.html#dfa-inference-nested-limitation