### PR TITLE
[Metrics UI] Update docs with AWS Metricset fields

### DIFF
--- a/docs/en/metrics/aws-ec2-metricset.asciidoc
+++ b/docs/en/metrics/aws-ec2-metricset.asciidoc
@@ -1,7 +1,7 @@
 [[aws-ec2-metricset]]
 [role="xpack"]
 
-== AWS EC2 Instance Fields
+=== AWS EC2 Instance Fields
 
 *ID*:: `cloud.instance.id`
 *Name*:: `cloud.instance.name`

--- a/docs/en/metrics/aws-ec2-metricset.asciidoc
+++ b/docs/en/metrics/aws-ec2-metricset.asciidoc
@@ -1,0 +1,22 @@
+[[aws-ec2-metricset]]
+[role="xpack"]
+
+== AWS EC2 Instnace Fields
+
+*ID*:: `cloud.instance.id`
+*Name*:: `cloud.instance.name`
+*IP Address*:: `aws.ec2.instance.public.ip`
+
+[float]
+=== AWS ECS Instance Metrics
+
+*CPU Usage*:: Average of `aws.ec2.cpu.total.pct`
+
+*Inbound Traffic*:: Average of `aws.ec2.network.in.bytes_per_sec`
+
+*Outbound Traffic*:: Average of `aws.ec2.network.out.bytes_per_sec`
+
+*Disk Reads (Bytes)*:: Average of `aws.ec2.diskio.read.bytes_per_sec`
+
+*Disk Writes (Bytes)*:: Average of `aws.ec2.diskio.write.bytes_per_sec`
+

--- a/docs/en/metrics/aws-ec2-metricset.asciidoc
+++ b/docs/en/metrics/aws-ec2-metricset.asciidoc
@@ -1,7 +1,7 @@
 [[aws-ec2-metricset]]
 [role="xpack"]
 
-== AWS EC2 Instnace Fields
+== AWS EC2 Instance Fields
 
 *ID*:: `cloud.instance.id`
 *Name*:: `cloud.instance.name`

--- a/docs/en/metrics/aws-rds-metricset.asciidoc
+++ b/docs/en/metrics/aws-rds-metricset.asciidoc
@@ -1,0 +1,21 @@
+[[aws-rds-metricset]]
+[role="xpack"]
+
+== AWS RDS Database Fields
+
+*ID*:: `aws.rds.db_instance.arn`
+*Name*:: `aws.rds.db_instance.identifier`
+
+[float]
+=== AWS RDS Database Metrics
+
+*CPU Usage*:: Average of `aws.rds.cpu.total.pct`
+
+*Connections*:: Average of `aws.rds.database_connections`
+
+*Queries Executed*:: Average of `aws.rds.queries`
+
+*Active Transactions*:: Average of `aws.rds.transactions.active`
+
+*Latency*:: Average of `aws.rds.latency.dml`
+

--- a/docs/en/metrics/aws-rds-metricset.asciidoc
+++ b/docs/en/metrics/aws-rds-metricset.asciidoc
@@ -1,7 +1,7 @@
 [[aws-rds-metricset]]
 [role="xpack"]
 
-== AWS RDS Database Fields
+=== AWS RDS Database Fields
 
 *ID*:: `aws.rds.db_instance.arn`
 *Name*:: `aws.rds.db_instance.identifier`

--- a/docs/en/metrics/aws-s3-metricset.asciidoc
+++ b/docs/en/metrics/aws-s3-metricset.asciidoc
@@ -1,0 +1,21 @@
+[[aws-s3-metricset]]
+[role="xpack"]
+
+== AWS S3 Bucket Fields
+
+*ID*:: `aws.s3.bucket.name`
+*Name*:: `aws.s3.bucket.name`
+
+[float]
+=== AWS S3 Bucket Metrics
+
+*Bucket Size*:: Average of `aws.s3_daily_storage.bucket.size.bytes`
+
+*Total Requests*:: Average of `aws.s3_request.requests.total`
+
+*Number of Objects*:: Average of `aws.s3_daily_storage.number_of_objects`
+
+*Downloads (Bytes)*:: Average of `aws.s3_request.downloaded.bytes`
+
+*Uploads (Bytes)*:: Average of `aws.s3_request.uploaded.bytes`
+

--- a/docs/en/metrics/aws-s3-metricset.asciidoc
+++ b/docs/en/metrics/aws-s3-metricset.asciidoc
@@ -1,7 +1,7 @@
 [[aws-s3-metricset]]
 [role="xpack"]
 
-== AWS S3 Bucket Fields
+=== AWS S3 Bucket Fields
 
 *ID*:: `aws.s3.bucket.name`
 *Name*:: `aws.s3.bucket.name`

--- a/docs/en/metrics/aws-sqs-metricset.asciidoc
+++ b/docs/en/metrics/aws-sqs-metricset.asciidoc
@@ -1,7 +1,7 @@
 [[aws-sqs-metricset]]
 [role="xpack"]
 
-== AWS SQS Queue Fields
+=== AWS SQS Queue Fields
 
 *ID*:: `aws.sqs.queue.name`
 *Name*:: `aws.sqs.queue.name`

--- a/docs/en/metrics/aws-sqs-metricset.asciidoc
+++ b/docs/en/metrics/aws-sqs-metricset.asciidoc
@@ -1,0 +1,22 @@
+[[aws-sqs-metricset]]
+[role="xpack"]
+
+== AWS SQS Queue Fields
+
+*ID*:: `aws.sqs.queue.name`
+*Name*:: `aws.sqs.queue.name`
+
+[float]
+=== AWS SQS Queue Metrics
+
+*Messages Available*:: Max of `aws.sqs.messages.visible`
+
+*Messages Delayed*:: Max of `aws.sqs.messages.delayed`
+
+*Messages Added*:: Max of `aws.sqs.messages.sent`
+
+*Messages Returned Empty*:: Max of `aws.sqs.messages.not_visible`
+
+*Oldest Message*:: Max of `aws.sqs.oldest_message_age.sec`
+
+

--- a/docs/en/metrics/docker-metricset.asciidoc
+++ b/docs/en/metrics/docker-metricset.asciidoc
@@ -1,0 +1,19 @@
+[[docker-metricset]]
+[role="xpack"]
+
+== Docker Container Fields
+
+*ID*:: `container.id`
+*Name*:: `container.name`
+*IP Address*:: `container.ip_address`
+
+[float]
+=== Docker Container Metrics
+
+*CPU Usage*:: Average of `docker.cpu.total.pct`
+
+*Memory Usage*:: Average of `docker.memory.usage.pct`
+
+*Inbound Traffic*:: Derivative of the maximum of `docker.network.in.bytes` scaled to a 1 second rate
+
+*Outbound Traffic*:: Derivative of the maximum of `docker.network.out.bytes` scaled to a 1 second rate

--- a/docs/en/metrics/docker-metricset.asciidoc
+++ b/docs/en/metrics/docker-metricset.asciidoc
@@ -1,7 +1,7 @@
 [[docker-metricset]]
 [role="xpack"]
 
-== Docker Container Fields
+=== Docker Container Fields
 
 *ID*:: `container.id`
 *Name*:: `container.name`

--- a/docs/en/metrics/host-metricset.asciidoc
+++ b/docs/en/metrics/host-metricset.asciidoc
@@ -1,7 +1,7 @@
 [[host-metricset]]
 [role="xpack"]
 
-== Hosts Fields
+=== Hosts Fields
 
 *ID*:: `host.name`
 *Name*:: `host.name`

--- a/docs/en/metrics/host-metricset.asciidoc
+++ b/docs/en/metrics/host-metricset.asciidoc
@@ -1,0 +1,24 @@
+[[host-metricset]]
+[role="xpack"]
+
+== Hosts Fields
+
+*ID*:: `host.name`
+*Name*:: `host.name`
+*IP Address*:: `host.ip`
+
+[float]
+=== Host Metrics
+
+*CPU Usage*:: Average of `system.cpu.user.pct` added to the average of `system.cpu.system.pct` divided by `system.cpu.cores`
+
+*Memory Usage*:: Average of `system.memory.actual.used.pct`
+
+*Load*:: Average of `system.load.5`
+
+*Inbound Traffic*:: Derivative of the maximum of `system.network.in.bytes` scaled to a 1 second rate
+
+*Outbound Traffic*:: Derivative of the maximum of `system.network.out.bytes` scaled to a 1 second rate
+
+*Log Rate*:: Derivative of the cumulative sum of the document count scaled to a 1 second rate.
+This metric relies on the same indices as the logs.

--- a/docs/en/metrics/index.asciidoc
+++ b/docs/en/metrics/index.asciidoc
@@ -17,3 +17,17 @@ include::installation.asciidoc[]
 include::infrastructure-metrics.asciidoc[]
 
 include::infra-ui-intro.asciidoc[]
+
+include::host-metricset.asciidoc[]
+
+include::docker-metricset.asciidoc[]
+
+include::kubernetes-metricset.asciidoc[]
+
+include::aws-ec2-metricset.asciidoc[]
+
+include::aws-s3-metricset.asciidoc[]
+
+include::aws-sqs-metricset.asciidoc[]
+
+include::aws-rds-metricset.asciidoc[]

--- a/docs/en/metrics/index.asciidoc
+++ b/docs/en/metrics/index.asciidoc
@@ -17,17 +17,3 @@ include::installation.asciidoc[]
 include::infrastructure-metrics.asciidoc[]
 
 include::infra-ui-intro.asciidoc[]
-
-include::host-metricset.asciidoc[]
-
-include::docker-metricset.asciidoc[]
-
-include::kubernetes-metricset.asciidoc[]
-
-include::aws-ec2-metricset.asciidoc[]
-
-include::aws-s3-metricset.asciidoc[]
-
-include::aws-sqs-metricset.asciidoc[]
-
-include::aws-rds-metricset.asciidoc[]

--- a/docs/en/metrics/infrastructure-metrics.asciidoc
+++ b/docs/en/metrics/infrastructure-metrics.asciidoc
@@ -7,7 +7,7 @@ This section contains detailed information about each of the metricsets the {met
 
 * <<host-metricset, Hosts>>
 * <<docker-metricset, Docker Containers>>
-* <<kibernetes-metricset, Kubernetes Pods>>
+* <<kubernetes-metricset, Kubernetes Pods>>
 * <<aws-ec2-metricset, AWS EC2 Instances>>
 * <<aws-s3-metricset, AWS S3 Buckets>>
 * <<aws-rds-metricset, AWS RDS Databases>>

--- a/docs/en/metrics/infrastructure-metrics.asciidoc
+++ b/docs/en/metrics/infrastructure-metrics.asciidoc
@@ -3,50 +3,19 @@
 
 == Infrastructure metrics
 
-// ++ More explanation needed. Beats provides these metrics automatically, but other solutions for collecting metrics or logs will need to provide these values.
-The metrics listed below are provided by the {beats} shippers.
-Each system type requires their corresponding identity field to be in the same event document:
+This section contains detailed information about each of the metricsets the {metrics-app} supports. The metrics listed below are provided by the {beats} shippers.
 
-* Hosts require `host.name`
-* Docker containers require `container.id`
-* Kubernetes pods require `kubernetes.pod.uid`
+* <<host-metricset, Hosts>>
+* <<docker-metricset, Docker Containers>>
+* <<kibernetes-metricset, Kubernetes Pods>>
+* <<aws-ec2-metricset, AWS EC2 Instances>>
+* <<aws-s3-metricset, AWS S3 Buckets>>
+* <<aws-rds-metricset, AWS RDS Databases>>
+* <<aws-sqs-metricset, AWS SQS Queues>>
+
+[float]
+=== Additional field details
 
 The `event.dataset` field is required to display data properly in some views. This field is a combination of `metricset.module`, which is the Metricbeat module name, and `metricset.name`, which is the metricset name.
 
-[float]
-=== Host Metrics
-
-*CPU Usage*:: Average of `system.cpu.user.pct` added to the average of `system.cpu.system.pct` divided by `system.cpu.cores`
-
-*Memory Usage*:: Average of `system.memory.actual.used.pct`
-
-*Load*:: Average of `system.load.5`
-
-*Inbound Traffic*:: Derivative of the maximum of `system.network.in.bytes` scaled to a 1 second rate
-
-*Outbound Traffic*:: Derivative of the maximum of `system.network.out.bytes` scaled to a 1 second rate
-
-*Log Rate*:: Derivative of the cumulative sum of the document count scaled to a 1 second rate.
-This metric relies on the same indices as the logs.
-
-[float]
-=== Docker Container Metrics
-
-*CPU Usage*:: Average of `docker.cpu.total.pct`
-
-*Memory Usage*:: Average of `docker.memory.usage.pct`
-
-*Inbound Traffic*:: Derivative of the maximum of `docker.network.in.bytes` scaled to a 1 second rate
-
-*Outbound Traffic*:: Derivative of the maximum of `docker.network.out.bytes` scaled to a 1 second rate
-
-[float]
-=== Kubernetes Pod Metrics
-
-*CPU Usage*:: Average of `kubernetes.pod.cpu.usage.node.pct`
-
-*Memory Usage*:: Average of `kubernetes.pod.memory.usage.node.pct`
-
-*Inbound Traffic*:: Derivative of the maximum of `kubernetes.pod.network.rx.bytes` scaled to a 1 second rate
-
-*Outbound Traffic*:: Derivative of the maximum of `kubernetes.pod.network.tx.bytes` scaled to a 1 second rate
+All the charts use the `metricset.period` to determine the optimal time interval for each metric. If `metricset.period` is not available then it falls back to 1 minute intervals.

--- a/docs/en/metrics/infrastructure-metrics.asciidoc
+++ b/docs/en/metrics/infrastructure-metrics.asciidoc
@@ -19,3 +19,17 @@ This section contains detailed information about each of the metricsets the {met
 The `event.dataset` field is required to display data properly in some views. This field is a combination of `metricset.module`, which is the Metricbeat module name, and `metricset.name`, which is the metricset name.
 
 All the charts use the `metricset.period` to determine the optimal time interval for each metric. If `metricset.period` is not available then it falls back to 1 minute intervals.
+
+include::host-metricset.asciidoc[]
+
+include::docker-metricset.asciidoc[]
+
+include::kubernetes-metricset.asciidoc[]
+
+include::aws-ec2-metricset.asciidoc[]
+
+include::aws-s3-metricset.asciidoc[]
+
+include::aws-sqs-metricset.asciidoc[]
+
+include::aws-rds-metricset.asciidoc[]

--- a/docs/en/metrics/kubernetes-metricset.asciidoc
+++ b/docs/en/metrics/kubernetes-metricset.asciidoc
@@ -1,7 +1,7 @@
 [[kubernetes-metricset]]
 [role="xpack"]
 
-== Kubernetes Pod Fields
+=== Kubernetes Pod Fields
 
 *ID*:: `kubernetes.pod.uid`
 *Name*:: `kubernetes.pod.name`

--- a/docs/en/metrics/kubernetes-metricset.asciidoc
+++ b/docs/en/metrics/kubernetes-metricset.asciidoc
@@ -1,0 +1,19 @@
+[[kubernetes-metricset]]
+[role="xpack"]
+
+== Kubernetes Pod Fields
+
+*ID*:: `kubernetes.pod.uid`
+*Name*:: `kubernetes.pod.name`
+*IP Address*:: `kubernetes.pod.ip`
+
+[float]
+=== Kubernetes Pod Metrics
+
+*CPU Usage*:: Average of `kubernetes.pod.cpu.usage.node.pct`
+
+*Memory Usage*:: Average of `kubernetes.pod.memory.usage.node.pct`
+
+*Inbound Traffic*:: Derivative of the maximum of `kubernetes.pod.network.rx.bytes` scaled to a 1 second rate
+
+*Outbound Traffic*:: Derivative of the maximum of `kubernetes.pod.network.tx.bytes` scaled to a 1 second rate


### PR DESCRIPTION
This PR re-organizes the "Infrastructure metrics" page to support linking to multiple sub pages for details about the fields we use for each of the metricsets. The original layout had everything on the same page. Breaking this up will allow us to document the ever growing lists of metricsets.