### PR TITLE
[DOCS] Fixes out-dated links

### DIFF
--- a/docs/en/install-upgrade/upgrading-stack.asciidoc
+++ b/docs/en/install-upgrade/upgrading-stack.asciidoc
@@ -53,7 +53,7 @@ production cluster.
 
 . Back up your data. You **cannot roll back** to an earlier version unless
 you have a snapshot of your data. For information about creating snapshots, see
-{ref}/modules-snapshots.html[Snapshot and Restore].
+{ref}/snapshot-restore.html[Snapshot and restore].
 
 . Consider closing {ml} jobs before you start the upgrade process. While {ml}
 jobs can continue to run during a rolling upgrade, it increases the overhead

--- a/docs/en/stack/ml/anomaly-detection/calendars.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/calendars.asciidoc
@@ -32,9 +32,8 @@ iCalendar (`.ics`) file in {kib} or a JSON file in the
 for that time period. Machine learning results are not updated retroactively.
 * If your iCalendar file contains recurring events, only the first occurrence is
 imported.
-* Bucket results are generated during scheduled events but they have an
-anomaly score of zero. For more information about bucket results, see
-{ref}/ml-results-resource.html[Results resources].
+* <<ml-bucket-results,Bucket results>> are generated during scheduled events but
+they have an anomaly score of zero.
 * If you use long or frequent scheduled events, it might take longer for the
 {ml} analytics to learn to model your data and some anomalous behavior might be
 missed.

--- a/docs/en/stack/ml/anomaly-detection/datafeeds.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/datafeeds.asciidoc
@@ -9,11 +9,9 @@ for analysis, which is the simpler and more common scenario.
 If you create {anomaly-jobs} in {kib}, you must use {dfeeds}. When you create a
 job, you select an index pattern and {kib} configures the {dfeed} for you under
 the covers. If you use APIs instead, you can create a {dfeed} by using the
-{ref}/ml-put-datafeed.html[create {dfeeds} API] after you create an
-{anomaly-job}. You can associate only one {dfeed} with each job.
-
-For a description of all the {dfeed} properties, see
-{ref}/ml-datafeed-resource.html[Datafeed resources].
+create {dfeeds} API after you create an {anomaly-job}. You can associate only
+one {dfeed} with each job. For a description of all the {dfeed} properties, see
+the {ref}/ml-put-datafeed.html[create {dfeeds} API].
 
 To start retrieving data from {es}, you must start the {dfeed}. When you start
 it, you can optionally specify start and end times. If you do not specify an

--- a/docs/en/stack/ml/anomaly-detection/getting-started-multi.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/getting-started-multi.asciidoc
@@ -176,9 +176,7 @@ might differ slightly. This disparity occurs because for each job we generate
 bucket results, influencer results, and record results. Anomaly scores are
 generated for each type of result. The anomaly timeline uses the bucket-level
 anomaly scores. The list of top influencers uses the influencer-level anomaly
-scores. The list of anomalies uses the record-level anomaly scores. For more
-information about these different result types, see
-{ref}/ml-results-resource.html[Results Resources].
+scores. The list of anomalies uses the record-level anomaly scores.
 
 Click on a section in the swim lanes to obtain more information about the
 anomalies in that time period. For example, click on the red section in the swim

--- a/docs/en/stack/ml/anomaly-detection/getting-started-single.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/getting-started-single.asciidoc
@@ -159,11 +159,9 @@ The status of the mathematical models. When you create jobs by using the APIs or
 by using the advanced options in {kib}, you can specify a `model_memory_limit`.
 That value is the maximum amount of memory resources that the mathematical
 models can use. Once that limit is approached, data pruning becomes more
-aggressive. Upon exceeding that limit, new entities are not modeled. For more
-information about this setting, see
-{ref}/ml-job-resource.html#ml-apilimits[Analysis Limits]. The memory status
-field reflects whether you have reached or exceeded the model memory limit. It
-can have one of the following values: +
+aggressive. Upon exceeding that limit, new entities are not modeled. The memory
+status field reflects whether you have reached or exceeded the model memory
+limit. It can have one of the following values: +
 `ok`::: The models stayed below the configured value.
 `soft_limit`::: The models used more than 60% of the configured memory limit
 and older unused models will be pruned to free up space.

--- a/docs/en/stack/ml/anomaly-detection/job-tips.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/job-tips.asciidoc
@@ -17,8 +17,8 @@ The bucket span is the time interval that {ml} analytics use to summarize and
 model data for your job. When you create an {anomaly-job} in {kib}, you can
 choose to estimate a bucket span value based on your data characteristics. 
 
-NOTE: The bucket span must contain a valid time interval. For more information, 
-see {ref}/ml-job-resource.html#ml-analysisconfig[Analysis configuration objects].
+NOTE: The bucket span must contain a valid time interval. See
+{ref}/common-options.html#time-units[Time units].
 
 If you choose a value that is larger than one day or is significantly different 
 than the estimated value, you receive an informational message. For more 
@@ -99,8 +99,3 @@ If you are using {ece} or the hosted Elasticsearch Service on Elastic Cloud,
 that cannot be allocated to any {ml} nodes in the cluster. If you find that you 
 cannot increase `model_memory_limit` for your {ml} jobs, the solution is to 
 increase the size of the {ml} nodes in your cluster.
-
-For more information about the `model_memory_limit` property and the 
-`xpack.ml.max_model_memory_limit` setting, see 
-{ref}/ml-job-resource.html#ml-analysisconfig[Analysis limits] and 
-{ref}/ml-settings.html[Machine learning settings].

--- a/docs/en/stack/ml/anomaly-detection/jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/jobs.asciidoc
@@ -19,15 +19,13 @@ in a population. There are also multiple options for splitting the data into
 categories and partitions. Some of these more advanced job configurations
 are described in the following section: <<anomaly-examples>>.
 
-For a description of all the job properties, see
-{ref}/ml-job-resource.html[{anomaly-jobs-cap} resources].
+For a description of all the job properties, see the 
+{ref}/ml-put-job.html[create {anomaly-jobs} API].
 
 In {kib}, there are wizards that help you create specific types of jobs, such
 as _single metric_, _multi-metric_, and _population_ jobs. A single metric job
 is just a job with a single detector and limited job properties. To have access
 to all of the job properties in {kib}, you must choose the _advanced_ job wizard.
-//If you want to try creating single and multi-metrics jobs in {kib} with sample
-//data, see <<ml-getting-started>>.
 
 You can also optionally assign jobs to one or more _job groups_. You can use
 job groups to view the results from multiple jobs more easily and to expedite

--- a/docs/en/stack/ml/anomaly-detection/limitations.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/limitations.asciidoc
@@ -103,7 +103,7 @@ Missing fields might be expected due to the structure of the data and therefore
 do not generate poor results.
 
 For more information about `missing_field_count`,
-see {ref}/ml-jobstats.html#ml-datacounts[Data Counts Objects].
+see the {ref}/ml-get-job-stats.html[get {anomaly-job} statistics API].
 
 
 [float]
@@ -145,9 +145,6 @@ this additional model information for every bucket might be problematic. If you
 are not certain that you need this option or if you experience performance
 issues, edit your job configuration to disable this option.
 
-For more information, see
-{ref}/ml-job-resource.html#ml-apimodelplotconfig[Model Plot Config].
-
 Likewise, when you create a single or multi-metric job in {kib}, in some cases
 it uses aggregations on the data that it retrieves from {es}. One of the
 benefits of summarizing data this way is that {es} automatically distributes
@@ -160,8 +157,6 @@ The {ml} analytics are designed to be aggregation-aware and the likely increase
 in performance that is gained by pre-aggregating the data makes the potentially
 poorer precision worthwhile. If you want to view or change the aggregations
 that are used in your job, refer to the `aggregations` property in your {dfeed}.
-
-For more information, see {ref}/ml-datafeed-resource.html[Datafeed Resources].
 
 [float]
 === Security integration

--- a/docs/en/stack/ml/anomaly-detection/troubleshooting.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/troubleshooting.asciidoc
@@ -86,8 +86,7 @@ abbreviated name, it is displayed.
 Create {anomaly-jobs} in {kib} or ensure that you create {anomaly-jobs} with
 valid identifiers when you use the APIs. For more information about valid
 identifiers, see
-{ref}/ml-put-job.html[Create {anomaly-jobs} API] or
-{ref}/ml-job-resource.html[{anomaly-detect-cap} job resources].
+{ref}/ml-put-job.html[Create {anomaly-jobs} API].
 
 [[ml-upgradedf]]
 


### PR DESCRIPTION
This PR fixes links to pages that have been deleted from the Elasticsearch Reference. They currently do not generate build errors because there are entries for them in https://github.com/elastic/elasticsearch/blob/master/docs/reference/redirects.asciidoc