### PR TITLE
[7.6] [Docs][SIEM] Add https requirement to detections (#882)

### DIFF
--- a/docs/en/siem/detection-engine-intro.asciidoc
+++ b/docs/en/siem/detection-engine-intro.asciidoc
@@ -85,6 +85,8 @@ To investigate a signal in the Timeline, click the *View in timeline* icon.
 
 If you are using an *on-premises* {stack} deployment:
 
+* HTTPS must be configured for communication between
+{kibana-ref}/configuring-tls.html#configuring-tls-kib-es[{es} and {kib}].
 * In the `elasticsearch.yml` configuration file, set the 
 `xpack.security.enabled` setting to `true`. For more information, see 
 {ref}/settings.html[Configuring {es}] and


### PR DESCRIPTION
Backports the following commits to 7.6:
 - [Docs][SIEM] Add https requirement to detections (#882)