### PR TITLE
[7.5][DOCS] Adds hyperparameter optimization link to limitation text

### DIFF
--- a/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
@@ -47,13 +47,14 @@ dedicated for {ml} processes. For general {ml} settings, see
 The runtime of the {dfanalytics-jobs} depends on numerous factors, such as the 
 number of data points in the dataset, the type of analytics, the number of 
 fields that are included in the analysis, the supplied 
-hyperparameters, the type of analyzed fields and so on. For example, running an 
-analysis on a dataset with many numerical fields will take longer than running 
-an analysis on a dataset that contains mainly categorical fields. 
-Hyperparameters specified by the user also lower the runtime. For this reason, a 
-general runtime value that applies to all or most of the situations does not 
-exist. The runtime of a {dfanalytics-job} may take from a couple of minutes up 
-to 35 hours in extreme cases.
+{ref}/ml-dfa-analysis-objects.html#ml-hyperparam-optimization[hyperparameters], 
+the type of analyzed fields and so on. For example, running an analysis on a 
+dataset with many numerical fields will take longer than running an analysis on 
+a dataset that contains mainly categorical fields. Hyperparameters specified by 
+the user also lower the runtime. For this reason, a general runtime value that 
+applies to all or most of the situations does not exist. The runtime of a 
+{dfanalytics-job} may take from a couple of minutes up to 35 hours in extreme 
+cases.
 
 The runtime increases with the increasing number of analyzed fields in a nearly 
 linear fashion. For datasets of more than 100 000 points, we recommend to start 


### PR DESCRIPTION
This PR adds a link pointing to the definition of hyperparameter optimization to one of the limitations items on the DFA limitation page.