### PR TITLE
[DOCS] Documents imbalanced class sizes and their effect on classification

### DIFF
--- a/docs/en/stack/ml/df-analytics/dfa-classification.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-classification.asciidoc
@@ -50,9 +50,10 @@ means that you need to supply a labeled training dataset that has some
 relationships between the features and the {depvar}. Once you’ve trained the 
 model on your training dataset, you can reuse the knowledge that the model has 
 learned about the relationships between the data points to classify new data. 
-Your training dataset should be approximately balanced, otherwise the {classanalysis} may not 
-provide the best predictions. Read <<dfa-classification-imbalanced-classes>> to 
-learn more.
+Your training dataset should be approximately balanced which means the number of 
+data points belonging to the various classes should not be widely different, 
+otherwise the {classanalysis} may not provide the best predictions. Read 
+<<dfa-classification-imbalanced-classes>> to learn more.
 
 
 [discrete]

--- a/docs/en/stack/ml/df-analytics/dfa-classification.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-classification.asciidoc
@@ -49,7 +49,10 @@ means that you need to supply a labeled training dataset that has some
 {feature-vars} and a {depvar}. The {classification} algorithm learns the 
 relationships between the features and the {depvar}. Once you’ve trained the 
 model on your training dataset, you can reuse the knowledge that the model has 
-learned about the relationships between the data points to classify new data.
+learned about the relationships between the data points to classify new data. 
+Your training dataset should be balanced, otherwise the {classanalysis} may not 
+provide the best predictions. Read <<dfa-classification-imbalanced-classes>> to 
+learn more.
 
 
 [discrete]

--- a/docs/en/stack/ml/df-analytics/dfa-classification.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-classification.asciidoc
@@ -50,7 +50,7 @@ means that you need to supply a labeled training dataset that has some
 relationships between the features and the {depvar}. Once you’ve trained the 
 model on your training dataset, you can reuse the knowledge that the model has 
 learned about the relationships between the data points to classify new data. 
-Your training dataset should be balanced, otherwise the {classanalysis} may not 
+Your training dataset should be approximately balanced, otherwise the {classanalysis} may not 
 provide the best predictions. Read <<dfa-classification-imbalanced-classes>> to 
 learn more.
 

--- a/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
@@ -110,14 +110,16 @@ destination index that don't contain a results field are not included in the
 
 If your training data is very imbalanced, then {classanalysis} may not provide 
 good predictions. Training tries to mitigate the effects of imbalanced 
-training data by maximizing the minimum recall of any class. For imbalanced training data, this means that it
-will try to balance the proportion of values it correctly labels in the minority and majority class.
-However, this process can result in a slight degradation of the overall 
-accuracy. Try to avoid highly imbalanced situations. It is required at least 50 
-examples for each class in order to get better results. If your training dataset 
-is very imbalanced, fine-tune the data, for example, by downsampling the 
-majority classes. Consider investigating methods to change data that fit your 
-use case the most.
+training data by maximizing the minimum recall of any class. For imbalanced 
+training data, this means that it will try to balance the proportion of values 
+it correctly labels in the minority and majority class. However, this process 
+can result in a slight degradation of the overall accuracy. Try to avoid highly 
+imbalanced situations. We recommend having at least 50 examples of each class 
+and a ratio of no more than 10 to 1 for the majority to minority class labels in 
+the training data. If your training dataset is very imbalanced, consider 
+downsampling the majority class, upsampling the minority class or – if it's 
+possible – gather more data. Consider investigating methods to change data that 
+fit your use case the most.
 
 [float]
 [[dfa-inference-nested-limitation]]

--- a/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
@@ -110,7 +110,7 @@ destination index that don't contain a results field are not included in the
 
 If your training data is very imbalanced, then {classanalysis} may not provide 
 good predictions. Training tries to mitigate the effects of imbalanced 
-training data by maximizing the minimum recall of any class. It means that it 
+training data by maximizing the minimum recall of any class. For imbalanced training data, this means that it
 tries to get correct the highest number of examples in the minority classes. 
 However, this process can result in a slight degradation of the overall 
 accuracy. Try to avoid highly imbalanced situations. It is required at least 50 

--- a/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
@@ -109,7 +109,7 @@ destination index that don't contain a results field are not included in the
 === Imbalanced class sizes affect {classification} performance
 
 If your training data is very imbalanced, then {classanalysis} may not provide 
-good predictions. The system tries to mitigate the effects of imbalanced 
+good predictions. Training tries to mitigate the effects of imbalanced 
 training data by maximizing the minimum recall of any class. It means that it 
 tries to get correct the highest number of examples in the minority classes. 
 However, this process can result in a slight degradation of the overall 

--- a/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
@@ -105,6 +105,21 @@ destination index that don't contain a results field are not included in the
 {classanalysis}.
 
 [float]
+[[dfa-classification-imbalanced-classes]]
+=== Imbalanced class sizes affect {classification} performance
+
+If your training data is very imbalanced, then {classanalysis} may not provide 
+good predictions. The system tries to mitigate the effects of imbalanced 
+training data by maximizing the minimum recall of any class. It means that it 
+tries to get correct the highest number of examples in the minority classes. 
+However, this process can result in a slight degradation of the overall 
+accuracy. Try to avoid highly imbalanced situations. It is required at least 50 
+examples for each class in order to get better results. If your training dataset 
+is very imbalanced, fine-tune the data, for example, by downsampling the 
+majority classes. Consider investigating methods to change data that fit your 
+use case the most.
+
+[float]
 [[dfa-inference-nested-limitation]]
 === Deeply nested objects affect {infer} performance
 

--- a/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
@@ -111,7 +111,7 @@ destination index that don't contain a results field are not included in the
 If your training data is very imbalanced, then {classanalysis} may not provide 
 good predictions. Training tries to mitigate the effects of imbalanced 
 training data by maximizing the minimum recall of any class. For imbalanced training data, this means that it
-tries to get correct the highest number of examples in the minority classes. 
+will try to balance the proportion of values it correctly labels in the minority and majority class.
 However, this process can result in a slight degradation of the overall 
 accuracy. Try to avoid highly imbalanced situations. It is required at least 50 
 examples for each class in order to get better results. If your training dataset 


### PR DESCRIPTION
This PR adds a limitation item about imbalanced class sizes to the limitation section and mentions the issue in the classification conceptual documentation.

Docs preview: http://stack-docs_806.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-dfa-limitations.html