### PR TITLE
[DOCS] Clarify feature importance values

### DIFF
--- a/docs/en/stack/ml/shared-ml-concepts.asciidoc
+++ b/docs/en/stack/ml/shared-ml-concepts.asciidoc
@@ -24,6 +24,6 @@ stored in the destination index in fields prefixed by `ml.feature_importance`.
 
 NOTE: The number of feature importance values for each document might be less
 than the `num_top_feature_importance_values` property value. For example, it
-returns only features had a positive or negative effect on the prediction.
+returns only features that had a positive or negative effect on the prediction.
 
 end::feature-importance[]

--- a/docs/en/stack/ml/shared-ml-concepts.asciidoc
+++ b/docs/en/stack/ml/shared-ml-concepts.asciidoc
@@ -15,5 +15,15 @@ generally (for the whole data set).
 
 Feature importance in the {stack} is calculated using the SHAP (SHapley Additive 
 exPlanations) method as described in
-https://papers.nips.cc/paper/7062-a-unified-approach-to-interpreting-model-predictions.pdf[Lundberg, S. M., & Lee, S.-I. A Unified Approach to Interpreting Model Predictions. In NeurIPS 2017.].
+https://papers.nips.cc/paper/7062-a-unified-approach-to-interpreting-model-predictions.pdf[Lundberg, S. M., & Lee, S.-I. A Unified Approach to Interpreting Model Predictions. In NeurIPS 2017].
+
+By default, feature importance values are not calculated. To generate this
+information, when you create a {dfanalytics-job} you must specify the 
+`num_top_feature_importance_values` property. The feature importance values are
+stored in the destination index in fields prefixed by `ml.feature_importance`.
+
+NOTE: The number of feature importance values for each document might be less
+than the `num_top_feature_importance_values` property value. For example, it
+returns only features had a positive or negative effect on the prediction.
+
 end::feature-importance[]


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/52246

This PR augments the description of feature importance in the classification and regression overview pages.

It also removes unnecessary "discrete" attributes so that we get links in the top right navigation for these long overview pages.

Preview:
* http://stack-docs_881.docs-preview.app.elstc.co/guide/en/machine-learning/master/dfa-classification.html#dfa-classification-feature-importance
* http://stack-docs_881.docs-preview.app.elstc.co/guide/en/machine-learning/master/dfa-regression.html#dfa-regression-feature-importance