### PR TITLE
[7.6][docs] Add APM tagged regions for 7.6.0

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -31,7 +31,7 @@ Upgrade Assistant provides information about which {dfeeds} need to be updated.
 This list summarizes the most important breaking changes in APM.
 For the complete list, go to {apm-server-ref-70}/breaking-changes.html[APM Server 7.0 breaking changes].
 
-//include::{apm-repo-dir}/apm-breaking-changes.asciidoc[tag=notable-v7-breaking-changes]
+include::{apm-repo-dir}/apm-breaking-changes.asciidoc[tag=notable-v76-breaking-changes]
 
 [[beats-breaking-changes]]
 === Beats breaking changes

--- a/docs/en/install-upgrade/highlights.asciidoc
+++ b/docs/en/install-upgrade/highlights.asciidoc
@@ -4,12 +4,11 @@
 Each release brings new features and product improvements. This section
 highlights notable new features and enhancements in {version}.
 
-//** <<apm-highlights,APM>>
+** <<apm-highlights,APM>>
 ** <<beats-highlights,Beats>>
 ** <<elasticsearch-highlights,{es}>>
 ** <<kibana-higlights,{kib}>>
 
-////
 [[apm-highlights]]
 === APM highlights
 ++++
@@ -20,8 +19,7 @@ This list summarizes the most important enhancements in APM.
 For the complete list, go to
 {apm-overview-ref-v}/apm-release-notes.html[APM release highlights].
 
-include::{apm-repo-dir}/apm-release-notes.asciidoc[tag=notable-v7-highlights]
-////
+include::{apm-repo-dir}/apm-release-notes.asciidoc[tag=notable-v76-highlights]
 
 [[beats-highlights]]
 === Beats highlights


### PR DESCRIPTION
**Blocked by https://github.com/elastic/apm-server/pull/3282**.

Cherrypick to `7.x` and `master`.