### PR TITLE
[DOCS] Adds DFA limitation regarding feature importance

### DIFF
--- a/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
@@ -130,3 +130,17 @@ of combinations of dot delimited and nested fields (for example:
 `{"a.b": "c", "a": {"b": "c"},...}`), the performance of the operation might be 
 slightly slower. Consider using as simple mapping as possible for the best 
 performance profile.
+
+[float]
+[[dfa-feature-importance-limitation]]
+=== Analytics runtime performance may slow down with feature importance
+
+For complex models – those with deep trees and many leaves – the calculation of 
+feature importance takes extra time. Feature importance is calculated at the end 
+of the analysis and therefore the job may appear to be stuck at 99% for several 
+hours.
+
+If a reduction in runtime is important to you, please try strategies such as 
+disabling feature importance, using a smaller training percent, setting 
+hyperparameter values and/or only selecting fields for analysis that are 
+relevant.

--- a/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
@@ -135,7 +135,7 @@ performance profile.
 [[dfa-feature-importance-limitation]]
 === Analytics runtime performance may slow down with feature importance
 
-For complex models – those with deep trees and many leaves – the calculation of 
+For complex models – those with many deep trees – the calculation of 
 feature importance takes extra time. Feature importance is calculated at the end 
 of the analysis and therefore the job may appear to be stuck at 99% for several 
 hours.

--- a/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
@@ -133,7 +133,7 @@ performance profile.
 
 [float]
 [[dfa-feature-importance-limitation]]
-=== Analytics runtime performance may slow down with feature importance
+=== Analytics runtime performance may significantly slow down with feature importance computation
 
 For complex models – those with many deep trees – the calculation of 
 feature importance takes significant extra time. Feature importance is calculated at the end 

--- a/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
@@ -141,6 +141,6 @@ of the analysis and therefore the job may appear to be stuck at 99% for several
 hours.
 
 If a reduction in runtime is important to you, please try strategies such as 
-disabling feature importance, using a smaller training percent, setting 
+disabling feature importance, using a smaller transform, setting 
 hyperparameter values and/or only selecting fields for analysis that are 
 relevant.

--- a/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
@@ -136,7 +136,7 @@ performance profile.
 === Analytics runtime performance may slow down with feature importance
 
 For complex models – those with many deep trees – the calculation of 
-feature importance takes extra time. Feature importance is calculated at the end 
+feature importance takes significant extra time. Feature importance is calculated at the end 
 of the analysis and therefore the job may appear to be stuck at 99% for several 
 hours.
 


### PR DESCRIPTION
Adds a new item to the DFA limitation section about possible performance effects of feature importance calculation.

Related issue: https://github.com/elastic/ml-team/issues/274#issuecomment-585262454