### PR TITLE
[DOCS] Adds a page that lists the modules with OOTB ML jobs

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -67,7 +67,7 @@ Influencers:
 Bucket span: 1h.
 
 Function: `high_distinct_count`.
-
+////
 
 status_code_rate_ecs::
 

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -120,7 +120,7 @@ Influencers:
 Bucket span: 15m.
 
 Function: `high_mean`.
-
+////
 
 abnormal_trace_durations_nodejs::
 

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -618,7 +618,7 @@ packetbeat_dns_tunneling::
 
 Looks for unusual DNS activity that could indicate command-and-control or data 
 exfiltration activity.
-
+////
 Influencers:
 
 * `destination.ip`
@@ -628,7 +628,7 @@ Influencers:
 Bucket span: 15m.
 
 Function: `high_info_content`.
-
+////
 
 packetbeat_rare_dns_question::
 
@@ -637,7 +637,7 @@ packetbeat_rare_dns_question::
 * Detects DNS activity that is rare compared to other DNS activities.
 
 Looks for unusual DNS activity that could indicate command-and-control activity.
-
+////
 Influencers:
 
 * `host.name`
@@ -645,7 +645,7 @@ Influencers:
 Bucket span: 15m.
 
 Function: `rare`.
-
+////
 
 packetbeat_rare_server_domain::
 
@@ -656,7 +656,7 @@ packetbeat_rare_server_domain::
 
 Looks for unusual HTTP or TLS destination domain activity that could indicate 
 execution, persistence, command-and-control or data exfiltration activity.
-
+////
 Influencers:
 
 * `destination.ip`
@@ -666,7 +666,7 @@ Influencers:
 Bucket span: 15m.
 
 Function: `rare`.
-
+////
 
 packetbeat_rare_urls::
 
@@ -676,7 +676,7 @@ packetbeat_rare_urls::
 
 Looks for unusual web browsing URL activity that could indicate execution, 
 persistence, command-and-control or data exfiltration activity.
-
+////
 Influencers:
 
 * `destination.ip`
@@ -685,7 +685,7 @@ Influencers:
 Bucket span: 15m.
 
 Function: `rare`.
-
+////
 
 packetbeat_rare_user_agent::
 
@@ -696,7 +696,7 @@ packetbeat_rare_user_agent::
 
 Looks for unusual HTTP user agent activity that could indicate execution, 
 persistence, command-and-control or data exfiltration activity.
-
+////
 Influencers:
 
 * `destination.ip`
@@ -705,7 +705,7 @@ Influencers:
 Bucket span: 15m.
 
 Function: `rare`.
-
+////
 
 rare_process_by_host_linux_ecs::
 rare_process_by_host_windows_ecs::
@@ -713,7 +713,7 @@ rare_process_by_host_windows_ecs::
 * For network activity logs where `agent.type` is `auditbeat` or `winlogbeat`.
 * Models occurrences of process activities on the host. 
 * Detect unusually rare processes compared to other processes on Linux/Windows.
-
+////
 Influencers:
 
 * `host.name` 
@@ -723,7 +723,7 @@ Influencers:
 Bucket span: 15m.
 
 Function: `rare`.
-
+////
 
 suspicious_login_activity_ecs::
 
@@ -731,7 +731,7 @@ suspicious_login_activity_ecs::
 * Models occurrences of authentication attempts (`partition_field_name` is 
   `host.name`).
 * Detects unusually high number of authentication attempts.
-
+////
 Influencers:
 
 * `host.name` 
@@ -741,7 +741,7 @@ Influencers:
 Bucket span: 15m.
 
 Function: `high_non_zero_count`.
-
+////
 
 windows_anomalous_path_activity_ecs::
 
@@ -751,7 +751,7 @@ windows_anomalous_path_activity_ecs::
 
 Activities in unusual paths may indicate execution of malware or persistence 
 mechanisms. Windows payloads often execute from user profile paths.
-
+////
 Influencers:
 
 * `host.name` 

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -282,7 +282,7 @@ Influencers:
 Bucket span: 1h.
 
 Function: `rare`.
-
+////
 
 [float]
 [[ootb-ml-jobs-logs-ui]]

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -207,7 +207,7 @@ high_mean_response_time::
 Bucket span: 15m.
 
 Function: `high_mean`.
-
+////
 
 [float]
 [[ootb-ml-jobs-auditbeat]]

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -304,7 +304,7 @@ Influencers:
 Bucket span: 15m.
 
 Function: `count`.
-
+////
 
 log_entry_rate::
 

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -225,7 +225,7 @@ Function: `high_mean`.
 [[ootb-ml-jobs-auditbeat]]
 === Auditbeat
 
-tag::auditbeat-jobs[]
+// tag::auditbeat-jobs[]
 These {anomaly-job} wizards appear in {kib} if you use 
 {auditbeat-ref}/index.html[{auditbeat}] to audit process activity on your 
 systems.
@@ -304,13 +304,13 @@ Bucket span: 1h.
 
 Function: `rare`.
 ////
-end::auditbeat-jobs[]
+// end::auditbeat-jobs[]
 
 [float]
 [[ootb-ml-jobs-logs-ui]]
 === Logs UI
 
-tag::logs-jobs[]
+// tag::logs-jobs[]
 These {anomaly-jobs} appear by default in the {kibana-ref}/xpack-logs.html[Logs app] in {kib}. 
 log_entry_categories_count::
 
@@ -347,13 +347,13 @@ Bucket span: 15m.
 
 Function: `count`.
 ////
-end::logs-jobs[]
+// end::logs-jobs[]
 
 [float]
 [[ootb-ml-jobs-metricbeat]]
 === Metricbeat
 
-tag::metricbeat-jobs[]
+// tag::metricbeat-jobs[]
 These {anomaly-job} wizards appear in {kib} if you use the 
 {metricbeat-ref}/metricbeat-module-system.html[{metricbeat} system module] to 
 monitor your servers.
@@ -412,13 +412,13 @@ Bucket span: 10m.
 
 Function: `low_count`.
 ////
-end::metricbeat-jobs[]
+// end::metricbeat-jobs[]
 
 [float]
 [[ootb-ml-jobs-nginx]]
 === Nginx
 
-tag::nginx-jobs[]
+// tag::nginx-jobs[]
 These {anomaly-job} wizards appear in {kib} if you use {filebeat} to ship access 
 logs from your http://nginx.org/[Nginx] HTTP servers to {es} and store it using 
 fields and datatypes from the Elastic Common Schema (ECS).
@@ -501,13 +501,13 @@ Bucket span: 15m.
 
 Function: `non_zero_count`.
 ////
-end::nginx-jobs[]
+// end::nginx-jobs[]
 
 [float]
 [[ootb-ml-jobs-siem]]
 === SIEM
 
-tag::siem-jobs[]
+// tag::siem-jobs[]
 These {anomaly-jobs} appear by default in the Anomaly Detection interface of the 
 {siem-guide}/machine-learning.html[SIEM app] in {kib}. They help you 
 automatically detect file system and network anomalies on your hosts.
@@ -928,4 +928,4 @@ Bucket span: 15m.
 
 Function: `rare`.
 ////
-end::siem-jobs[]
+// end::siem-jobs[]

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -12,7 +12,7 @@ prebuilt {anomaly-jobs} that you can use via {kib}.
 [[ootb-ml-jobs-apache]]
 === Apache
 
-tag::apache-jobs[]
+// tag::apache-jobs[]
 These {anomaly-job} wizards appear in {kib} if you use 
 {filebeat-ref}/index.html[{filebeat}] to ship access logs from your 
 https://httpd.apache.org/[Apache] HTTP servers to {es} and store it using fields 
@@ -96,13 +96,13 @@ Bucket span: 15m.
 
 Function: `non_zero_count`.
 ////
-end::apache-jobs[]
+// end::apache-jobs[]
 
 [float]
 [[ootb-ml-jobs-apm]]
 === APM
 
-tag::apm-jobs[]
+// tag::apm-jobs[]
 abnormal_span_durations_jsbase::
 abnormal_span_durations_nodejs::
 
@@ -219,7 +219,7 @@ Bucket span: 15m.
 
 Function: `high_mean`.
 ////
-end::apm-jobs[]
+// end::apm-jobs[]
 
 [float]
 [[ootb-ml-jobs-auditbeat]]

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -828,7 +828,7 @@ Influencers:
 Bucket span: 15m.
 
 Function: `rare`.
-
+////
 
 windows_rare_user_runas_event::
 

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -101,6 +101,7 @@ Function: `non_zero_count`.
 [float]
 [[ootb-ml-jobs-apm]]
 === APM
+These {anomaly-job} wizards appear in {kib} if you have data from APM Agents or an APM Server stored in {es}.
 
 // tag::apm-jobs[]
 abnormal_span_durations_jsbase::

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -466,7 +466,7 @@ Function: `non_zero_count`.
 [float]
 [[ootb-ml-jobs-siem]]
 === SIEM
-
+These {anomaly-jobs} appear by default in the Anomaly Detection interface of the {siem-guide}/machine-learning.html[SIEM app] in {kib}. They help you automatically detect file system and network anomalies on your hosts.
 linux_anomalous_network_activity_ecs::
 windows_anomalous_network_activity_ecs::
 

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -158,7 +158,7 @@ Influencers:
 Bucket span: 15m.
 
 Function: `high_non_zero_count`.
-
+////
 
 decreased_throughput_jsbase::
 decreased_throughput_nodejs::

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -504,7 +504,7 @@ command-and-control, persistence mechanism, or data exfiltration activity.
 
 This job can be created if auditbeat data exists, matching the defined filter, 
 and is available via the SIEM application.
-
+////
 Influencers:
 
 * `destination.ip`
@@ -515,7 +515,7 @@ Influencers:
 Bucket span: 15m.
 
 Function: `rare`.
-
+////
 
 linux_anomalous_network_service::
 
@@ -529,7 +529,7 @@ services, backdoors, or persistence mechanisms.
 
 This job can be created if auditbeat data exists, matching the defined filter, 
 and is available via the SIEM application.
-
+////
 Influencers:
 
 * `host.name` 
@@ -539,7 +539,7 @@ Influencers:
 Bucket span: 15m.
 
 Function: `rare`.
-
+////
 
 linux_anomalous_network_url_activity_ecs::
 
@@ -553,7 +553,7 @@ request activity is very common but unusual web requests from a Linux server can
 sometimes be malware delivery or execution.
 
 and is available via the SIEM application.
-
+////
 Influencers:
 
 * `destination.ip`
@@ -563,7 +563,7 @@ Influencers:
 Bucket span: 15m.
 
 Function: `rare`.
-
+////
 
 linux_anomalous_process_all_hosts_ecs::
 windows_anomalous_process_all_hosts_ecs::
@@ -576,7 +576,7 @@ windows_anomalous_process_all_hosts_ecs::
 Looks for processes that are unusual to all Linux/Windows hosts. Such unusual 
 processes may indicate unauthorized services, malware, or persistence 
 mechanisms.
-
+////
 Influencers:
 
 * `host.name` 
@@ -586,7 +586,7 @@ Influencers:
 Bucket span: 15m.
 
 Function: `rare`.
-
+////
 
 linux_anomalous_user_name_ecs::
 windows_anomalous_user_name_ecs::
@@ -598,7 +598,7 @@ windows_anomalous_user_name_ecs::
 Rare and unusual users that are not normally active may indicate unauthorized 
 changes or activity by an unauthorized user which may be credentialed access or 
 lateral movement.
-
+////
 Influencers:
 
 * `host.name` 
@@ -608,7 +608,7 @@ Influencers:
 Bucket span: 15m.
 
 Function: `rare`.
-
+////
 
 packetbeat_dns_tunneling::
 

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -22,8 +22,8 @@ low_request_rate_ecs::
 
 * For HTTP web access logs where `event.dataset` is `apache.access`.
 * Models the event rate of HTTP requests. 
-* Detects unusually low counts of HTTP requests compared to the previous event (using the <<ml-count,`low_count` function>>)
-rate.
+* Detects unusually low counts of HTTP requests compared to the previous event 
+  rate (using the <<ml-count,`low_count` function>>).
 
 ////
 Bucket span: 15m.
@@ -53,7 +53,7 @@ source_ip_url_count_ecs::
 * For HTTP web access logs where `event.dataset` is `apache.access`.
 * Models the event rate of HTTP requests by source IP.
 * Detects source IPs with unusually high distinct count of URLs in the HTTP 
-access log.
+access log (using the <<ml-distinct-count,`high_distinct_count` function>>).
 
 ////
 Influencers:
@@ -71,7 +71,7 @@ status_code_rate_ecs::
 * Models the occurrences of HTTP response status codes (`partition_field_name` 
   is `http.response.status_code`).
 * Detects unusual status code rates in the HTTP access log compared to previous 
-  rates.
+  rates (using the <<ml-count,`count` function>>).
 
 ////
 Influencers:
@@ -89,7 +89,7 @@ visitor_rate_ecs::
 * For HTTP web access logs where `event.dataset` is `apache.access`.
 * Models visitor rates.
 * Detects unusual visitor rates in the HTTP access log ompared to previous 
-  rates.
+  rates (using the <<ml-nonzero-count,`non_zero_count` function>>).
 
 ////
 Bucket span: 15m.
@@ -108,7 +108,8 @@ abnormal_span_durations_nodejs::
 
 * For APM data where `agent.name` is `js-base` or `nodejs`.
 * Models the duration of spans (`partition_field_name` is `span.type`).
-* Detects for spans that are taking longer than usual to process.
+* Detects for spans that are taking longer than usual to process (using the 
+  <<ml-metric-mean,`high_mean` function>>).
 
 ////
 Influencers:
@@ -127,7 +128,8 @@ abnormal_trace_durations_nodejs::
 
 * For APM data where `agent.name` is `nodejs`.
 * Models the duration of trace transactions.
-* Detects trace transactions that are processing slower than usual.
+* Detects trace transactions that are processing slower than usual (using the 
+  <<ml-metric-mean,`high_mean` function>>).
 
 ////
 Influencers:
@@ -146,7 +148,8 @@ anomalous_error_rate_for_user_agents_jsbase::
 * For APM data where `agent.name` is `js-base`.
 * Models the error rate of user agents (`partition_field_name` is 
   `user_agent.name`).
-* Detects user agents that are encountering errors at an above normal rate.
+* Detects user agents that are encountering errors at an above normal rate 
+  (using the <<ml-nonzero-count,`high_non_zero_count` function>>).
   
 This job can help detect browser compatibility issues.
 
@@ -169,7 +172,7 @@ decreased_throughput_nodejs::
 * For APM data where `agent.name` is `js-base` or `nodejs`.
 * Models the transaction rate of the application.
 * Detects periods during which the application is processing fewer requests 
-than normal.
+than normal (using the <<ml-count,`low_count` function>>).
 
 ////
 Influencers:
@@ -187,7 +190,8 @@ high_count_by_user_agent_jsbase::
 * For APM data where `agent.name` is `js-base`.
 * Models the request rate of user agents (`partition_field_name` is 
   `user_agent.name`).
-* Detects user agents that are making requests at a suspiciously high rate.
+* Detects user agents that are making requests at a suspiciously high rate 
+  (using the <<ml-nonzero-count,`high_non_zero_count` function>>).
 
 This job is useful in identifying bots.
 
@@ -207,7 +211,8 @@ high_mean_response_time::
 * For transaction data where `processor.event` is `transaction` and 
 `transaction.type` is `request`.
 * Models response time duration of transactions.
-* Detects anomalies in high mean of transaction duration.
+* Detects anomalies in high mean of transaction duration (using the 
+  <<ml-metric-mean,`high_mean` function>>).
 
 ////
 Bucket span: 15m.
@@ -230,7 +235,8 @@ docker_high_count_process_events_ecs::
 * For Auditbeat data where `event.module` is `auditd` and `container.runtime` is 
 `docker`.
 * Models process execution rates (`partition_field_name` is `container.name`).
-* Detects unusual increases in process execution rates in Docker containers.
+* Detects unusual increases in process execution rates in Docker containers 
+  (using the <<ml-count,`high_count` function>>).
 
 ////
 Influencers:
@@ -249,7 +255,8 @@ docker_rare_process_activity_ecs::
 `docker`.
 * Models occurrences of process execution (`partition_field_name` is 
   `container.name`).
-* Detects rare process executions in Docker containers.
+* Detects rare process executions in Docker containers (using the 
+  <<ml-rare,`rare` function>>).
 
 ////
 Influencers:
@@ -266,7 +273,8 @@ hosts_high_count_process_events_ecs::
 
 * For Auditbeat data where `event.module` is `auditd`.
 * Models process execution rates (`partition_field_name` is `host.name`).
-* Detects unusual increases in process execution rates.
+* Detects unusual increases in process execution rates (using the 
+  <<ml-nonzero-count,`high_non_zero_count` function>>).
 
 ////
 Influencers:
@@ -283,7 +291,8 @@ hosts_rare_process_activity_ecs::
 
 * For Auditbeat data where `event.module` is `auditd`.
 * Models process execution rates (`partition_field_name` is `host.name`).
-* Detects rare process executions on hosts.
+* Detects rare process executions on hosts (using the 
+  <<ml-rare,`rare` function>>).
 
 ////
 Influencers:
@@ -308,7 +317,8 @@ log_entry_categories_count::
 * For log entry categories via the Logs UI.
 * Models the occurrences of log events (`partition_field_name` is 
   `event.dataset`).
-* Detects anomalies in count of log entries by category.
+* Detects anomalies in count of log entries by category (using the 
+  <<ml-count,`count` function>>).
 
 ////
 Influencers:
@@ -325,7 +335,8 @@ log_entry_rate::
 
 * For log entries via the Logs UI.
 * Models ingestion rates (`partition_field_name` is `event.dataset`). 
-* Detects anomalies in the log entry ingestion rate.
+* Detects anomalies in the log entry ingestion rate (using the 
+  <<ml-count,`low_count` function>>).
 
 ////
 Influencers:
@@ -352,7 +363,8 @@ high_mean_cpu_iowait_ecs::
 * For {metricbeat} data where `event.dataset` is `system.cpu` and 
   `system.filesystem`.
 * Models CPU time spent in iowait (`partition_field_name` is `host.name`).
-* Detects unusual increases in cpu time spent in iowait.
+* Detects unusual increases in cpu time spent in iowait (using the 
+  <<ml-metric-mean,`high_mean` function>>).
 
 ////
 Influencers:
@@ -369,7 +381,8 @@ max_disk_utilization_ecs::
 * For {metricbeat} data where `event.dataset` is `system.cpu` and 
   `system.filesystem`.
 * Models disc utilization (`partition_field_name` is `host.name`).
-* Detects unusual increases in disk utilization.
+* Detects unusual increases in disk utilization (using the 
+  <<ml-metric-max,`max` function>>).
 
 ////
 Influencers:
@@ -387,7 +400,8 @@ metricbeat_outages_ecs::
   `system.filesystem`.
 * Models counts of {metricbeat} documents 
   (`partition_field_name` is `event.dataset`).
-* Detects unusual decreases in {metricbeat} documents.
+* Detects unusual decreases in {metricbeat} documents (using the 
+  <<ml-count,`low_count` function>>).
 
 ////
 Influencers:
@@ -414,7 +428,7 @@ low_request_rate_ecs::
 * For HTTP web access logs where `event.dataset` is `nginx.access`.
 * Models the event rate of http requests. 
 * Detects unusually low counts of HTTP requests compared to the previous event 
-rate.
+  rate (using the <<ml-count,`low_count` function>>).
 
 ////
 Bucket span: 15m.
@@ -427,7 +441,7 @@ source_ip_request_rate_ecs::
 * For HTTP web access logs where `event.dataset` is `nginx.access`.
 * Models the event rate of HTTP requests by source IP.
 * Detects source IPs with unusually high request rates in the HTTP access log 
-  compared to the previous rate. 
+  compared to the previous rate (using the <<ml-count,`high_count` function>>). 
 
 ////
 Influencers:
@@ -444,7 +458,7 @@ source_ip_url_count_ecs::
 * For HTTP web access logs where `event.dataset` is `nginx.access`.
 * Models the event rate of HTTP requests by source IP.
 * Detects source IPs with unusually high distinct count of URLs in the HTTP 
-  access log.
+  access log (using the <<ml-distinct-count,`high_distinct_count` function>>).
 
 ////
 Influencers:
@@ -462,7 +476,7 @@ status_code_rate_ecs::
 * Models the occurrences of HTTP response status codes (`partition_field_name` 
   is `http.response.status_code`).
 * Detects unusual status code rates in the HTTP access log compared to previous 
-  rates.
+  rates (using the <<ml-count,`count` function>>).
 
 ////
 Influencers:
@@ -480,7 +494,7 @@ visitor_rate_ecs::
 * For HTTP web access logs where `event.dataset` is `nginx.access`.
 * Models visitor rates.
 * Detects unusual visitor rates in the HTTP access log ompared to previous 
-  rates.
+  rates (using the <<ml-nonzero-count,`non_zero_count` function>>).
 
 ////
 Bucket span: 15m.
@@ -504,7 +518,7 @@ windows_anomalous_network_activity_ecs::
 * For network activity logs where `agent.type` is `auditbeat` or `winlogbeat`.
 * Models the occurrences of processes that cause network activity.
 * Detects network activity caused by processes that occur rarely compared to 
-  other processes.
+  other processes (using the <<ml-rare,`rare` function>>).
 
 Looks for unusual processes using the network which could indicate
 command-and-control, lateral movement, persistence, or data exfiltration
@@ -528,7 +542,7 @@ linux_anomalous_network_port_activity_ecs::
 * For network activity logs where `agent.type` is `auditbeat`.
 * Models destination port activity.
 * Detects destination port activity that occurs rarely compared to other port 
-  activities.
+  activities (using the <<ml-rare,`rare` function>>).
 
 Looks for unusual destination port activity that could indicate 
 command-and-control, persistence mechanism, or data exfiltration activity.
@@ -551,7 +565,7 @@ linux_anomalous_network_service::
 * For network activity logs where `agent.type` is `auditbeat`.
 * Models listening port activity.
 * Detects unusual listening port activity that occurs rarely compared to 
-  other port activities.
+  other port activities (using the <<ml-rare,`rare` function>>).
 
 Looks for unusual listening ports that could indicate execution of unauthorized 
 services, backdoors, or persistence mechanisms.
@@ -573,7 +587,7 @@ linux_anomalous_network_url_activity_ecs::
 * For network activity logs where `agent.type` is `auditbeat`.
 * Models the occurrences of URL requests.
 * Detects unusual web URL request that is rare compared to other web URL 
-  requests.
+  requests (using the <<ml-rare,`rare` function>>).
 
 Looks for an unusual web URL request from a Linux instance. Curl and wget web 
 request activity is very common but unusual web requests from a Linux server can 
@@ -597,7 +611,7 @@ windows_anomalous_process_all_hosts_ecs::
 * For network activity logs where `agent.type` is `auditbeat` or `winlogbeat`.
 * Models the occurrences of processes on all hosts.
 * Detects processes that occur rarely compared to other processes to all 
-  Linux/Windows hosts.
+  Linux/Windows hosts (using the <<ml-rare,`rare` function>>).
 
 Looks for processes that are unusual to all Linux/Windows hosts. Such unusual 
 processes may indicate unauthorized services, malware, or persistence 
@@ -620,7 +634,8 @@ windows_anomalous_user_name_ecs::
 
 * For network activity logs where `agent.type` is `auditbeat` or `winlogbeat`.
 * Models user activity.
-* Detects users that are rarely or unusually active compared to other users.
+* Detects users that are rarely or unusually active compared to other users 
+  (using the <<ml-rare,`rare` function>>).
 
 Rare and unusual users that are not normally active may indicate unauthorized 
 changes or activity by an unauthorized user which may be credentialed access or 
@@ -642,7 +657,8 @@ packetbeat_dns_tunneling::
 
 * For network activity logs where `agent.type` is `packetbeat`.
 * Models occurrances of DNS activity.
-* Detects unusual DNS activity.
+* Detects unusual DNS activity (using the 
+  <<ml-info-content,`high_info_content` function>>).
 
 Looks for unusual DNS activity that could indicate command-and-control or data 
 exfiltration activity.
@@ -663,7 +679,8 @@ packetbeat_rare_dns_question::
 
 * For network activity logs where `agent.type` is `packetbeat`.
 * Models occurrences of DNS activity.
-* Detects DNS activity that is rare compared to other DNS activities.
+* Detects DNS activity that is rare compared to other DNS activities (using the 
+  <<ml-rare,`rare` function>>).
 
 Looks for unusual DNS activity that could indicate command-and-control activity.
 
@@ -682,7 +699,7 @@ packetbeat_rare_server_domain::
 * For network activity logs where `agent.type` is `packetbeat`.
 * Models HTTP or TLS domain activity.
 * Detects HTTP or TLS domain activity that is rarely occurs compared to other 
-  activities.
+  activities (using the <<ml-rare,`rare` function>>).
 
 Looks for unusual HTTP or TLS destination domain activity that could indicate 
 execution, persistence, command-and-control or data exfiltration activity.
@@ -703,7 +720,8 @@ packetbeat_rare_urls::
 
 * For network activity logs where `agent.type` is `packetbeat`.
 * Models occurrences of web browsing URL activity.
-* Detects URL activity that rarely occurs compared to other URL activities.
+* Detects URL activity that rarely occurs compared to other URL activities 
+  (using the <<ml-rare,`rare` function>>).
 
 Looks for unusual web browsing URL activity that could indicate execution, 
 persistence, command-and-control or data exfiltration activity.
@@ -724,7 +742,7 @@ packetbeat_rare_user_agent::
 * For network activity logs where `agent.type` is `packetbeat`.
 * Models occurrences of HTTP user agent activity.
 * Detects HTTP user agent activity that occurs rarely compared to other HTTP 
-  user agent activities.
+  user agent activities (using the <<ml-rare,`rare` function>>).
 
 Looks for unusual HTTP user agent activity that could indicate execution, 
 persistence, command-and-control or data exfiltration activity.
@@ -745,7 +763,8 @@ rare_process_by_host_windows_ecs::
 
 * For network activity logs where `agent.type` is `auditbeat` or `winlogbeat`.
 * Models occurrences of process activities on the host. 
-* Detect unusually rare processes compared to other processes on Linux/Windows.
+* Detect unusually rare processes compared to other processes on Linux/Windows 
+  (using the <<ml-rare,`rare` function>>).
 
 ////
 Influencers:
@@ -764,7 +783,8 @@ suspicious_login_activity_ecs::
 * For network activity logs where `agent.type` is `auditbeat`.
 * Models occurrences of authentication attempts (`partition_field_name` is 
   `host.name`).
-* Detects unusually high number of authentication attempts.
+* Detects unusually high number of authentication attempts (using the 
+  <<ml-nonzero-count,`high_non_zero_count` function>>).
 
 ////
 Influencers:
@@ -782,7 +802,7 @@ windows_anomalous_path_activity_ecs::
 
 * For network activity logs where `agent.type` is `winlogbeat`.
 * Models occurrences of processes in paths.
-* Detects activity in unusual paths.
+* Detects activity in unusual paths (using the <<ml-rare,`rare` function>>).
 
 Activities in unusual paths may indicate execution of malware or persistence 
 mechanisms. Windows payloads often execute from user profile paths.
@@ -805,7 +825,7 @@ windows_anomalous_process_creation::
 * Models occurrences of process creation activities (`partition_field_name` is 
   `process.parent.name`).
 * Detects process relationships that are rare compared to other process 
-  relationships.
+  relationships (using the <<ml-rare,`rare` function>>).
 
 Looks for unusual process relationships which may indicate execution of malware 
 or persistence mechanisms.
@@ -827,7 +847,8 @@ windows_anomalous_script::
 * For network activity logs where `agent.type` is `winlogbeat`.
 * Models occurrences of powershell script activities.
 * Detects unusual powershell script execution compared to other powershell 
-  script activities.
+  script activities (using the 
+  <<ml-info-content,`high_info_content` function>>).
 
 Looks for unusual powershell scripts that may indicate execution of malware, or 
 persistence mechanisms.
@@ -849,7 +870,7 @@ windows_anomalous_service::
 * For network activity logs where `agent.type` is `winlogbeat`.
 * Models occurrences of Windows service activities.
 * Detects Windows service activities that occur rarely compared to other Windows 
-  service activities.
+  service activities (using the <<ml-rare,`rare` function>>).
 
 Looks for rare and unusual Windows services which may indicate execution of 
 unauthorized services, malware, or persistence mechanisms.
@@ -870,7 +891,7 @@ windows_rare_user_runas_event::
 * For network activity logs where `agent.type` is `winlogbeat`.
 * Models occurrences of user context switches.
 * Detects user context switches that occur rarely compared to other user context 
-  switches.
+  switches (using the <<ml-rare,`rare` function>>).
 
 Unusual user context switches can be due to privilege escalation.
 
@@ -891,7 +912,7 @@ windows_rare_user_type10_remote_login::
 * For network activity logs where `agent.type` is `winlogbeat`.
 * Models occurrences of user remote login activities.
 * Detects user remote login activities that occur rarely compared to other 
-  user remote login activities.
+  user remote login activities (using the <<ml-rare,`rare` function>>).
 
 Looks for unusual user remote logins. Unusual RDP (remote desktop protocol) 
 user logins can indicate account takeover or credentialed access.

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -232,7 +232,7 @@ Influencers:
 Bucket span: 1h.
 
 Function: `high_count`.
-
+////
 
 docker_rare_process_activity_ecs::
 

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -85,7 +85,7 @@ Influencers:
 Bucket span: 15m.
 
 Function: `count`.
-
+////
 
 visitor_rate_ecs::
 

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -808,7 +808,7 @@ Influencers:
 Bucket span: 15m.
 
 Function: `high_info_content`.
-
+////
 
 windows_anomalous_service::
 

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -397,7 +397,7 @@ filter.
 Bucket span: 15m.
 
 Function: `low_count`.
-
+////
 
 source_ip_request_rate_ecs::
 
@@ -405,7 +405,7 @@ source_ip_request_rate_ecs::
 * Models the event rate of HTTP requests by source IP.
 * Detects source IPs with unusually high request rates in the HTTP access log 
   compared to the previous rate. 
-
+////
 Influencers:
 
 * `source.address`
@@ -413,7 +413,7 @@ Influencers:
 Bucket span: 1h.
 
 Function: `high_count`.
-
+////
 
 source_ip_url_count_ecs::
 
@@ -421,7 +421,7 @@ source_ip_url_count_ecs::
 * Models the event rate of HTTP requests by source IP.
 * Detects source IPs with unusually high distinct count of URLs in the HTTP 
   access log.
-
+////
 Influencers:
 
 * `source.address`
@@ -429,7 +429,7 @@ Influencers:
 Bucket span: 1h.
 
 Function: `high_distinct_count`.
-
+////
 
 status_code_rate_ecs::
 
@@ -438,7 +438,7 @@ status_code_rate_ecs::
   is `http.response.status_code`).
 * Detects unusual status code rates in the HTTP access log compared to previous 
   rates.
-
+////
 Influencers:
 
 * `http.response.status_code` 
@@ -447,7 +447,7 @@ Influencers:
 Bucket span: 15m.
 
 Function: `count`.
-
+////
 
 visitor_rate_ecs::
 
@@ -455,11 +455,11 @@ visitor_rate_ecs::
 * Models visitor rates.
 * Detects unusual visitor rates in the HTTP access log ompared to previous 
   rates.
-
+////
 Bucket span: 15m.
 
 Function: `non_zero_count`.
-
+////
 
 [float]
 [[ootb-ml-jobs-siem]]

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -106,7 +106,7 @@ Function: `non_zero_count`.
 abnormal_span_durations_jsbase::
 abnormal_span_durations_nodejs::
 
-* For APM data where `agent.name` is `js-base` or `nodejs`.
+* For data from {apm-rum-agents} or {apm-node-agents} (where `agent.name` is `js-base` or `nodejs`).
 * Models the duration of spans (`partition_field_name` is `span.type`).
 * Detects for spans that are taking longer than usual to process (using the 
   <<ml-metric-mean,`high_mean` function>>).
@@ -126,7 +126,7 @@ Function: `high_mean`.
 
 abnormal_trace_durations_nodejs::
 
-* For APM data where `agent.name` is `nodejs`.
+* For data from {apm-node-agents} (where `agent.name` is `nodejs`).
 * Models the duration of trace transactions.
 * Detects trace transactions that are processing slower than usual (using the 
   <<ml-metric-mean,`high_mean` function>>).
@@ -145,7 +145,7 @@ Function: `high_mean`.
 
 anomalous_error_rate_for_user_agents_jsbase::
 
-* For APM data where `agent.name` is `js-base`.
+* For data from {apm-rum-agents} (where `agent.name` is `js-base`).
 * Models the error rate of user agents (`partition_field_name` is 
   `user_agent.name`).
 * Detects user agents that are encountering errors at an above normal rate 
@@ -169,7 +169,7 @@ Function: `high_non_zero_count`.
 decreased_throughput_jsbase::
 decreased_throughput_nodejs::
 
-* For APM data where `agent.name` is `js-base` or `nodejs`.
+* For data from {apm-rum-agents} or {apm-node-agents} (where `agent.name` is `js-base` or `nodejs`).
 * Models the transaction rate of the application.
 * Detects periods during which the application is processing fewer requests 
 than normal (using the <<ml-count,`low_count` function>>).
@@ -187,7 +187,7 @@ Function: `low_count`.
 
 high_count_by_user_agent_jsbase::
 
-* For APM data where `agent.name` is `js-base`.
+* For data from {apm-rum-agents} (where `agent.name` is `js-base`).
 * Models the request rate of user agents (`partition_field_name` is 
   `user_agent.name`).
 * Detects user agents that are making requests at a suspiciously high rate 
@@ -312,6 +312,7 @@ Function: `rare`.
 
 // tag::logs-jobs[]
 These {anomaly-jobs} appear by default in the {kibana-ref}/xpack-logs.html[Logs app] in {kib}. 
+
 log_entry_categories_count::
 
 * For log entry categories via the Logs UI.

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -93,7 +93,7 @@ visitor_rate_ecs::
 * Models visitor rates.
 * Detects unusual visitor rates in the HTTP access log ompared to previous 
   rates.
-
+////
 Bucket span: 15m.
 
 Function: `non_zero_count`.

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -250,7 +250,7 @@ Influencers:
 Bucket span: 1h.
 
 Function: `rare`.
-
+////
 
 hosts_high_count_process_events_ecs::
 

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -848,7 +848,7 @@ Influencers:
 Bucket span: 15m.
 
 Function: `rare`.
-
+////
 
 windows_rare_user_type10_remote_login::
 

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -798,7 +798,7 @@ windows_anomalous_script::
 
 Looks for unusual powershell scripts that may indicate execution of malware, or 
 persistence mechanisms.
-
+////
 Influencers:
 
 * `host.name` 

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -147,7 +147,7 @@ anomalous_error_rate_for_user_agents_jsbase::
 * Detects user agents that are encountering errors at an above normal rate.
   
 This job can help detect browser compatibility issues.
-
+////
 Influencers:
 
 * `user_agent.name`

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -167,7 +167,7 @@ decreased_throughput_nodejs::
 * Models the transaction rate of the application.
 * Detects periods during which the application is processing fewer requests 
 than normal.
-
+////
 Influencers:
 
 * `service.name`

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -100,7 +100,7 @@ Bucket span: 15m.
 
 Function: `non_zero_count`.
 
-
+end::apache-jobs[]
 [float]
 [[ootb-ml-jobs-apm]]
 === APM

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -351,7 +351,7 @@ max_disk_utilization_ecs::
   `system.filesystem`.
 * Models disc utilization (`partition_field_name` is `host.name`).
 * Detects unusual increases in disk utilization.
-
+////
 Influencers:
 
 * `host.name`

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -137,7 +137,7 @@ Influencers:
 Bucket span: 15m.
 
 Function: `high_mean`.
-
+////
 
 anomalous_error_rate_for_user_agents_jsbase::
 

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -45,7 +45,7 @@ source_ip_request_rate_ecs::
 
 This job can be created if web access log data exists matching the defined 
 filter.
-
+////
 Influencers:
 
 * `source.address`

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -295,7 +295,7 @@ log_entry_categories_count::
 * Models the occurrences of log events (`partition_field_name` is 
   `event.dataset`).
 * Detects anomalies in count of log entries by category.
-
+////
 Influencers:
 
 * `event.dataset`

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -287,7 +287,8 @@ Function: `rare`.
 [float]
 [[ootb-ml-jobs-logs-ui]]
 === Logs UI
-
+tag::logs-jobs[]
+These {anomaly-jobs} appear by default in the {kibana-ref}/xpack-logs.html[Logs app] in {kib}. 
 log_entry_categories_count::
 
 * For log entry categories via the Logs UI.

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -335,7 +335,7 @@ high_mean_cpu_iowait_ecs::
   `system.filesystem`.
 * Models CPU time spent in iowait (`partition_field_name` is `host.name`).
 * Detects unusual increases in cpu time spent in iowait.
-
+////
 Influencers:
 
 * `host.name`

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -176,7 +176,7 @@ Influencers:
 Bucket span: 15m.
 
 Function: `low_count`.
-
+////
 
 high_count_by_user_agent_jsbase::
 

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -343,7 +343,7 @@ Influencers:
 Bucket span: 10m.
 
 Function: `high_mean`.
-
+////
 
 max_disk_utilization_ecs::
 

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -376,7 +376,7 @@ Influencers:
 Bucket span: 10m.
 
 Function: `low_count`.
-
+////
 
 [float]
 [[ootb-ml-jobs-nginx]]

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -859,7 +859,7 @@ windows_rare_user_type10_remote_login::
 
 Looks for unusual user remote logins. Unusual RDP (remote desktop protocol) 
 user logins can indicate account takeover or credentialed access.
-
+////
 Influencers:
 
 * `host.name` 

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -43,7 +43,6 @@ source_ip_request_rate_ecs::
 * Detects source IPs with unusually high request rates in the HTTP access log 
   compared to the previous rate (using the <<ml-count,`high_count` function>>).
 
-filter.
 ////
 Influencers:
 

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -319,7 +319,7 @@ Influencers:
 Bucket span: 15m.
 
 Function: `count`.
-
+////
 
 [float]
 [[ootb-ml-jobs-metricbeat]]

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -392,7 +392,6 @@ low_request_rate_ecs::
 * Detects unusually low counts of HTTP requests compared to the previous event 
 rate.
 
-This job can be created if web access log data exists matching the defined 
 filter.
 
 Bucket span: 15m.

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -554,7 +554,6 @@ Looks for an unusual web URL request from a Linux instance. Curl and wget web
 request activity is very common but unusual web requests from a Linux server can 
 sometimes be malware delivery or execution.
 
-This job can be created if auditbeat data exists, matching the defined filter, 
 and is available via the SIEM application.
 
 Influencers:

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -127,7 +127,7 @@ abnormal_trace_durations_nodejs::
 * For APM data where `agent.name` is `nodejs`.
 * Models the duration of trace transactions.
 * Detects trace transactions that are processing slower than usual.
-
+////
 Influencers:
 
 * `service.name` 

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -53,7 +53,7 @@ Influencers:
 Bucket span: 1h.
 
 Function: `high_count`.
-
+////
 
 source_ip_url_count_ecs::
 

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -59,7 +59,7 @@ source_ip_url_count_ecs::
 * Models the event rate of HTTP requests by source IP.
 * Detects source IPs with unusually high distinct count of URLs in the HTTP 
 access log.
-
+////
 Influencers:
 
 * `source.address`

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -819,7 +819,7 @@ windows_anomalous_service::
 
 Looks for rare and unusual Windows services which may indicate execution of 
 unauthorized services, malware, or persistence mechanisms.
-
+////
 Influencers:
 
 * `host.name` 

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -241,7 +241,7 @@ docker_rare_process_activity_ecs::
 * Models occurrences of process execution (`partition_field_name` is 
   `container.name`).
 * Detects rare process executions in Docker containers.
-
+////
 Influencers:
 
 * `container.name`

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -368,7 +368,7 @@ metricbeat_outages_ecs::
 * Models counts of {metricbeat} documents 
   (`partition_field_name` is `event.dataset`).
 * Detects unusual decreases in {metricbeat} documents.
-
+////
 Influencers:
 
 * `event.dataset`

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -186,7 +186,7 @@ high_count_by_user_agent_jsbase::
 * Detects user agents that are making requests at a suspiciously high rate.
 
 This job is useful in identifying bots.
-
+////
 Influencers:
 
 * `service.name`

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -203,7 +203,7 @@ high_mean_response_time::
 `transaction.type` is `request`.
 * Models response time duration of transactions.
 * Detects anomalies in high mean of transaction duration.
-
+////
 Bucket span: 15m.
 
 Function: `high_mean`.

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -273,7 +273,7 @@ hosts_rare_process_activity_ecs::
 * For Auditbeat data where `event.module` is `auditd`.
 * Models process execution rates (`partition_field_name` is `host.name`).
 * Detects rare process executions on hosts.
-
+////
 Influencers:
 
 * `host.name`

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -838,7 +838,7 @@ windows_rare_user_runas_event::
   switches.
 
 Unusual user context switches can be due to privilege escalation.
-
+////
 Influencers:
 
 * `host.name` 

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -76,7 +76,7 @@ status_code_rate_ecs::
   is `http.response.status_code`).
 * Detects unusual status code rates in the HTTP access log compared to previous 
   rates.
-
+////
 Influencers:
 
 * `http.response.status_code` 

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -109,7 +109,7 @@ abnormal_span_durations_nodejs::
 * For APM data where `agent.name` is `js-base` or `nodejs`.
 * Models the duration of spans (`partition_field_name` is `span.type`).
 * Detects for spans that are taking longer than usual to process.
-
+////
 Influencers:
 
 * `service.name` 

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -5,17 +5,13 @@
 {anomaly-jobs-cap} contain the configuration information and metadata necessary 
 to perform an analytics task. {kib} can recognize certain types of data and 
 provide specialized wizards for that context. This page lists the available 
-prebuilt {anomaly-jobs} that you can use via {kib}. Every module item in the 
-list contains a name, a short description, information about 
-the {ml-docs}/ml-buckets.html#ml-buckets[`bucket_span`] and the 
-{ml-docs}/ml-functions.html[analysis function] as well as the influencers – the 
-entities that have contributed to, or are to blame for, the anomalies – of the 
-{anomaly-detect} job.
+prebuilt {anomaly-jobs} that you can use via {kib}.
 
 
 [float]
 [[ootb-ml-jobs-apache]]
 === Apache
+
 tag::apache-jobs[]
 These {anomaly-job} wizards appear in {kib} if you use 
 {filebeat-ref}/index.html[{filebeat}] to ship access logs from your 
@@ -58,6 +54,7 @@ source_ip_url_count_ecs::
 * Models the event rate of HTTP requests by source IP.
 * Detects source IPs with unusually high distinct count of URLs in the HTTP 
 access log.
+
 ////
 Influencers:
 
@@ -75,6 +72,7 @@ status_code_rate_ecs::
   is `http.response.status_code`).
 * Detects unusual status code rates in the HTTP access log compared to previous 
   rates.
+
 ////
 Influencers:
 
@@ -92,22 +90,26 @@ visitor_rate_ecs::
 * Models visitor rates.
 * Detects unusual visitor rates in the HTTP access log ompared to previous 
   rates.
+
 ////
 Bucket span: 15m.
 
 Function: `non_zero_count`.
 ////
 end::apache-jobs[]
+
 [float]
 [[ootb-ml-jobs-apm]]
 === APM
 
+tag::apm-jobs[]
 abnormal_span_durations_jsbase::
 abnormal_span_durations_nodejs::
 
 * For APM data where `agent.name` is `js-base` or `nodejs`.
 * Models the duration of spans (`partition_field_name` is `span.type`).
 * Detects for spans that are taking longer than usual to process.
+
 ////
 Influencers:
 
@@ -126,6 +128,7 @@ abnormal_trace_durations_nodejs::
 * For APM data where `agent.name` is `nodejs`.
 * Models the duration of trace transactions.
 * Detects trace transactions that are processing slower than usual.
+
 ////
 Influencers:
 
@@ -146,6 +149,7 @@ anomalous_error_rate_for_user_agents_jsbase::
 * Detects user agents that are encountering errors at an above normal rate.
   
 This job can help detect browser compatibility issues.
+
 ////
 Influencers:
 
@@ -166,6 +170,7 @@ decreased_throughput_nodejs::
 * Models the transaction rate of the application.
 * Detects periods during which the application is processing fewer requests 
 than normal.
+
 ////
 Influencers:
 
@@ -185,6 +190,7 @@ high_count_by_user_agent_jsbase::
 * Detects user agents that are making requests at a suspiciously high rate.
 
 This job is useful in identifying bots.
+
 ////
 Influencers:
 
@@ -202,16 +208,19 @@ high_mean_response_time::
 `transaction.type` is `request`.
 * Models response time duration of transactions.
 * Detects anomalies in high mean of transaction duration.
+
 ////
 Bucket span: 15m.
 
 Function: `high_mean`.
 ////
+end::apm-jobs[]
 
 [float]
 [[ootb-ml-jobs-auditbeat]]
 === Auditbeat
 
+tag::auditbeat-jobs[]
 These {anomaly-job} wizards appear in {kib} if you use 
 {auditbeat-ref}/index.html[{auditbeat}] to audit process activity on your 
 systems.
@@ -222,6 +231,7 @@ docker_high_count_process_events_ecs::
 `docker`.
 * Models process execution rates (`partition_field_name` is `container.name`).
 * Detects unusual increases in process execution rates in Docker containers.
+
 ////
 Influencers:
 
@@ -240,6 +250,7 @@ docker_rare_process_activity_ecs::
 * Models occurrences of process execution (`partition_field_name` is 
   `container.name`).
 * Detects rare process executions in Docker containers.
+
 ////
 Influencers:
 
@@ -256,6 +267,7 @@ hosts_high_count_process_events_ecs::
 * For Auditbeat data where `event.module` is `auditd`.
 * Models process execution rates (`partition_field_name` is `host.name`).
 * Detects unusual increases in process execution rates.
+
 ////
 Influencers:
 
@@ -272,6 +284,7 @@ hosts_rare_process_activity_ecs::
 * For Auditbeat data where `event.module` is `auditd`.
 * Models process execution rates (`partition_field_name` is `host.name`).
 * Detects rare process executions on hosts.
+
 ////
 Influencers:
 
@@ -282,10 +295,12 @@ Bucket span: 1h.
 
 Function: `rare`.
 ////
+end::auditbeat-jobs[]
 
 [float]
 [[ootb-ml-jobs-logs-ui]]
 === Logs UI
+
 tag::logs-jobs[]
 These {anomaly-jobs} appear by default in the {kibana-ref}/xpack-logs.html[Logs app] in {kib}. 
 log_entry_categories_count::
@@ -294,6 +309,7 @@ log_entry_categories_count::
 * Models the occurrences of log events (`partition_field_name` is 
   `event.dataset`).
 * Detects anomalies in count of log entries by category.
+
 ////
 Influencers:
 
@@ -310,6 +326,7 @@ log_entry_rate::
 * For log entries via the Logs UI.
 * Models ingestion rates (`partition_field_name` is `event.dataset`). 
 * Detects anomalies in the log entry ingestion rate.
+
 ////
 Influencers:
 
@@ -319,11 +336,13 @@ Bucket span: 15m.
 
 Function: `count`.
 ////
+end::logs-jobs[]
 
 [float]
 [[ootb-ml-jobs-metricbeat]]
 === Metricbeat
 
+tag::metricbeat-jobs[]
 These {anomaly-job} wizards appear in {kib} if you use the 
 {metricbeat-ref}/metricbeat-module-system.html[{metricbeat} system module] to 
 monitor your servers.
@@ -334,6 +353,7 @@ high_mean_cpu_iowait_ecs::
   `system.filesystem`.
 * Models CPU time spent in iowait (`partition_field_name` is `host.name`).
 * Detects unusual increases in cpu time spent in iowait.
+
 ////
 Influencers:
 
@@ -350,6 +370,7 @@ max_disk_utilization_ecs::
   `system.filesystem`.
 * Models disc utilization (`partition_field_name` is `host.name`).
 * Detects unusual increases in disk utilization.
+
 ////
 Influencers:
 
@@ -367,6 +388,7 @@ metricbeat_outages_ecs::
 * Models counts of {metricbeat} documents 
   (`partition_field_name` is `event.dataset`).
 * Detects unusual decreases in {metricbeat} documents.
+
 ////
 Influencers:
 
@@ -376,11 +398,13 @@ Bucket span: 10m.
 
 Function: `low_count`.
 ////
+end::metricbeat-jobs[]
 
 [float]
 [[ootb-ml-jobs-nginx]]
 === Nginx
 
+tag::nginx-jobs[]
 These {anomaly-job} wizards appear in {kib} if you use {filebeat} to ship access 
 logs from your http://nginx.org/[Nginx] HTTP servers to {es} and store it using 
 fields and datatypes from the Elastic Common Schema (ECS).
@@ -392,7 +416,6 @@ low_request_rate_ecs::
 * Detects unusually low counts of HTTP requests compared to the previous event 
 rate.
 
-filter.
 ////
 Bucket span: 15m.
 
@@ -405,6 +428,7 @@ source_ip_request_rate_ecs::
 * Models the event rate of HTTP requests by source IP.
 * Detects source IPs with unusually high request rates in the HTTP access log 
   compared to the previous rate. 
+
 ////
 Influencers:
 
@@ -421,6 +445,7 @@ source_ip_url_count_ecs::
 * Models the event rate of HTTP requests by source IP.
 * Detects source IPs with unusually high distinct count of URLs in the HTTP 
   access log.
+
 ////
 Influencers:
 
@@ -438,6 +463,7 @@ status_code_rate_ecs::
   is `http.response.status_code`).
 * Detects unusual status code rates in the HTTP access log compared to previous 
   rates.
+
 ////
 Influencers:
 
@@ -455,16 +481,23 @@ visitor_rate_ecs::
 * Models visitor rates.
 * Detects unusual visitor rates in the HTTP access log ompared to previous 
   rates.
+
 ////
 Bucket span: 15m.
 
 Function: `non_zero_count`.
 ////
+end::nginx-jobs[]
 
 [float]
 [[ootb-ml-jobs-siem]]
 === SIEM
-These {anomaly-jobs} appear by default in the Anomaly Detection interface of the {siem-guide}/machine-learning.html[SIEM app] in {kib}. They help you automatically detect file system and network anomalies on your hosts.
+
+tag::siem-jobs[]
+These {anomaly-jobs} appear by default in the Anomaly Detection interface of the 
+{siem-guide}/machine-learning.html[SIEM app] in {kib}. They help you 
+automatically detect file system and network anomalies on your hosts.
+
 linux_anomalous_network_activity_ecs::
 windows_anomalous_network_activity_ecs::
 
@@ -477,8 +510,6 @@ Looks for unusual processes using the network which could indicate
 command-and-control, lateral movement, persistence, or data exfiltration
 activity.
 
-This job can be created if auditbeat or winlogbeat data exists, matching the 
-defined filter, and is available via the SIEM application.
 ////
 Influencers:
 
@@ -502,8 +533,6 @@ linux_anomalous_network_port_activity_ecs::
 Looks for unusual destination port activity that could indicate 
 command-and-control, persistence mechanism, or data exfiltration activity.
 
-This job can be created if auditbeat data exists, matching the defined filter, 
-and is available via the SIEM application.
 ////
 Influencers:
 
@@ -527,8 +556,6 @@ linux_anomalous_network_service::
 Looks for unusual listening ports that could indicate execution of unauthorized 
 services, backdoors, or persistence mechanisms.
 
-This job can be created if auditbeat data exists, matching the defined filter, 
-and is available via the SIEM application.
 ////
 Influencers:
 
@@ -552,7 +579,6 @@ Looks for an unusual web URL request from a Linux instance. Curl and wget web
 request activity is very common but unusual web requests from a Linux server can 
 sometimes be malware delivery or execution.
 
-and is available via the SIEM application.
 ////
 Influencers:
 
@@ -576,6 +602,7 @@ windows_anomalous_process_all_hosts_ecs::
 Looks for processes that are unusual to all Linux/Windows hosts. Such unusual 
 processes may indicate unauthorized services, malware, or persistence 
 mechanisms.
+
 ////
 Influencers:
 
@@ -598,6 +625,7 @@ windows_anomalous_user_name_ecs::
 Rare and unusual users that are not normally active may indicate unauthorized 
 changes or activity by an unauthorized user which may be credentialed access or 
 lateral movement.
+
 ////
 Influencers:
 
@@ -618,6 +646,7 @@ packetbeat_dns_tunneling::
 
 Looks for unusual DNS activity that could indicate command-and-control or data 
 exfiltration activity.
+
 ////
 Influencers:
 
@@ -637,6 +666,7 @@ packetbeat_rare_dns_question::
 * Detects DNS activity that is rare compared to other DNS activities.
 
 Looks for unusual DNS activity that could indicate command-and-control activity.
+
 ////
 Influencers:
 
@@ -656,6 +686,7 @@ packetbeat_rare_server_domain::
 
 Looks for unusual HTTP or TLS destination domain activity that could indicate 
 execution, persistence, command-and-control or data exfiltration activity.
+
 ////
 Influencers:
 
@@ -676,6 +707,7 @@ packetbeat_rare_urls::
 
 Looks for unusual web browsing URL activity that could indicate execution, 
 persistence, command-and-control or data exfiltration activity.
+
 ////
 Influencers:
 
@@ -696,6 +728,7 @@ packetbeat_rare_user_agent::
 
 Looks for unusual HTTP user agent activity that could indicate execution, 
 persistence, command-and-control or data exfiltration activity.
+
 ////
 Influencers:
 
@@ -713,6 +746,7 @@ rare_process_by_host_windows_ecs::
 * For network activity logs where `agent.type` is `auditbeat` or `winlogbeat`.
 * Models occurrences of process activities on the host. 
 * Detect unusually rare processes compared to other processes on Linux/Windows.
+
 ////
 Influencers:
 
@@ -731,6 +765,7 @@ suspicious_login_activity_ecs::
 * Models occurrences of authentication attempts (`partition_field_name` is 
   `host.name`).
 * Detects unusually high number of authentication attempts.
+
 ////
 Influencers:
 
@@ -751,6 +786,7 @@ windows_anomalous_path_activity_ecs::
 
 Activities in unusual paths may indicate execution of malware or persistence 
 mechanisms. Windows payloads often execute from user profile paths.
+
 ////
 Influencers:
 
@@ -773,6 +809,7 @@ windows_anomalous_process_creation::
 
 Looks for unusual process relationships which may indicate execution of malware 
 or persistence mechanisms.
+
 ////
 Influencers:
 
@@ -794,6 +831,7 @@ windows_anomalous_script::
 
 Looks for unusual powershell scripts that may indicate execution of malware, or 
 persistence mechanisms.
+
 ////
 Influencers:
 
@@ -815,6 +853,7 @@ windows_anomalous_service::
 
 Looks for rare and unusual Windows services which may indicate execution of 
 unauthorized services, malware, or persistence mechanisms.
+
 ////
 Influencers:
 
@@ -834,6 +873,7 @@ windows_rare_user_runas_event::
   switches.
 
 Unusual user context switches can be due to privilege escalation.
+
 ////
 Influencers:
 
@@ -855,6 +895,7 @@ windows_rare_user_type10_remote_login::
 
 Looks for unusual user remote logins. Unusual RDP (remote desktop protocol) 
 user logins can indicate account takeover or credentialed access.
+
 ////
 Influencers:
 
@@ -865,3 +906,5 @@ Influencers:
 Bucket span: 15m.
 
 Function: `rare`.
+////
+end::siem-jobs[]

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -266,7 +266,7 @@ Influencers:
 Bucket span: 1h.
 
 Function: `high_non_zero_count`.
-
+////
 
 hosts_rare_process_activity_ecs::
 

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -29,7 +29,6 @@ low_request_rate_ecs::
 * Detects unusually low counts of HTTP requests compared to the previous event (using the <<ml-count,`low_count` function>>)
 rate.
 
-filter.
 ////
 Bucket span: 15m.
 

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -311,7 +311,7 @@ log_entry_rate::
 * For log entries via the Logs UI.
 * Models ingestion rates (`partition_field_name` is `event.dataset`). 
 * Detects anomalies in the log entry ingestion rate.
-
+////
 Influencers:
 
 * `event.dataset`

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -787,7 +787,7 @@ Influencers:
 Bucket span: 15m.
 
 Function: `rare`.
-
+////
 
 windows_anomalous_script::
 

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -195,7 +195,7 @@ Influencers:
 Bucket span: 15m.
 
 Function: `high_non_zero_count`.
-
+////
 
 high_mean_response_time::
 

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -97,7 +97,7 @@ visitor_rate_ecs::
 Bucket span: 15m.
 
 Function: `non_zero_count`.
-
+////
 end::apache-jobs[]
 [float]
 [[ootb-ml-jobs-apm]]

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -393,7 +393,7 @@ low_request_rate_ecs::
 rate.
 
 filter.
-
+////
 Bucket span: 15m.
 
 Function: `low_count`.

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -359,7 +359,7 @@ Influencers:
 Bucket span: 10m.
 
 Function: `max`.
-
+////
 
 metricbeat_outages_ecs::
 

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -43,7 +43,6 @@ source_ip_request_rate_ecs::
 * Detects source IPs with unusually high request rates in the HTTP access log 
   compared to the previous rate (using the <<ml-count,`high_count` function>>).
 
-This job can be created if web access log data exists matching the defined 
 filter.
 ////
 Influencers:

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -257,7 +257,7 @@ hosts_high_count_process_events_ecs::
 * For Auditbeat data where `event.module` is `auditd`.
 * Models process execution rates (`partition_field_name` is `host.name`).
 * Detects unusual increases in process execution rates.
-
+////
 Influencers:
 
 * `host.name`

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -479,7 +479,7 @@ activity.
 
 This job can be created if auditbeat or winlogbeat data exists, matching the 
 defined filter, and is available via the SIEM application.
-
+////
 Influencers:
 
 * `destination.ip`
@@ -490,7 +490,7 @@ Influencers:
 Bucket span: 15m.
 
 Function: `rare`.
-
+////
 
 linux_anomalous_network_port_activity_ecs::
 

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -223,7 +223,7 @@ docker_high_count_process_events_ecs::
 `docker`.
 * Models process execution rates (`partition_field_name` is `container.name`).
 * Detects unusual increases in process execution rates in Docker containers.
-
+////
 Influencers:
 
 * `container.name`


### PR DESCRIPTION
This PR adds documentation of the modules with prebuilt anomaly detection jobs.

Related issue: https://github.com/elastic/stack-docs/issues/708

Preview: http://stack-docs_843.docs-preview.app.elstc.co/guide/en/machine-learning/master/ootb-ml-jobs.html

Source: https://github.com/elastic/kibana/tree/master/x-pack/legacy/plugins/ml/server/models/data_recognizer/modules