### PR TITLE
[DOCS] Remove cluster privilege requirement

### DIFF
--- a/docs/en/stack/ml/setup.asciidoc
+++ b/docs/en/stack/ml/setup.asciidoc
@@ -60,14 +60,9 @@ If you use {ml-features} in {kib}, you must also have:
 {kibana-ref}/xpack-security-authorization.html[grants access to {kib}]
 * [ ] `monitor` cluster privilege to manage {dfanalytics-jobs}
 
-If you use {kib} to create categorization {anomaly-jobs}, you must
-also have:
-
-[%interactive]
-* [ ] `manage` cluster privileges
-
 If you use the *Data Visualizer* to upload files in {kib}, you must also have:
 
 [%interactive]
 * [ ] `monitor` and `manage_ingest_pipelines` cluster privileges
 * [ ] `read`, `manage`, and `index` index privileges for the destination index
+  


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/52259

This PR updates the list of security privileges for machine learning, in particular related to the privilege that will no longer be required by the Kibana categorization job wizard.