### PR TITLE
[DOCS] Adds one-liner description of classification to the overview page

### DIFF
--- a/docs/en/stack/ml/df-analytics/ml-dfa-overview.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-overview.asciidoc
@@ -7,7 +7,8 @@ annotate it with the results. By doing this, it provides additional insights
 into the data. <<dfa-outlier-detection,{oldetection-cap}>> identifies unusual 
 data points in the dataset. <<dfa-regression,{regression-cap}>> makes 
 predictions on your data after it determines certain relationships among your 
-data points.
+data points. <<dfa-classification,{classification-cap}>> predicts the class or 
+category of a given data point in a dataset.
 
 The process leaves the source index intact, it creates a new index that contains 
 a copy of the source data and the annotated data. You can slice and dice the 


### PR DESCRIPTION
This PR adds a one-sentence description of classification to the Overview section.