### PR TITLE
[DOCS] Adds machine learning setup page

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/architecture.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/architecture.asciidoc
@@ -1,8 +1,0 @@
-[role="xpack"]
-[[ml-nodes]]
-=== Machine learning nodes
-
-A {ml} node is a node that has `xpack.ml.enabled` and `node.ml` set to `true`, which is the default behavior. If you set `node.ml` to `false`, the node can
-service API requests but it cannot run jobs. If you want to use {ml-features},
-there must be at least one {ml} node in your cluster. For more
-information, see {ref}/modules-node.html#ml-node[Machine learning node].

--- a/docs/en/stack/ml/anomaly-detection/ml-concepts.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-concepts.asciidoc
@@ -12,7 +12,6 @@ This section explains the fundamental concepts of the Elastic {ml}
 * <<ml-calendars>>
 * <<ml-rules>>
 * <<ml-model-snapshots>>
-* <<ml-nodes>>
 
 include::jobs.asciidoc[]
 
@@ -25,7 +24,5 @@ include::influencers.asciidoc[]
 include::calendars.asciidoc[]
 
 include::rules.asciidoc[]
-
-include::architecture.asciidoc[]
 
 include::model-snapshots.asciidoc[]

--- a/docs/en/stack/ml/index.asciidoc
+++ b/docs/en/stack/ml/index.asciidoc
@@ -9,6 +9,8 @@
 include::{asciidoc-dir}/../../shared/versions/stack/{source_branch}.asciidoc[]
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
+include::setup.asciidoc[]
+
 include::anomaly-detection/index.asciidoc[]
 
 include::df-analytics/index.asciidoc[]

--- a/docs/en/stack/ml/setup.asciidoc
+++ b/docs/en/stack/ml/setup.asciidoc
@@ -5,10 +5,10 @@
 <titleabbrev>Setup</titleabbrev>
 ++++
 
-To use the {ml-features}, you must have the {subscriptions}[appropriate license]
-and at least one <<ml-nodes,{ml} node>> in your {es} cluster. If {es}
-{security-features} are enabled, you must also ensure your users have the
-<<setup-privileges,necessary privileges>>.
+To use the {stack} {ml-features}, you must have the
+{subscriptions}[appropriate license] and at least one <<ml-nodes,{ml} node>> in
+your {es} cluster. If {stack} {security-features} are enabled, you must also
+ensure your users have the <<setup-privileges,necessary privileges>>.
 
 TIP: The fastest way to get started with {ml-features} is to
 https://www.elastic.co/cloud/elasticsearch-service/signup[start a free 14-day
@@ -18,9 +18,9 @@ trial of {ess}] in the cloud.
 [[ml-nodes]]
 === Machine learning nodes
 
-If you want to use {ml-features}, there must be at least one {ml} node in your
-cluster. A {ml} node is a node that has `xpack.ml.enabled` and `node.ml` set to
-`true`, which is the default behavior.
+To use {ml-features}, there must be at least one {ml} node in your cluster. A
+{ml} node is a node that has `xpack.ml.enabled` and `node.ml` set to `true`,
+which is the default behavior.
 
 You can limit which nodes run resource-intensive activity related to {ml} jobs
 by setting `node.ml` to `false` on some nodes. In that case, they can service

--- a/docs/en/stack/ml/setup.asciidoc
+++ b/docs/en/stack/ml/setup.asciidoc
@@ -1,0 +1,46 @@
+[role="xpack"]
+[[setup]]
+== Set up {ml-features}
+++++
+<titleabbrev>Setup</titleabbrev>
+++++
+
+To use the {ml-features}, you must have the {subscriptions}[appropriate license]
+and at least one <<ml-nodes,{ml} node>> in your {es} cluster. If {es}
+{security-features} are enabled, you must also ensure your users have the
+<<setup-privileges,necessary privileges>>.
+
+TIP: The fastest way to get started with {ml-features} is to
+https://www.elastic.co/cloud/elasticsearch-service/signup[start a free 14-day
+trial of {ess}] in the cloud.
+
+[discrete]
+[[ml-nodes]]
+=== Machine learning nodes
+
+If you want to use {ml-features}, there must be at least one {ml} node in your
+cluster. A {ml} node is a node that has `xpack.ml.enabled` and `node.ml` set to
+`true`, which is the default behavior.
+
+You can limit which nodes run resource-intensive activity related to {ml} jobs
+by setting `node.ml` to `false` on some nodes. In that case, they can service
+API requests but cannot run {ml} jobs. For more information, see
+{ref}/modules-node.html#ml-node[Machine learning nodes].
+
+[discrete]
+[[setup-privileges]]
+=== Security privileges
+
+The {es} {security-features} provide `machine_learning_admin` and
+`machine_learning_user` {ref}/built-in-roles.html[built-in roles] and
+`manage_ml` and `monitor_ml` {ref}/security-privileges.html[cluster privileges].
+These roles and privileges make it easier to control which users can manage or
+view {ml} objects such as jobs, {dfeeds}, results, and model snapshots.
+
+Some actions might require additional authority. For example, if you are viewing
+the results of {anomaly-jobs}, you must also have `read` index privileges on the
+index that stores the results. If you are creating {dfanalytics-jobs}, you must
+have specific privileges with respect to the source and destination indices.
+For more information, see the prerequisites for each
+{ref}/ml-apis.html[{anomaly-detect} API] and
+{ref}/ml-df-analytics-apis.html[{dfanalytics} API].

--- a/docs/en/stack/redirects.asciidoc
+++ b/docs/en/stack/redirects.asciidoc
@@ -68,7 +68,7 @@ See {ml-docs}/ml-rules.html[Custom rules].
 === Machine learning nodes
 
 This page has moved.
-See {ml-docs}/ml-nodes.html[{ml-cap} nodes].
+See {ml-docs}/setup.html#ml-nodes[{ml-cap} nodes].
 
 [role="exclude",id="ml-model-snapshots"]
 === Model snapshots


### PR DESCRIPTION
This PR creates a new page in the Machine Learning book for setup instructions.

This information was previously included in the getting started tutorial (https://github.com/elastic/stack-docs/pull/225) but it seems like a good idea to separate it out. There was also a "Machine learning nodes" page nested under the Anomaly Detection concepts, but this change makes it redundant.

The subsection about security privileges can be expanded in subsequent PRs depending on the level of detail required.

Preview: http://stack-docs_818.docs-preview.app.elstc.co/guide/en/machine-learning/master/setup.html