### PR TITLE
[DOCS] Augments list of machine learning privileges

### DIFF
--- a/docs/en/stack/ml/setup.asciidoc
+++ b/docs/en/stack/ml/setup.asciidoc
@@ -35,22 +35,22 @@ The {es} {security-features} provide built-in roles and privileges that make it
 easier to control which users can manage or view {ml} objects such as jobs,
 {dfeeds}, results, and model snapshots. 
 
-To have view the configuration, status, and results of the {ml-features}, you
+To _view_ the configuration, status, and results of the {ml-features}, you
 must have:
 
 [%interactive]
-* [ ] `machine_learning_user` {ref}/built-in-roles.html[built-in role]
+* [ ] `machine_learning_user` or `machine_learning_admin`
+{ref}/built-in-roles.html[built-in roles]
 * [ ] `read` and `view_index_metadata`
 {ref}/security-privileges.html#privileges-list-indices[index privileges] on the
 indices that contain the source data
 * [ ] `read` index privileges on the destination indices
 (for {dfanalytics-jobs} only)
 
-To manage {ml-features}, you must have:
+To _manage_ {ml-features}, you must have:
 
 [%interactive]
-* [ ] `machine_learning_admin` or `machine_learning_user`
-{ref}/built-in-roles.html[built-in roles]
+* [ ] `machine_learning_admin` {ref}/built-in-roles.html[built-in role]
 * [ ] `read` and `view_index_metadata` index privileges on the indices that
 contain the source data
 * [ ] `read`, `manage`, and `index` index privileges on the destination indices

--- a/docs/en/stack/ml/setup.asciidoc
+++ b/docs/en/stack/ml/setup.asciidoc
@@ -31,30 +31,27 @@ API requests but cannot run {ml} jobs. For more information, see
 [[setup-privileges]]
 === Security privileges
 
-The {es} {security-features} provide built-in roles and privileges that make it
-easier to control which users can manage or view {ml} objects such as jobs,
-{dfeeds}, results, and model snapshots. 
+The {es} {security-features} provide {ref}/built-in-roles.html[built-in roles]
+and {ref}/security-privileges.html[privileges] that make it easier to control
+which users can manage or view {ml} objects such as jobs, {dfeeds}, results, and
+model snapshots. 
 
 To _view_ the configuration, status, and results of the {ml-features}, you
 must have:
 
 [%interactive]
-* [ ] `machine_learning_user` or `machine_learning_admin`
-{ref}/built-in-roles.html[built-in roles]
-* [ ] `read` and `view_index_metadata`
-{ref}/security-privileges.html#privileges-list-indices[index privileges] on the
-indices that contain the source data
-* [ ] `read` index privileges on the destination indices
-(for {dfanalytics-jobs} only)
+* [ ] `machine_learning_user` or `machine_learning_admin` built-in roles
+* [ ] `read` and `view_index_metadata` index privileges on source indices
+* [ ] `read` index privileges on destination indices (for {dfanalytics-jobs}
+  only)
 
 To _manage_ {ml-features}, you must have:
 
 [%interactive]
-* [ ] `machine_learning_admin` {ref}/built-in-roles.html[built-in role]
-* [ ] `read` and `view_index_metadata` index privileges on the indices that
-contain the source data
-* [ ] `read`, `manage`, and `index` index privileges on the destination indices
-(for {dfanalytics-jobs} only)
+* [ ] `machine_learning_admin` built-in role
+* [ ] `read` and `view_index_metadata` index privileges on source indices
+* [ ] `read`, `manage`, and `index` index privileges on destination indices (for
+  {dfanalytics-jobs} only)
 
 If you use {ml-features} in {kib}, you must also have:
 
@@ -64,5 +61,45 @@ If you use {ml-features} in {kib}, you must also have:
 * [ ] `monitor` and `manage_ingest_pipelines` cluster privileges and `read`,
 `manage`, and `index` index privileges for the destination index when you upload
 files to the *Data Visualizer*
-* [ ] `monitor` cluster privilege and `monitor` index privilege for the
-destination index when you use the *{dfanalytics-cap}* tab
+* [ ] `monitor` cluster privilege to manage {dfanalytics-jobs}
+
+[discrete]
+==== Alternative layout
+
+If {stack} {security-features} are enabled, the following roles and privileges
+are required to use {ml-features}:
+
+|===
+2+| Required roles or privileges | Description
+
+.2+| Built-in role | `machine_learning_admin` | Required to manage {ml-features}
+
+| `machine_learning_user` | Minimal authority necessary to view {ml}
+configuration, status, and results.
+
+.3+| Index privileges | `read` and `view_index_metadata` | Required on source
+indices to manage {dfanalytics-jobs}
+
+| `read`, `manage`, and `index` | Required on destination indices to manage
+{dfanalytics-jobs} 
+
+| `read` | Required on destination indices to view the results of
+{dfanalytics-jobs} 
+
+|===
+
+There are additional authorization requirements when you use {ml-features} in
+{kib}:
+
+|===
+2+| Required roles or privileges | Description
+
+.2+| Cluster privileges | `monitor` and `manage_ingest_pipelines` | Required to
+upload files to the *Data Visualizer*
+
+| `monitor` | Required to manage {dfanalytics-jobs}
+
+| Index privileges | `read`, `manage`, and `index` | Required on
+destination indices to upload files to the *Data Visualizer*
+
+|===

--- a/docs/en/stack/ml/setup.asciidoc
+++ b/docs/en/stack/ml/setup.asciidoc
@@ -71,21 +71,21 @@ If {stack} {security-features} are enabled, the following roles and privileges
 are required to use {ml-features}:
 
 |===
-2+| Required roles or privileges | Description
+| Required roles or privileges | Description
 
-.2+| Built-in role | `machine_learning_admin` | Required to manage {ml-features}
+| `machine_learning_admin` built-in role | Required to manage {ml-features}
 
-| `machine_learning_user` | Minimal authority necessary to view {ml}
-configuration, status, and results.
+| `machine_learning_user` built-in role | Minimal authority necessary to view
+{ml} configuration, status, and results.
 
-.3+| Index privileges | `read` and `view_index_metadata` | Required on source
+| `read` and `view_index_metadata` index privileges | Required on source
 indices to manage {dfanalytics-jobs}
 
-| `read`, `manage`, and `index` | Required on destination indices to manage
-{dfanalytics-jobs} 
+| `read`, `manage`, and `index` index privileges | Required on destination
+indices to manage {dfanalytics-jobs} 
 
-| `read` | Required on destination indices to view the results of
-{dfanalytics-jobs} 
+| `read` index privilege | Required on destination indices to view the results
+of {dfanalytics-jobs} 
 
 |===
 
@@ -93,14 +93,18 @@ There are additional authorization requirements when you use {ml-features} in
 {kib}:
 
 |===
-2+| Required roles or privileges | Description
+| Required roles or privileges | Description
 
-.2+| Cluster privileges | `monitor` and `manage_ingest_pipelines` | Required to
+| `kibana_admin` built-in role | Required to use {ml-features} in {kib}.
+Alternatively, use a custom role that
+{kibana-ref}/xpack-security-authorization.html[grants access to {kib}]
+
+| `monitor` and `manage_ingest_pipelines` cluster privileges | Required to
 upload files to the *Data Visualizer*
 
-| `monitor` | Required to manage {dfanalytics-jobs}
+| `monitor` cluster privileges | Required to manage {dfanalytics-jobs}
 
-| Index privileges | `read`, `manage`, and `index` | Required on
+| `read`, `manage`, and `index` index privileges | Required on
 destination indices to upload files to the *Data Visualizer*
 
 |===

--- a/docs/en/stack/ml/setup.asciidoc
+++ b/docs/en/stack/ml/setup.asciidoc
@@ -59,52 +59,16 @@ If you use {ml-features} in {kib}, you must also have:
 * [ ] `kibana_admin` built-in role or a custom role that
 {kibana-ref}/xpack-security-authorization.html[grants access to {kib}]
 * [ ] `monitor` cluster privilege to manage {dfanalytics-jobs}
-* [ ] `monitor` and `manage_ingest_pipelines` cluster privileges when you upload
-files in the *Data Visualizer*
+
+If you use job wizard in {kib} to create categorization {anomaly-jobs}, you must
+also have:
+
+[%interactive]
+* [ ] `manage` cluster privileges
+
+If you use the *Data Visualizer* to upload files in {kib}, you must also have:
+
+[%interactive]
+* [ ] `monitor` and `manage_ingest_pipelines` cluster privileges
 * [ ] `read`, `manage`, and `index` index privileges for the destination index
-when you upload files in the *Data Visualizer*
 
-[discrete]
-==== Alternative layout
-
-If {stack} {security-features} are enabled, the following roles and privileges
-are required to use {ml-features}:
-
-|===
-| Required roles or privileges | Description
-
-| `machine_learning_admin` built-in role | Required to manage {ml-features}
-
-| `machine_learning_user` built-in role | Minimal authority necessary to view
-{ml} configuration, status, and results.
-
-| `read` and `view_index_metadata` index privileges | Required on source
-indices to manage {dfanalytics-jobs}
-
-| `read`, `manage`, and `index` index privileges | Required on destination
-indices to manage {dfanalytics-jobs} 
-
-| `read` index privilege | Required on destination indices to view the results
-of {dfanalytics-jobs} 
-
-|===
-
-There are additional authorization requirements when you use {ml-features} in
-{kib}:
-
-|===
-| Required roles or privileges | Description
-
-| `kibana_admin` built-in role | Required to use {ml-features} in {kib}.
-Alternatively, use a custom role that
-{kibana-ref}/xpack-security-authorization.html[grants access to {kib}]
-
-| `monitor` and `manage_ingest_pipelines` cluster privileges | Required to
-upload files to the *Data Visualizer*
-
-| `monitor` cluster privileges | Required to manage {dfanalytics-jobs}
-
-| `read`, `manage`, and `index` index privileges | Required on
-destination indices to upload files to the *Data Visualizer*
-
-|===

--- a/docs/en/stack/ml/setup.asciidoc
+++ b/docs/en/stack/ml/setup.asciidoc
@@ -56,12 +56,13 @@ To _manage_ {ml-features}, you must have:
 If you use {ml-features} in {kib}, you must also have:
 
 [%interactive]
-* [ ] `kibana_user` built-in role or a custom role that
+* [ ] `kibana_admin` built-in role or a custom role that
 {kibana-ref}/xpack-security-authorization.html[grants access to {kib}]
-* [ ] `monitor` and `manage_ingest_pipelines` cluster privileges and `read`,
-`manage`, and `index` index privileges for the destination index when you upload
-files to the *Data Visualizer*
 * [ ] `monitor` cluster privilege to manage {dfanalytics-jobs}
+* [ ] `monitor` and `manage_ingest_pipelines` cluster privileges when you upload
+files in the *Data Visualizer*
+* [ ] `read`, `manage`, and `index` index privileges for the destination index
+when you upload files in the *Data Visualizer*
 
 [discrete]
 ==== Alternative layout

--- a/docs/en/stack/ml/setup.asciidoc
+++ b/docs/en/stack/ml/setup.asciidoc
@@ -38,28 +38,31 @@ easier to control which users can manage or view {ml} objects such as jobs,
 To have view the configuration, status, and results of the {ml-features}, you
 must have:
 
-* `machine_learning_user` {ref}/built-in-roles.html[built-in role]
-* `read` and `view_index_metadata`
+[%interactive]
+* [ ] `machine_learning_user` {ref}/built-in-roles.html[built-in role]
+* [ ] `read` and `view_index_metadata`
 {ref}/security-privileges.html#privileges-list-indices[index privileges] on the
 indices that contain the source data
-* `read` index privileges on the destination indices
+* [ ] `read` index privileges on the destination indices
 (for {dfanalytics-jobs} only)
 
 To manage {ml-features}, you must have:
 
-* `machine_learning_admin` or `machine_learning_user`
+[%interactive]
+* [ ] `machine_learning_admin` or `machine_learning_user`
 {ref}/built-in-roles.html[built-in roles]
-* `read` and `view_index_metadata` index privileges on the indices that
+* [ ] `read` and `view_index_metadata` index privileges on the indices that
 contain the source data
-* `read`, `manage`, and `index` index privileges on the destination indices
+* [ ] `read`, `manage`, and `index` index privileges on the destination indices
 (for {dfanalytics-jobs} only)
 
 If you use {ml-features} in {kib}, you must also have:
 
-* `kibana_user` built-in role or a custom role that
+[%interactive]
+* [ ] `kibana_user` built-in role or a custom role that
 {kibana-ref}/xpack-security-authorization.html[grants access to {kib}]
-* `monitor` and `manage_ingest_pipelines` cluster privileges and `read`,
+* [ ] `monitor` and `manage_ingest_pipelines` cluster privileges and `read`,
 `manage`, and `index` index privileges for the destination index when you upload
 files to the *Data Visualizer*
-* `monitor` cluster privilege and `monitor` index privilege for the
+* [ ] `monitor` cluster privilege and `monitor` index privilege for the
 destination index when you use the *{dfanalytics-cap}* tab

--- a/docs/en/stack/ml/setup.asciidoc
+++ b/docs/en/stack/ml/setup.asciidoc
@@ -60,7 +60,7 @@ If you use {ml-features} in {kib}, you must also have:
 {kibana-ref}/xpack-security-authorization.html[grants access to {kib}]
 * [ ] `monitor` cluster privilege to manage {dfanalytics-jobs}
 
-If you use job wizard in {kib} to create categorization {anomaly-jobs}, you must
+If you use {kib} to create categorization {anomaly-jobs}, you must
 also have:
 
 [%interactive]
@@ -71,4 +71,3 @@ If you use the *Data Visualizer* to upload files in {kib}, you must also have:
 [%interactive]
 * [ ] `monitor` and `manage_ingest_pipelines` cluster privileges
 * [ ] `read`, `manage`, and `index` index privileges for the destination index
-

--- a/docs/en/stack/ml/setup.asciidoc
+++ b/docs/en/stack/ml/setup.asciidoc
@@ -31,16 +31,35 @@ API requests but cannot run {ml} jobs. For more information, see
 [[setup-privileges]]
 === Security privileges
 
-The {es} {security-features} provide `machine_learning_admin` and
-`machine_learning_user` {ref}/built-in-roles.html[built-in roles] and
-`manage_ml` and `monitor_ml` {ref}/security-privileges.html[cluster privileges].
-These roles and privileges make it easier to control which users can manage or
-view {ml} objects such as jobs, {dfeeds}, results, and model snapshots.
+The {es} {security-features} provide built-in roles and privileges that make it
+easier to control which users can manage or view {ml} objects such as jobs,
+{dfeeds}, results, and model snapshots. 
 
-Some actions might require additional authority. For example, if you are viewing
-the results of {anomaly-jobs}, you must also have `read` index privileges on the
-index that stores the results. If you are creating {dfanalytics-jobs}, you must
-have specific privileges with respect to the source and destination indices.
-For more information, see the prerequisites for each
-{ref}/ml-apis.html[{anomaly-detect} API] and
-{ref}/ml-df-analytics-apis.html[{dfanalytics} API].
+To have view the configuration, status, and results of the {ml-features}, you
+must have:
+
+* `machine_learning_user` {ref}/built-in-roles.html[built-in role]
+* `read` and `view_index_metadata`
+{ref}/security-privileges.html#privileges-list-indices[index privileges] on the
+indices that contain the source data
+* `read` index privileges on the destination indices
+(for {dfanalytics-jobs} only)
+
+To manage {ml-features}, you must have:
+
+* `machine_learning_admin` or `machine_learning_user`
+{ref}/built-in-roles.html[built-in roles]
+* `read` and `view_index_metadata` index privileges on the indices that
+contain the source data
+* `read`, `manage`, and `index` index privileges on the destination indices
+(for {dfanalytics-jobs} only)
+
+If you use {ml-features} in {kib}, you must also have:
+
+* `kibana_user` built-in role or a custom role that
+{kibana-ref}/xpack-security-authorization.html[grants access to {kib}]
+* `monitor` and `manage_ingest_pipelines` cluster privileges and `read`,
+`manage`, and `index` index privileges for the destination index when you upload
+files to the *Data Visualizer*
+* `monitor` cluster privilege and `monitor` index privilege for the
+destination index when you use the *{dfanalytics-cap}* tab


### PR DESCRIPTION
This PR clarifies the list of security privileges that are required to use the machine learning features.

It currently contains the information in two formats (checklist and table) to get feedback on which is easiest to follow.

Preview: http://stack-docs_824.docs-preview.app.elstc.co/guide/en/machine-learning/master/setup.html#setup-privileges