### PR TITLE
[DOCS] Fixes Elasticsearch release highlights and breaking changes

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -39,7 +39,7 @@ For the complete list, go to {apm-server-ref-70}/breaking-changes.html[APM Serve
 <titleabbrev>Beats</titleabbrev>
 ++++
 
-coming[7.6.0]
+coming:[7.6.0]
 
 This list summarizes the most important breaking changes in Beats. For the
 complete list, go to {beats-ref}/breaking-changes.html[Beats breaking changes].
@@ -54,10 +54,12 @@ complete list, go to {beats-ref}/breaking-changes.html[Beats breaking changes].
 <titleabbrev>{es}</titleabbrev>
 ++++
 
+coming:[7.6.0]
+
 This list summarizes the most important breaking changes in {es} {version}. For
 the complete list, go to {ref}/breaking-changes.html[{es} breaking changes].
 
-include::{es-repo-dir}/reference/migration/migrate_7_4.asciidoc[tag=notable-breaking-changes]
+include::{es-repo-dir}/reference/migration/migrate_7_6.asciidoc[tag=notable-breaking-changes]
 
 [[elasticsearch-hadoop-breaking-changes]]
 === {es} Hadoop breaking changes

--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -39,7 +39,7 @@ For the complete list, go to {apm-server-ref-70}/breaking-changes.html[APM Serve
 <titleabbrev>Beats</titleabbrev>
 ++++
 
-coming:[7.6.0]
+coming::[7.6.0]
 
 This list summarizes the most important breaking changes in Beats. For the
 complete list, go to {beats-ref}/breaking-changes.html[Beats breaking changes].
@@ -54,7 +54,7 @@ complete list, go to {beats-ref}/breaking-changes.html[Beats breaking changes].
 <titleabbrev>{es}</titleabbrev>
 ++++
 
-coming:[7.6.0]
+coming::[7.6.0]
 
 This list summarizes the most important breaking changes in {es} {version}. For
 the complete list, go to {ref}/breaking-changes.html[{es} breaking changes].
@@ -83,6 +83,8 @@ include::{hadoop-repo-dir}/appendix/breaking.adoc[tag=notable-v7-breaking-change
 
 This list summarizes the most important breaking changes in {kib} {version}. For
 the complete list, go to {kibana-ref}/breaking-changes.html[{kib} breaking changes].
+
+coming::[7.6.0]
 
 //include::{kib-repo-dir}/migration/migrate_7_2.asciidoc[tag=notable-breaking-changes]
 

--- a/docs/en/install-upgrade/highlights.asciidoc
+++ b/docs/en/install-upgrade/highlights.asciidoc
@@ -29,7 +29,7 @@ include::{apm-repo-dir}/apm-release-notes.asciidoc[tag=notable-v7-highlights]
 <titleabbrev>Beats</titleabbrev>
 ++++
 
-coming:[7.6.0]
+coming::[7.6.0]
 
 This list summarizes the most important enhancements in Beats.
 For the complete list, go to {beats-ref}/release-highlights.html[Beats release highlights].
@@ -43,7 +43,7 @@ For the complete list, go to {beats-ref}/release-highlights.html[Beats release h
 <titleabbrev>{es}</titleabbrev>
 ++++
 
-coming:[7.6.0]
+coming::[7.6.0]
 
 This list summarizes the most important enhancements in {es} {version}.
 For the complete list, go to {ref}/release-highlights.html[{es} release highlights].
@@ -63,10 +63,11 @@ include::{es-repo-dir}/reference/release-notes/highlights-7.6.0.asciidoc[tag=not
 
 This list summarizes the most important enhancements in {kib} {version}.
 
+coming::[7.6.0]
 ////
 :leveloffset: +1
 
-include::{kib-repo-dir}/release-notes/highlights-7.3.0.asciidoc[tag=notable-highlights]
+include::{kib-repo-dir}/release-notes/highlights-7.6.0.asciidoc[tag=notable-highlights]
 
 :leveloffset: -1
 ////

--- a/docs/en/install-upgrade/highlights.asciidoc
+++ b/docs/en/install-upgrade/highlights.asciidoc
@@ -29,7 +29,7 @@ include::{apm-repo-dir}/apm-release-notes.asciidoc[tag=notable-v7-highlights]
 <titleabbrev>Beats</titleabbrev>
 ++++
 
-coming[7.6.0]
+coming:[7.6.0]
 
 This list summarizes the most important enhancements in Beats.
 For the complete list, go to {beats-ref}/release-highlights.html[Beats release highlights].
@@ -43,16 +43,16 @@ For the complete list, go to {beats-ref}/release-highlights.html[Beats release h
 <titleabbrev>{es}</titleabbrev>
 ++++
 
+coming:[7.6.0]
+
 This list summarizes the most important enhancements in {es} {version}.
 For the complete list, go to {ref}/release-highlights.html[{es} release highlights].
 
-////
 :leveloffset: +1
 
-include::{es-repo-dir}/reference/release-notes/highlights-7.3.0.asciidoc[tag=notable-highlights]
+include::{es-repo-dir}/reference/release-notes/highlights-7.6.0.asciidoc[tag=notable-highlights]
 
 :leveloffset: -1
-////
 
 [[kibana-higlights]]
 === {kib} highlights


### PR DESCRIPTION
This PR fixes the files that are pulled into the Installation and Upgrade Guide for the Elasticsearch release highlights and breaking changes.

Preview: http://stack-docs_834.docs-preview.app.elstc.co/guide/en/elastic-stack/7.6/elasticsearch-highlights.html