### PR TITLE
[DOCS] Adds language identification documentation to the ML DFA docs

### DIFF
--- a/docs/en/stack/ml/df-analytics/examples.asciidoc
+++ b/docs/en/stack/ml/df-analytics/examples.asciidoc
@@ -8,16 +8,18 @@
 
 beta[]
 
-These examples demonstrate how to use {dfanalytics} to derive useful 
-insights from your data.
+These examples demonstrate how to use {dfanalytics} to derive useful insights 
+from your data.
 
 * <<ecommerce-outliers>>
 * https://github.com/elastic/examples/tree/master/Machine%20Learning/Outlier%20Detection/Introduction[{oldetection-cap} example (Jupyter notebook)]
 * <<flightdata-regression>>
 * <<flightdata-classification>>
 * https://github.com/elastic/examples/tree/master/Machine%20Learning/Analytics%20Jupyter%20Notebooks[{classanalysis-cap} example (Jupyter notebook)]
+* * <<ml-lang-ident>
 
 
 include::ecommerce-outliers.asciidoc[]
 include::flightdata-regression.asciidoc[]
 include::flightdata-classification.asciidoc[]
+include::ml-lang-ident.asciidoc[]

--- a/docs/en/stack/ml/df-analytics/examples.asciidoc
+++ b/docs/en/stack/ml/df-analytics/examples.asciidoc
@@ -16,7 +16,7 @@ from your data.
 * <<flightdata-regression>>
 * <<flightdata-classification>>
 * https://github.com/elastic/examples/tree/master/Machine%20Learning/Analytics%20Jupyter%20Notebooks[{classanalysis-cap} example (Jupyter notebook)]
-* * <<ml-lang-ident>
+* <<ml-lang-ident>>
 
 
 include::ecommerce-outliers.asciidoc[]

--- a/docs/en/stack/ml/df-analytics/ml-dfa-concepts.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-concepts.asciidoc
@@ -9,10 +9,12 @@ feature and the corresponding {evaluatedf-api}.
 * <<dfa-regression>>
 * <<dfa-classification>>
 * <<ml-inference>>
+* <<ml-lang-ident>
 * <<ml-dfanalytics-evaluate>>
 
 include::dfa-outlierdetection.asciidoc[]
 include::dfa-regression.asciidoc[]
 include::dfa-classification.asciidoc[]
 include::ml-inference.asciidoc[]
+include::ml-lang-ident.asciidoc[]
 include::evaluatedf-api.asciidoc[]

--- a/docs/en/stack/ml/df-analytics/ml-dfa-concepts.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-concepts.asciidoc
@@ -9,12 +9,10 @@ feature and the corresponding {evaluatedf-api}.
 * <<dfa-regression>>
 * <<dfa-classification>>
 * <<ml-inference>>
-* <<ml-lang-ident>
 * <<ml-dfanalytics-evaluate>>
 
 include::dfa-outlierdetection.asciidoc[]
 include::dfa-regression.asciidoc[]
 include::dfa-classification.asciidoc[]
 include::ml-inference.asciidoc[]
-include::ml-lang-ident.asciidoc[]
 include::evaluatedf-api.asciidoc[]

--- a/docs/en/stack/ml/df-analytics/ml-lang-ident.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-lang-ident.asciidoc
@@ -6,7 +6,7 @@ experimental[]
 
 {lang-ident-cap} `model_id`: `lang_ident_model_1`
 
-{lang-ident-cap} is an {infer} trained model that you can use to determine on 
+{lang-ident-cap} is an {infer} trained model that you can use to determine in 
 which language a certain text is written. You can reference the {lang-ident} 
 model in an {ref}/inference-processor.html[{infer} processor] of an ingest 
 pipeline by using its `model_id`. The input filed name is `text` by default. If 

--- a/docs/en/stack/ml/df-analytics/ml-lang-ident.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-lang-ident.asciidoc
@@ -2,12 +2,17 @@
 [[ml-lang-ident]]
 === {lang-ident-cap}
 
-{lang-ident-cap}
+{lang-ident-cap} 
 
 
 [[ml-lang-ident-supported-languages]]
 ==== Supported languages
 
+The table below contains the ISO codes and the English names of the languages 
+that {lang-ident} supports. If a language has a 2-letter `ISO 639-1` code, the 
+table contains that identifier. Otherwise, the 3-letter `ISO 639-2` code is 
+used. The ‘Latn’ subtag indicates that the language is transliterated into Latin 
+script.
 
 [cols="<,<,<,<,<,<"]
 |===

--- a/docs/en/stack/ml/df-analytics/ml-lang-ident.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-lang-ident.asciidoc
@@ -1,0 +1,5 @@
+[role="xpack"]
+[[ml-lang-ident]]
+=== {lang-ident-cap}
+
+{lang-ident-cap}

--- a/docs/en/stack/ml/df-analytics/ml-lang-ident.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-lang-ident.asciidoc
@@ -8,7 +8,7 @@ experimental[]
 
 {lang-ident-cap} is an {infer} trained model that you can use to determine on 
 which language a certain text is written. You can reference the {lang-ident} 
-model in an {ref}//inference-processor.html[{infer} processor] of an ingest 
+model in an {ref}/inference-processor.html[{infer} processor] of an ingest 
 pipeline by using its `model_id`. The input filed name is `text` by default. If 
 you want to run {lang-ident} on an field with a different name, then you have to 
 map your field name to `text` in the ingest processor.

--- a/docs/en/stack/ml/df-analytics/ml-lang-ident.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-lang-ident.asciidoc
@@ -7,7 +7,7 @@ experimental[]
 {lang-ident-cap} `model_id`: `lang_ident_model_1`
 
 {lang-ident-cap} is an {infer} trained model that you can use to determine in 
-which language a certain text is written. You can reference the {lang-ident} 
+which language text is written. You can reference the {lang-ident} 
 model in an {ref}/inference-processor.html[{infer} processor] of an ingest 
 pipeline by using its `model_id`. The input filed name is `text` by default. If 
 you want to run {lang-ident} on an field with a different name, then you have to 

--- a/docs/en/stack/ml/df-analytics/ml-lang-ident.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-lang-ident.asciidoc
@@ -16,7 +16,7 @@ map your field name to `text` in the ingest processor settings.
 The longer the text passed into the {lang-ident} model, the more accurate the 
 model will be identifying the language. It is fairly accurate on shorter samples 
 (for example, 50 character-long streams) in certain languages, but languages 
-that are very similar to each other are hard to identify based on a very short 
+that are similar to each other are harder to identify based on a short 
 character stream.
 
 {lang-ident-cap} takes into account Unicode boundaries when the feature set is 

--- a/docs/en/stack/ml/df-analytics/ml-lang-ident.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-lang-ident.asciidoc
@@ -20,7 +20,7 @@ that are similar to each other are harder to identify based on a short
 character stream.
 
 {lang-ident-cap} takes into account Unicode boundaries when the feature set is 
-built. If the text has diacritical marks then the model uses that information 
+built. If the text has diacritical marks, then the model uses that information 
 for identifying the language of the text.  In certain cases, the model can 
 detect the source language even if it is not written in the script that the 
 language traditionally uses. These languages are marked in the supported 

--- a/docs/en/stack/ml/df-analytics/ml-lang-ident.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-lang-ident.asciidoc
@@ -10,13 +10,22 @@ experimental[]
 which language a certain text is written. You can reference the {lang-ident} 
 model in an {ref}//inference-processor.html[{infer} processor] of an ingest 
 pipeline by using its `model_id`. The input filed name is `text` by default. If 
-you want to run {lang-ident} on an other field, you have to  
+you want to run {lang-ident} on an field with a different name, then you have to 
+map your field name to `text` in the ingest processor.
 
-The longer the text passed into the {lang-ident} model, the more likely it is 
-able to correctly identify the language. In certain cases, the model can detect 
-the source language even if it is not written in the script that the language 
-traditionally use. These languages are marked in the supported languages table 
-(see below) with the `Latn` subtag.
+The longer the text passed into the {lang-ident} model, the more accurate the 
+model will be to identify the language. It is fairly accurate on shorter samples 
+(for example, 50 character-long streams) at certain languages, but languages 
+that are very similar to each other are hard to identify based on a very short 
+character stream.
+
+{lang-ident-cap} takes into account Unicode boundaries when the feature set is 
+built. If the text has diacritical marks then the model uses that information 
+for identifying the language of the text.  In certain cases, the model can 
+detect the source language even if it is not written in the script that the 
+language traditionally uses. These languages are marked in the supported 
+languages table (see below) with the `Latn` subtag. {lang-ident-cap} supports 
+Unicode input.
 
 
 [[ml-lang-ident-supported-languages]]

--- a/docs/en/stack/ml/df-analytics/ml-lang-ident.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-lang-ident.asciidoc
@@ -14,7 +14,7 @@ you want to run {lang-ident} on an field with a different name, then you have to
 map your field name to `text` in the ingest processor settings.
 
 The longer the text passed into the {lang-ident} model, the more accurate the 
-model will be to identify the language. It is fairly accurate on shorter samples 
+model will be identifying the language. It is fairly accurate on shorter samples 
 (for example, 50 character-long streams) at certain languages, but languages 
 that are very similar to each other are hard to identify based on a very short 
 character stream.

--- a/docs/en/stack/ml/df-analytics/ml-lang-ident.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-lang-ident.asciidoc
@@ -11,7 +11,7 @@ which language text is written. You can reference the {lang-ident}
 model in an {ref}/inference-processor.html[{infer} processor] of an ingest 
 pipeline by using its `model_id`. The input field name is `text`. If 
 you want to run {lang-ident} on an field with a different name, then you have to 
-map your field name to `text` in the ingest processor.
+map your field name to `text` in the ingest processor settings.
 
 The longer the text passed into the {lang-ident} model, the more accurate the 
 model will be to identify the language. It is fairly accurate on shorter samples 

--- a/docs/en/stack/ml/df-analytics/ml-lang-ident.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-lang-ident.asciidoc
@@ -3,3 +3,51 @@
 === {lang-ident-cap}
 
 {lang-ident-cap}
+
+
+[[ml-lang-ident-supported-languages]]
+==== Supported languages
+
+
+[cols="<,<,<,<,<,<"]
+|===
+| Code    | Language           | Code    | Language       | Code    | Language
+
+| af      | Afrikaans          | hr      | Croatian       | pa      | Punjabi        
+| am      | Amharic            | ht      | Haitian        | pl      | Polish        
+| ar      | Arabic             | hu      | Hungarian      | ps      | Pashto        
+| az      | Azerbaijani        | hy      | Armenian       | pt      | Portuguese
+| be      | Belarusian         | id      | Indonesian     | ro      | Romanian
+| bg      | Bulgarian          | ig      | Igbo           | ru      | Russian
+| bg-Latn | Bulgarian          | is      | Icelandic      | ru-Latn | Russian
+| bn      | Bengali            | it      | Italian        | sd      | Sindhi
+| bs      | Bosnian            | iw      | Hebrew         | si      | Sinhala
+| ca      | Catalan            | ja      | Japanese       | sk      | Slovak
+| ceb     | Cebuano            | ja-Latn | Japanese       | sl      | Slovenian
+| co      | Corsican           | jv      | Javanese       | sm      | Samoan
+| cs      | Czech              | ka      | Georgian       | sn      | Shona
+| cy      | Welsh              | kk      | Kazakh         | so      | Somali
+| da      | Danish             | km      | Central Khmer  | sq      | Albanian
+| de      | German             | kn      | Kannada        | sr      | Serbian
+| el      | Greek, modern      | ko      | Korean         | st      | Southern Sotho
+| el-Latn | Greek, modern      | ku      | Kurdish        | su      | Sundanese
+| en      | English            | ky      | Kirghiz        | sv      | Swedish
+| eo      | Esperanto          | la      | Latin          | sw      | Swahili
+| es      | Spanish, Castilian | lb      | Luxembourgish  | ta      | Tamil
+| et      | Estonian           | lo      | Lao            | te      | Telugu
+| eu      | Basque             | lt      | Lithuanian     | tg      | Tajik
+| fa      | Persian            | lv      | Latvian        | th      | Thai
+| fi      | Finnish            | mg      | Malagasy       | tr      | Turkish
+| fil     | Filipino           | mi      | Maori          | uk      | Ukrainian
+| fr      | French             | mk      | Macedonian     | ur      | Urdu
+| fy      | Western Frisian    | ml      | Malayalam      | uz      | Uzbek
+| ga      | Irish              | mn      | Mongolian      | vi      | Vietnamese
+| gd      | Gaelic             | mr      | Marathi        | xh      | Xhosa
+| gl      | Galician           | ms      | Malay          | yi      | Yiddish
+| gu      | Gujarati           | mt      | Maltese        | yo      | Yoruba
+| ha      | Hausa              | my      | Burmese        | zh      | Chinese
+| haw     | Hawaiian           | ne      | Nepali         | zh-Latn | Chinese
+| hi      | Hindi              | nl      | Dutch, Flemish | zu      | Zulu
+| hi-Latn | Hindi              | no      | Norwegian      |         |   
+| hmn     | Hmong              | ny      | Chichewa       |         |   
+|===

--- a/docs/en/stack/ml/df-analytics/ml-lang-ident.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-lang-ident.asciidoc
@@ -7,11 +7,11 @@ experimental[]
 {lang-ident-cap} `model_id`: `lang_ident_model_1`
 
 {lang-ident-cap} is an {infer} trained model that you can use to determine in 
-which language text is written. You can reference the {lang-ident} 
-model in an {ref}/inference-processor.html[{infer} processor] of an ingest 
-pipeline by using its `model_id`. The input field name is `text`. If 
-you want to run {lang-ident} on an field with a different name, then you have to 
-map your field name to `text` in the ingest processor settings.
+which language text is written. You can reference the {lang-ident} model in an 
+{ref}/inference-processor.html[{infer} processor] of an ingest pipeline by using 
+its `model_id`. The input field name is `text`. If you want to run {lang-ident} 
+on an field with a different name, then you have to map your field name to 
+`text` in the ingest processor settings.
 
 The longer the text passed into the {lang-ident} model, the more accurate the 
 model will be identifying the language. It is fairly accurate on shorter samples 

--- a/docs/en/stack/ml/df-analytics/ml-lang-ident.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-lang-ident.asciidoc
@@ -103,7 +103,7 @@ POST _ingest/pipeline/_simulate
    "docs":[
       {
          "_source":{ <3>
-            "text":"Sziasztok! Ez egy rövid magyar szöveg. Nézzük, vajon sikerül-e azonosítania a language identification funkciónak? Szerintem annak ellenére is sikerülni fog, hogy a szöveg két angol szót is tartalmaz."
+            "text":"Sziasztok! Ez egy rövid magyar szöveg. Nézzük, vajon sikerül-e azonosítania a language identification funkciónak? Annak ellenére is sikerülni fog, hogy a szöveg két angol szót is tartalmaz."
          }
       }
    ]
@@ -130,7 +130,7 @@ The request returns the following response:
         "_type" : "_doc",
         "_id" : "_id",
         "_source" : {
-          "text" : "Sziasztok! Ez egy nagyon rövid magyar szöveg. Nézzük, vajon sikerül-e azonosítania a language identification funkciónak? Szerintem annak ellenére is sikerülni fog, hogy a szöveg két angol szót is tartalmaz.",
+          "text" : "Sziasztok! Ez egy rövid magyar szöveg. Nézzük, vajon sikerül-e azonosítania a language identification funkciónak? Annak ellenére is sikerülni fog, hogy a szöveg két angol szót is tartalmaz.",
           "ml" : {
             "inference" : {
               "top_classes" : [ <1>

--- a/docs/en/stack/ml/df-analytics/ml-lang-ident.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-lang-ident.asciidoc
@@ -4,14 +4,12 @@
 
 experimental[]
 
-{lang-ident-cap} `model_id`: `lang_ident_model_1`
-
-{lang-ident-cap} is an {infer} trained model (`lang_ident_model_1`) that you can use to determine the language of text.
-which language text is written. You can reference the {lang-ident} model in an 
-{ref}/inference-processor.html[{infer} processor] of an ingest pipeline by using 
-its model ID (`lang_ident_model_1`). The input field name is `text`. If you want to run {lang-ident} 
-on a field with a different name, you must map your field name to 
-`text` in the ingest processor settings.
+{lang-ident-cap} is an {infer} trained model (`lang_ident_model_1`) that you can 
+use to determine the language of text. You can reference the {lang-ident} model 
+in an {ref}/inference-processor.html[{infer} processor] of an ingest pipeline by 
+using its model ID (`lang_ident_model_1`). The input field name is `text`. If 
+you want to run {lang-ident} on a field with a different name, you must map your 
+field name to `text` in the ingest processor settings.
 
 The longer the text passed into the {lang-ident} model, the more accurately the 
 model can identify the language. It is fairly accurate on short samples 

--- a/docs/en/stack/ml/df-analytics/ml-lang-ident.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-lang-ident.asciidoc
@@ -2,8 +2,21 @@
 [[ml-lang-ident]]
 === {lang-ident-cap}
 
-{lang-ident-cap} is an {infer} trained model that you can use out of the box. 
-It enables you to determine on which language a certain text is written.
+experimental[]
+
+{lang-ident-cap} `model_id`: `lang_ident_model_1`
+
+{lang-ident-cap} is an {infer} trained model that you can use to determine on 
+which language a certain text is written. You can reference the {lang-ident} 
+model in an {ref}//inference-processor.html[{infer} processor] of an ingest 
+pipeline by using its `model_id`. The input filed name is `text` by default. If 
+you want to run {lang-ident} on an other field, you have to  
+
+The longer the text passed into the {lang-ident} model, the more likely it is 
+able to correctly identify the language. In certain cases, the model can detect 
+the source language even if it is not written in the script that the language 
+traditionally use. These languages are marked in the supported languages table 
+(see below) with the `Latn` subtag.
 
 
 [[ml-lang-ident-supported-languages]]
@@ -64,34 +77,36 @@ script.
 
 In the following example, we feed the {lang-ident} trained model with a short 
 Hungarian text that contains diacritics and a couple of English words. Yet, the 
-model identifies the text correctly as Hungarian with very high probability.
+model identifies the text correctly as Hungarian with high probability.
 
 [source,js]
 ----------------------------------
 POST _ingest/pipeline/_simulate
 {
-	"pipeline": {
-		"processors": [
+   "pipeline":{
+      "processors":[
+         {
+            "inference":{
+               "model_id":"lang_ident_model_1", <1>
+               "inference_config":{
+                  "classification":{
+                     "num_top_classes":5 <2>
+                  }
+               },
+               "field_mappings":{
+
+               }
+            }
+         }
+      ]
+   },
+   "docs":[
       {
-			  "inference": {
-				  "model_id": "lang_ident_model_1", <1>
-				  "inference_config": {
-					  "classification": {
-						  "num_top_classes": 5 <2>
-					  }
-				  },
-				  "field_mappings": {}
-			  }
+         "_source":{ <3>
+            "text":"Sziasztok! Ez egy rövid magyar szöveg. Nézzük, vajon sikerül-e azonosítania a language identification funkciónak? Szerintem annak ellenére is sikerülni fog, hogy a szöveg két angol szót is tartalmaz."
+         }
       }
-    ]
-	},
-	"docs": [
-    {
-		  "_source": { <3>
-			  "text": "Sziasztok! Ez egy rövid magyar szöveg. Nézzük, vajon sikerül-e azonosítania a language identification funkciónak? Szerintem annak ellenére is sikerülni fog, hogy a szöveg két angol szót is tartalmaz."
-		  }
-	  }
-  ]
+   ]
 }
 ----------------------------------
 //NOTCONSOLE

--- a/docs/en/stack/ml/df-analytics/ml-lang-ident.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-lang-ident.asciidoc
@@ -14,7 +14,7 @@ on a field with a different name, you must map your field name to
 `text` in the ingest processor settings.
 
 The longer the text passed into the {lang-ident} model, the more accurately the 
-model will be identifying the language. It is fairly accurate on shorter samples 
+model can identify the language. It is fairly accurate on short samples 
 (for example, 50 character-long streams) in certain languages, but languages 
 that are similar to each other are harder to identify based on a short 
 character stream.

--- a/docs/en/stack/ml/df-analytics/ml-lang-ident.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-lang-ident.asciidoc
@@ -10,7 +10,7 @@ experimental[]
 which language text is written. You can reference the {lang-ident} model in an 
 {ref}/inference-processor.html[{infer} processor] of an ingest pipeline by using 
 its model ID (`lang_ident_model_1`). The input field name is `text`. If you want to run {lang-ident} 
-on an field with a different name, then you have to map your field name to 
+on a field with a different name, you must map your field name to 
 `text` in the ingest processor settings.
 
 The longer the text passed into the {lang-ident} model, the more accurate the 

--- a/docs/en/stack/ml/df-analytics/ml-lang-ident.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-lang-ident.asciidoc
@@ -85,7 +85,7 @@ script.
 ==== Example of {lang-ident}
 
 In the following example, we feed the {lang-ident} trained model a short 
-Hungarian text that contains diacritics and a couple of English words. Yet, the 
+Hungarian text that contains diacritics and a couple of English words. The 
 model identifies the text correctly as Hungarian with high probability.
 
 [source,js]

--- a/docs/en/stack/ml/df-analytics/ml-lang-ident.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-lang-ident.asciidoc
@@ -2,7 +2,8 @@
 [[ml-lang-ident]]
 === {lang-ident-cap}
 
-{lang-ident-cap} 
+{lang-ident-cap} is an {infer} trained model that you can use out of the box. 
+It enables you to determine on which language a certain text is written.
 
 
 [[ml-lang-ident-supported-languages]]
@@ -56,3 +57,111 @@ script.
 | hi-Latn | Hindi              | no      | Norwegian      |         |   
 | hmn     | Hmong              | ny      | Chichewa       |         |   
 |===
+
+
+[[ml-lang-ident-example]]
+==== Example of {lang-ident}
+
+In the following example, we feed the {lang-ident} trained model with a short 
+Hungarian text that contains diacritics and a couple of English words. Yet, the 
+model identifies the text correctly as Hungarian with very high probability.
+
+[source,js]
+----------------------------------
+POST _ingest/pipeline/_simulate
+{
+	"pipeline": {
+		"processors": [
+      {
+			  "inference": {
+				  "model_id": "lang_ident_model_1", <1>
+				  "inference_config": {
+					  "classification": {
+						  "num_top_classes": 5 <2>
+					  }
+				  },
+				  "field_mappings": {}
+			  }
+      }
+    ]
+	},
+	"docs": [
+    {
+		  "_source": { <3>
+			  "text": "Sziasztok! Ez egy rövid magyar szöveg. Nézzük, vajon sikerül-e azonosítania a language identification funkciónak? Szerintem annak ellenére is sikerülni fog, hogy a szöveg két angol szót is tartalmaz."
+		  }
+	  }
+  ]
+}
+----------------------------------
+//NOTCONSOLE
+
+<1> The ID of the {lang-ident} trained model.
+<2> It defines the number of categories for which the predicted probabilities 
+are reported. In this example, 5 classes (in this case, languages) with the 
+highest probability will be reported.
+<3> The source object that contains the text to identify.
+
+
+The request returns the following response:
+
+[source,js]
+----------------------------------
+{
+  "docs" : [
+    {
+      "doc" : {
+        "_index" : "_index",
+        "_type" : "_doc",
+        "_id" : "_id",
+        "_source" : {
+          "text" : "Sziasztok! Ez egy nagyon rövid magyar szöveg. Nézzük, vajon sikerül-e azonosítania a language identification funkciónak? Szerintem annak ellenére is sikerülni fog, hogy a szöveg két angol szót is tartalmaz.",
+          "ml" : {
+            "inference" : {
+              "top_classes" : [ <1>
+                {
+                  "class_name" : "hu",
+                  "class_probability" : 0.9999936063740517,
+                  "class_score" : 0.9999936063740517
+                },
+                {
+                  "class_name" : "lv",
+                  "class_probability" : 2.5020248433413966E-6,
+                  "class_score" : 2.5020248433413966E-6
+                },
+                {
+                  "class_name" : "is",
+                  "class_probability" : 1.0150420723037688E-6,
+                  "class_score" : 1.0150420723037688E-6
+                },
+                {
+                  "class_name" : "ga",
+                  "class_probability" : 6.67935962773335E-7,
+                  "class_score" : 6.67935962773335E-7
+                },
+                {
+                  "class_name" : "tr",
+                  "class_probability" : 5.591166324774555E-7,
+                  "class_score" : 5.591166324774555E-7
+                }
+              ],
+              "predicted_value" : "hu", <2>
+              "model_id" : "lang_ident_model_1"
+            }
+          }
+        },
+        "_ingest" : {
+          "timestamp" : "2020-01-22T14:25:14.644912Z"
+        }
+      }
+    }
+  ]
+}
+----------------------------------
+//NOTCONSOLE
+
+<1> An array of values specifying the probability of the prediction for the most 
+probable languages. The number of reported languages is defined by 
+`num_top_classes`.
+<2> The predicted value is the ISO identifier of the language with the highest 
+probability.

--- a/docs/en/stack/ml/df-analytics/ml-lang-ident.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-lang-ident.asciidoc
@@ -13,7 +13,7 @@ its model ID (`lang_ident_model_1`). The input field name is `text`. If you want
 on a field with a different name, you must map your field name to 
 `text` in the ingest processor settings.
 
-The longer the text passed into the {lang-ident} model, the more accurate the 
+The longer the text passed into the {lang-ident} model, the more accurately the 
 model will be identifying the language. It is fairly accurate on shorter samples 
 (for example, 50 character-long streams) in certain languages, but languages 
 that are similar to each other are harder to identify based on a short 

--- a/docs/en/stack/ml/df-analytics/ml-lang-ident.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-lang-ident.asciidoc
@@ -9,7 +9,7 @@ experimental[]
 {lang-ident-cap} is an {infer} trained model that you can use to determine in 
 which language text is written. You can reference the {lang-ident} 
 model in an {ref}/inference-processor.html[{infer} processor] of an ingest 
-pipeline by using its `model_id`. The input filed name is `text` by default. If 
+pipeline by using its `model_id`. The input field name is `text`. If 
 you want to run {lang-ident} on an field with a different name, then you have to 
 map your field name to `text` in the ingest processor.
 

--- a/docs/en/stack/ml/df-analytics/ml-lang-ident.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-lang-ident.asciidoc
@@ -121,7 +121,7 @@ POST _ingest/pipeline/_simulate
 //NOTCONSOLE
 
 <1> The ID of the {lang-ident} trained model.
-<2> It defines the number of categories for which the predicted probabilities 
+<2> Indicates that only the top five languages (that is to say, the ones with the highest probability) are returned.
 are reported. In this example, 5 classes (in this case, languages) with the 
 highest probability will be reported.
 <3> The source object that contains the text to identify.

--- a/docs/en/stack/ml/df-analytics/ml-lang-ident.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-lang-ident.asciidoc
@@ -15,7 +15,7 @@ map your field name to `text` in the ingest processor settings.
 
 The longer the text passed into the {lang-ident} model, the more accurate the 
 model will be identifying the language. It is fairly accurate on shorter samples 
-(for example, 50 character-long streams) at certain languages, but languages 
+(for example, 50 character-long streams) in certain languages, but languages 
 that are very similar to each other are hard to identify based on a very short 
 character stream.
 

--- a/docs/en/stack/ml/df-analytics/ml-lang-ident.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-lang-ident.asciidoc
@@ -84,7 +84,7 @@ script.
 [[ml-lang-ident-example]]
 ==== Example of {lang-ident}
 
-In the following example, we feed the {lang-ident} trained model with a short 
+In the following example, we feed the {lang-ident} trained model a short 
 Hungarian text that contains diacritics and a couple of English words. Yet, the 
 model identifies the text correctly as Hungarian with high probability.
 

--- a/docs/en/stack/ml/df-analytics/ml-lang-ident.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-lang-ident.asciidoc
@@ -6,7 +6,7 @@ experimental[]
 
 {lang-ident-cap} `model_id`: `lang_ident_model_1`
 
-{lang-ident-cap} is an {infer} trained model that you can use to determine in 
+{lang-ident-cap} is an {infer} trained model (`lang_ident_model_1`) that you can use to determine the language of text.
 which language text is written. You can reference the {lang-ident} model in an 
 {ref}/inference-processor.html[{infer} processor] of an ingest pipeline by using 
 its `model_id`. The input field name is `text`. If you want to run {lang-ident} 

--- a/docs/en/stack/ml/df-analytics/ml-lang-ident.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-lang-ident.asciidoc
@@ -9,7 +9,7 @@ experimental[]
 {lang-ident-cap} is an {infer} trained model (`lang_ident_model_1`) that you can use to determine the language of text.
 which language text is written. You can reference the {lang-ident} model in an 
 {ref}/inference-processor.html[{infer} processor] of an ingest pipeline by using 
-its `model_id`. The input field name is `text`. If you want to run {lang-ident} 
+its model ID (`lang_ident_model_1`). The input field name is `text`. If you want to run {lang-ident} 
 on an field with a different name, then you have to map your field name to 
 `text` in the ingest processor settings.
 

--- a/docs/en/stack/ml/df-analytics/ml-lang-ident.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-lang-ident.asciidoc
@@ -184,7 +184,7 @@ The request returns the following response:
 ----------------------------------
 //NOTCONSOLE
 
-<1> An array of values specifying the probability of the prediction for the most 
+<1> Contains probability scores for the top (most probable) inferred languages.
 probable languages. The number of reported languages is defined by 
 `num_top_classes`.
 <2> The predicted value is the ISO identifier of the language with the highest 


### PR DESCRIPTION
This PR adds language identification conceptual documentation to the machine learning data frame analytics chapter.

**Do not merge this PR before https://github.com/elastic/docs/pull/1706 is merged.**

Related issue: https://github.com/elastic/ml-team/issues/279

Preview: http://stack-docs_816.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-lang-ident.html