### PR TITLE
[DOCS] Adds Kibana 7.6.0 highlights

### DIFF
--- a/docs/en/install-upgrade/highlights.asciidoc
+++ b/docs/en/install-upgrade/highlights.asciidoc
@@ -64,10 +64,9 @@ include::{es-repo-dir}/reference/release-notes/highlights-7.6.0.asciidoc[tag=not
 This list summarizes the most important enhancements in {kib} {version}.
 
 coming::[7.6.0]
-////
+
 :leveloffset: +1
 
 include::{kib-repo-dir}/release-notes/highlights-7.6.0.asciidoc[tag=notable-highlights]
 
 :leveloffset: -1
-////


### PR DESCRIPTION
Related to https://github.com/elastic/kibana/pull/57160

This PR adds the notable Kibana 7.6.0 release highlights to the Installation and Upgrade Guide.

Preview: http://stack-docs_867.docs-preview.app.elstc.co/guide/en/elastic-stack/7.6/kibana-higlights.html