### PR TITLE
[DOCS] Moves forecast limitations out of overview

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/forecasting.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/forecasting.asciidoc
@@ -31,34 +31,10 @@ the forecast extends beyond the last record that was processed. By default, the
 duration is 1 day. Typically the farther into the future that you forecast, the
 lower the confidence levels become (that is to say, the bounds increase).
 Eventually if the confidence levels are too low, the forecast stops.
+For more information about limitations that affect your ability to create a
+forecast, see <<ml-forecast-limitations>>.
 
 You can also optionally specify when the forecast expires. By default, it
 expires in 14 days and is deleted automatically thereafter. You can specify a
 different expiration period by using the `expires_in` parameter in the
 {ref}/ml-forecast.html[forecast {anomaly-jobs} API].
-
-There are some limitations that affect your ability to create a forecast:
-
-* You can generate only three forecasts concurrently. There is no limit to the
-number of forecasts that you retain. Existing forecasts are not overwritten when
-you create new forecasts. Rather, they are automatically deleted when they expire.
-* If you use an `over_field_name` property in your {anomaly-job} (that is to say,
-it's a _population job_), you cannot create a forecast.
-* If you use any of the following analytical functions in your {anomaly-job},
-you cannot create a forecast:
-** `lat_long`
-** `rare` and `freq_rare`
-** `time_of_day` and `time_of_week`
-+
---
-For more information about any of these functions, see <<ml-functions>>.
---
-* Forecasts run concurrently with real-time {ml} analysis. That is to say, {ml}
-analysis does not stop while forecasts are generated. Forecasts can have an
-impact on {anomaly-jobs}, however, especially in terms of memory usage. For this
-reason, forecasts run only if the model memory status is acceptable.
-* The {anomaly-job} must be open when you create a forecast. Otherwise, an error
-occurs.
-* If there is insufficient data to generate any meaningful predictions, an
-error occurs. In general, forecasts that are created early in the learning phase
-of the data analysis are less accurate.

--- a/docs/en/stack/ml/anomaly-detection/limitations.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/limitations.asciidoc
@@ -170,27 +170,6 @@ permissions that were associated with the original roles. For more information,
 see <<ml-dfeeds>>.
 
 [float]
-=== Forecasts cannot be created for population jobs
-
-If you use an `over_field_name` property in your job (that is to say, it's a
-_population job_), you cannot create a forecast. If you try to create a forecast
-for this type of job, an error occurs. For more information about forecasts,
-see <<ml-forecasting>>.
-
-[float]
-=== Forecasts cannot be created for jobs that use geographic, rare, or time functions
-
-If you use any of the following analytical functions in your job, you cannot
-create a forecast:
-
-* `lat_long`
-* `rare` and `freq_rare`
-* `time_of_day` and `time_of_week`
-
-If you try to create a forecast for this type of job, an error occurs. For more
-information about any of these functions, see <<ml-functions>>.
-
-[float]
 === Jobs must be stopped before upgrades
 
 You must stop any {ml} jobs that are running before you start the upgrade
@@ -255,3 +234,33 @@ When you create an {anomaly-job}, you cannot use a field with the
 {ref}/date_nanos.html[`date_nanos` data type] as the `time_field` in the
 `data_description` object. This limitation applies irrespective of whether you
 create jobs in {kib} or by using APIs.
+
+[discrete]
+[[ml-forecast-limitations]]
+=== Forecast limitations
+
+There are some limitations that affect your ability to create a forecast:
+
+* You can generate only three forecasts concurrently. There is no limit to the
+number of forecasts that you retain. Existing forecasts are not overwritten when
+you create new forecasts. Rather, they are automatically deleted when they expire.
+* If you use an `over_field_name` property in your {anomaly-job} (that is to say,
+it's a _population job_), you cannot create a forecast.
+* If you use any of the following analytical functions in your {anomaly-job},
+you cannot create a forecast:
+** `lat_long`
+** `rare` and `freq_rare`
+** `time_of_day` and `time_of_week`
++
+--
+For more information about any of these functions, see <<ml-functions>>.
+--
+* Forecasts run concurrently with real-time {ml} analysis. That is to say, {ml}
+analysis does not stop while forecasts are generated. Forecasts can have an
+impact on {anomaly-jobs}, however, especially in terms of memory usage. For this
+reason, forecasts run only if the model memory status is acceptable.
+* The {anomaly-job} must be open when you create a forecast. Otherwise, an error
+occurs.
+* If there is insufficient data to generate any meaningful predictions, an
+error occurs. In general, forecasts that are created early in the learning phase
+of the data analysis are less accurate.


### PR DESCRIPTION
There is a list of forecast limitations in the anomaly detection overview (https://www.elastic.co/guide/en/machine-learning/master/ml-overview.html), which are partially duplicated in the anomaly detection limitations (e.g. https://www.elastic.co/guide/en/machine-learning/master/ml-limitations.html#_forecasts_cannot_be_created_for_population_jobs).

This PR moves the full list of forecast-related limitations into the Limitations page and links to it from the overview.