### PR TITLE
[DOCS] Add metadata to ML pages

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/api-quickref.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/api-quickref.asciidoc
@@ -1,6 +1,7 @@
 [role="xpack"]
 [[ml-api-quickref]]
 == API quick reference
+:keywords: reference
 
 All {ml} {anomaly-detect} endpoints have the following base:
 

--- a/docs/en/stack/ml/anomaly-detection/architecture.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/architecture.asciidoc
@@ -1,6 +1,7 @@
 [role="xpack"]
 [[ml-nodes]]
 === Machine learning nodes
+:keywords: concepts
 
 A {ml} node is a node that has `xpack.ml.enabled` and `node.ml` set to `true`, which is the default behavior. If you set `node.ml` to `false`, the node can
 service API requests but it cannot run jobs. If you want to use {ml-features},

--- a/docs/en/stack/ml/anomaly-detection/buckets.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/buckets.asciidoc
@@ -4,6 +4,7 @@
 ++++
 <titleabbrev>Buckets</titleabbrev>
 ++++
+:keywords: concepts
 
 The {ml-features} use the concept of a _bucket_ to divide the time series into
 batches for processing.

--- a/docs/en/stack/ml/anomaly-detection/calendars.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/calendars.asciidoc
@@ -1,6 +1,7 @@
 [role="xpack"]
 [[ml-calendars]]
 === Calendars and scheduled events
+:keywords: concepts
 
 Sometimes there are periods when you expect unusual activity to take place,
 such as bank holidays, "Black Friday", or planned system outages. If you

--- a/docs/en/stack/ml/anomaly-detection/datafeeds.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/datafeeds.asciidoc
@@ -1,6 +1,7 @@
 [role="xpack"]
 [[ml-dfeeds]]
 === {dfeeds-cap}
+:keywords: concepts
 
 {anomaly-jobs-cap} can analyze data that is stored in {es} or data that is
 sent from some other source via an API. _{dfeeds-cap}_ retrieve data from {es}

--- a/docs/en/stack/ml/anomaly-detection/influencers.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/influencers.asciidoc
@@ -1,6 +1,7 @@
 [role="xpack"]
 [[ml-influencers]]
 === Influencers
+:keywords: concepts
 
 When anomalous events occur, we want to know why. To determine the cause,
 however, you often need a broader knowledge of the domain. If you have

--- a/docs/en/stack/ml/anomaly-detection/jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/jobs.asciidoc
@@ -4,6 +4,7 @@
 ++++
 <titleabbrev>Jobs</titleabbrev>
 ++++
+:keywords: concepts
 
 {anomaly-jobs-cap} contain the configuration information and metadata
 necessary to perform an analytics task.

--- a/docs/en/stack/ml/anomaly-detection/model-snapshots.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/model-snapshots.asciidoc
@@ -1,6 +1,7 @@
 [role="xpack"]
 [[ml-model-snapshots]]
 === Model snapshots
+:keywords: concepts
 
 As described in <<ml-analyzing>>, {stack} {ml-features} can calculate baselines
 of normal behavior then extrapolate anomalous events. These baselines are

--- a/docs/en/stack/ml/anomaly-detection/rules.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/rules.asciidoc
@@ -1,6 +1,7 @@
 [role="xpack"]
 [[ml-rules]]
 === Custom rules
+:keywords: concepts
 
 By default, as described in <<ml-analyzing>>, anomaly detection is unsupervised 
 and the {ml} models have no awareness of the domain of your data. As a result, 

--- a/docs/en/stack/ml/df-analytics/api-quickref.asciidoc
+++ b/docs/en/stack/ml/df-analytics/api-quickref.asciidoc
@@ -1,6 +1,7 @@
 [role="xpack"]
 [[ml-dfanalytics-apis]]
 == API quick reference
+:keywords: reference
 
 All {dfanalytics} endpoints have the following base:
 

--- a/docs/en/stack/ml/df-analytics/dfa-classification.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-classification.asciidoc
@@ -1,6 +1,7 @@
 [role="xpack"]
 [[dfa-classification]]
 === {classification-cap}
+:keywords: concepts
 
 experimental[]
 

--- a/docs/en/stack/ml/df-analytics/dfa-outlierdetection.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-outlierdetection.asciidoc
@@ -1,6 +1,7 @@
 [role="xpack"]
 [[dfa-outlier-detection]]
 === {oldetection-cap}
+:keywords: concepts
 
 experimental[]
 

--- a/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
@@ -1,6 +1,7 @@
 [role="xpack"]
 [[dfa-regression]]
 === {regression-cap}
+:keywords: concepts
 
 experimental[]
 


### PR DESCRIPTION
This PR plays with adding Asciidoctor metadata to the machine learning content per https://asciidoctor.org/docs/user-manual/#metadata

In particular, this PR adds the page's content type (reference/concept/etc) as keyword metadata.  It results in the following, for example:

```
<head>
<meta name="keywords" content="concepts">
```

The values that we put in the "tags" and "subject" field in the https://github.com/elastic/docs/blob/master/conf.yaml, on the other hand, apply to every page in the book and are output as follows:

```
<head>
<meta name="DC.type" content="Learn/Docs/Elastic Stack/Machine learning/master">
<meta name="DC.subject" content="Machine learning">
```

Another option: "You can add content, such as custom metadata, stylesheet, and script information, to the header of the output document using docinfo ("document information" files)".  For example, we can have docinfo files that apply to all documents in the same directory. See https://asciidoctor.org/docs/user-manual/#docinfo-file