### PR TITLE
[DOCS] Adds influencer to Stack glossary

### DIFF
--- a/docs/en/glossary/glossary.asciidoc
+++ b/docs/en/glossary/glossary.asciidoc
@@ -373,6 +373,15 @@ order to index <<glossary-event,event>> data.
 +
 //Source: Logstash
 endif::logstash-terms[]
+ifdef::xpack-terms[]
+[[glossary-influencer]] influencer ::
+
+Influencers are fields that affect whether a bucket is anomalous in an
+<<glossary-anomaly-detection-job,{anomaly-job}>>. For more information, see
+{ml-docs}/ml-influencers.html[Influencers].
++
+//Source: X-Pack
+endif::xpack-terms[]
 ifdef::logstash-terms[]
 
 [[glossary-input-plugin]] input plugin ::

--- a/docs/en/glossary/glossary.asciidoc
+++ b/docs/en/glossary/glossary.asciidoc
@@ -76,14 +76,14 @@ ifdef::xpack-terms[]
 
 [[glossary-ml-bucket]] bucket ::
 
-The {ml-features} use the concept of a bucket to divide the time
-series into batches for processing. The _bucket span_ is part of the
-configuration information for {anomaly-jobs}. It defines the time interval that is used
-to summarize and model the data. This is typically between 5 minutes to 1 hour
-and it depends on your data characteristics. When you set the bucket span,
-take into account the granularity at which you want to analyze, the frequency
-of the input data, the typical duration of the anomalies, and the frequency at
-which alerting is required.
+The {ml-features} use the concept of a bucket to divide the time series into
+batches for processing. The _bucket span_ is part of the configuration
+information for {anomaly-jobs}. It defines the time interval that is used to
+summarize and model the data. This is typically between 5 minutes to 1 hour and
+it depends on your data characteristics. When you set the bucket span, take into
+account the granularity at which you want to analyze, the frequency of the input
+data, the typical duration of the anomalies, and the frequency at which alerting
+is required.
 +
 //Source: X-Pack
 endif::xpack-terms[]
@@ -191,9 +191,9 @@ ifdef::xpack-terms[]
 
 [[glossary-ml-datafeed]] datafeed ::
 
-{anomaly-jobs-cap} can analyze either a one-off batch of data or
-continuously in real time. {dfeeds-cap} retrieve data from {es} for analysis.
-Alternatively you can post data from any source directly to a {ml} API.
+{anomaly-jobs-cap} can analyze either a one-off batch of data or continuously in
+real time. {dfeeds-cap} retrieve data from {es} for analysis. Alternatively, you
+can post data from any source directly to a {ml} API.
 +
 //Source: X-Pack
 endif::xpack-terms[]
@@ -212,9 +212,9 @@ ifdef::xpack-terms[]
 [[glossary-ml-detector]] detector ::
 
 As part of the configuration information that is associated with {anomaly-jobs},
-detectors define the type of analysis that needs to be done. They
-also specify which fields to analyze. You can have more than one detector in a
-job, which is more efficient than running multiple jobs against the same data.
+detectors define the type of analysis that needs to be done. They also specify
+which fields to analyze. You can have more than one detector in a job, which is
+more efficient than running multiple jobs against the same data.
 +
 //Source: X-Pack
 endif::xpack-terms[]
@@ -376,8 +376,8 @@ endif::logstash-terms[]
 ifdef::xpack-terms[]
 [[glossary-influencer]] influencer ::
 
-Influencers are fields that affect whether a bucket is anomalous in an
-<<glossary-anomaly-detection-job,{anomaly-job}>>. For more information, see
+Influencers are entities that might have contributed to an anomaly in a specific
+bucket in an {anomaly-job}. For more information, see
 {ml-docs}/ml-influencers.html[Influencers].
 +
 //Source: X-Pack

--- a/docs/en/stack/ml/anomaly-detection/influencers.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/influencers.asciidoc
@@ -43,9 +43,12 @@ can be overwhelming and there is a small overhead to the analysis.
 ==== Influencer results
 
 The influencer results show which entities were anomalous and when. One
-influencer result is written per bucket for each influencer that is considered
-anomalous. For jobs with more than one detector, these scores provide a powerful
-view of the most anomalous entities.
+influencer result is written per bucket for each influencer that affects the
+anomalousness of the bucket. The {ml} analytics determine the impact of an
+influencer by performing a series of experiments that remove all data points
+with a specific influencer value and check whether the bucket is still anomalous.
+For jobs with more than one detector, influencer scores provide a powerful view
+of the most anomalous entities.
 
 For example, the `high_sum_total_sales` {anomaly-job} for the eCommerce orders
 sample data uses `customer_full_name.keyword` and `category.keyword` as


### PR DESCRIPTION
This PR adds "influencer" to the Elastic Stack glossary (https://www.elastic.co/guide/en/elastic-stack-glossary/current/terms.html). It also adds an additional sentence to the influencer overview in the Machine learning documentation (https://www.elastic.co/guide/en/machine-learning/current/ml-influencers.html). 

It also wraps some existing glossary entries to align with typical line lengths.