### PR TITLE
[DOCS] Fixes trained model terminology

### DIFF
--- a/docs/en/stack/ml/df-analytics/ml-inference.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-inference.asciidoc
@@ -21,6 +21,7 @@ Let's take a closer look at the machinery behind {infer}.
 
 
 [discrete]
+[[ml-inference-models]]
 ==== Trained {ml} models as functions
 
 When you create a {dfanalytics-job} that executes a supervised process, you need 
@@ -36,6 +37,7 @@ more information and configuration details, check the <<ml-lang-ident>> page.
 
 
 [discrete]
+[[ml-inference-processor]]
 ==== {infer-cap} processor
 
 {infer-cap} is a processor specified in an {ref}/pipeline.html[ingest pipeline]. 

--- a/docs/en/stack/ml/df-analytics/ml-lang-ident.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-lang-ident.asciidoc
@@ -4,9 +4,9 @@
 
 experimental[]
 
-{lang-ident-cap} is an {infer} trained model (`lang_ident_model_1`) that you can 
-use to determine the language of text. You can reference the {lang-ident} model 
-in an {ref}/inference-processor.html[{infer} processor] of an ingest pipeline by 
+{lang-ident-cap} is an trained model that you can use to determine the language
+of text. You can reference the {lang-ident} model in an
+{ref}/inference-processor.html[{infer} processor] of an ingest pipeline by 
 using its model ID (`lang_ident_model_1`). The input field name is `text`. If 
 you want to run {lang-ident} on a field with a different name, you must map your 
 field name to `text` in the ingest processor settings.


### PR DESCRIPTION
This PR updates the introductory sentence of the language identification example (https://www.elastic.co/guide/en/machine-learning/7.6/ml-lang-ident.html). 