### PR TITLE
[DOCS] Adds one liner about inference to the DFA overview page

### DIFF
--- a/docs/en/stack/ml/df-analytics/ml-dfa-overview.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-overview.asciidoc
@@ -8,7 +8,9 @@ into the data. <<dfa-outlier-detection,{oldetection-cap}>> identifies unusual
 data points in the dataset. <<dfa-regression,{regression-cap}>> makes 
 predictions on your data after it determines certain relationships among your 
 data points. <<dfa-classification,{classification-cap}>> predicts the class or 
-category of a given data point in a dataset.
+category of a given data point in a dataset. <<ml-inference,{infer-cap}>> 
+enables you to use trained {ml} models against incoming data in a continuous 
+fashion.
 
 The process leaves the source index intact, it creates a new index that contains 
 a copy of the source data and the annotated data. You can slice and dice the 


### PR DESCRIPTION
This PR adds a one-sentence long description of inference to the data frame analytics overview page.

Preview: http://stack-docs_829.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-dfa-overview.html