### PR TITLE
[Docs][SIEM] Add https requirement to detections

### DIFF
--- a/docs/en/siem/detection-engine-intro.asciidoc
+++ b/docs/en/siem/detection-engine-intro.asciidoc
@@ -85,6 +85,7 @@ To investigate a signal in the Timeline, click the *View in timeline* icon.
 
 If you are using an *on-premises* {stack} deployment:
 
+* HTTPS must be configured for {ref}/encrypting-communications.html[{es}] and {kibana-ref}/configuring-tls.html[{kib}].
 * In the `elasticsearch.yml` configuration file, set the 
 `xpack.security.enabled` setting to `true`. For more information, see 
 {ref}/settings.html[Configuring {es}] and

--- a/docs/en/siem/detection-engine-intro.asciidoc
+++ b/docs/en/siem/detection-engine-intro.asciidoc
@@ -85,7 +85,8 @@ To investigate a signal in the Timeline, click the *View in timeline* icon.
 
 If you are using an *on-premises* {stack} deployment:
 
-* HTTPS must be configured for {ref}/encrypting-communications.html[{es}] and {kibana-ref}/configuring-tls.html[{kib}].
+* HTTPS must be configured for communication between
+{kibana-ref}/configuring-tls.html#configuring-tls-kib-es[{es} and {kib}].
 * In the `elasticsearch.yml` configuration file, set the 
 `xpack.security.enabled` setting to `true`. For more information, see 
 {ref}/settings.html[Configuring {es}] and


### PR DESCRIPTION
Adds HTTPS as a Detections requirement.

[Preview](http://stack-docs_882.docs-preview.app.elstc.co/guide/en/siem/guide/master/detection-engine-overview.html#detections-permissions) 