### PR TITLE
[DOCS] Adds a paragraph about language identification to the inference conceptual docs

### DIFF
--- a/docs/en/stack/ml/df-analytics/ml-inference.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-inference.asciidoc
@@ -45,3 +45,11 @@ data together with the results are indexed into the destination index.
 Check the {ref}/inference-processor.html[{infer} processor] and 
 {ref}/ml-df-analytics-apis.html[the {ml} {dfanalytics} API documentation] to 
 learn more about the feature.
+
+
+[discrete]
+==== {lang-ident-cap} pre-trained model
+
+You can use {infer} to determine a language of text by using a pre-trained 
+{lang-ident} model. {lang-ident-cap} supports 109 languages. For more 
+information and configuration details, check the <<ml-lang-ident>> page.

--- a/docs/en/stack/ml/df-analytics/ml-inference.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-inference.asciidoc
@@ -30,6 +30,10 @@ data points that the model has never seen. The models that are created by
 the characteristics of your trained models are saved and ready to be used as 
 functions.
 
+Alternatively, you can use a pre-trained language identification model  to 
+determine a language of text. {lang-ident-cap} supports 109 languages. For more 
+information and configuration details, check the <<ml-lang-ident>> page.
+
 
 [discrete]
 ==== {infer-cap} processor
@@ -45,11 +49,3 @@ data together with the results are indexed into the destination index.
 Check the {ref}/inference-processor.html[{infer} processor] and 
 {ref}/ml-df-analytics-apis.html[the {ml} {dfanalytics} API documentation] to 
 learn more about the feature.
-
-
-[discrete]
-==== {lang-ident-cap} pre-trained model
-
-You can use {infer} to determine a language of text by using a pre-trained 
-{lang-ident} model. {lang-ident-cap} supports 109 languages. For more 
-information and configuration details, check the <<ml-lang-ident>> page.


### PR DESCRIPTION
This PR adds a short description of language identification with a link to the inference conceptual docs.

Preview: http://stack-docs_830.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-inference.html