### PR TITLE
[DOCS] Adds feature influence and importance to Glossary

### DIFF
--- a/docs/en/glossary/glossary.asciidoc
+++ b/docs/en/glossary/glossary.asciidoc
@@ -255,6 +255,27 @@ passed through the Logstash <<glossary-pipeline,pipeline>>.
 +
 //Source: Logstash
 endif::logstash-terms[]
+ifdef::xpack-terms[]
+[[glossary-feature-influence]] feature influence ::
+
+In {oldetection}, feature influence scores indicate which features of a data
+point contribute to its outlier behavior. See
+{ml-docs}/dfa-outlier-detection.html#dfa-feature-influence[Feature influence].
++
+//Source: X-Pack
+endif::xpack-terms[]
+ifdef::xpack-terms[]
+[[glossary-feature-importance]] feature importance ::
+
+In supervised {ml} methods such as {regression} and {classification}, feature
+importance indicates the degree to which a specific feature affects a prediction.
+See
+{ml-docs}/dfa-regression.html#dfa-regression-feature-importance[{regression-cap} feature importance]
+and 
+{ml-docs}/dfa-classification.html#dfa-classification-feature-importance[{classification-cap} feature importance].
++
+//Source: X-Pack
+endif::xpack-terms[]
 ifdef::elasticsearch-terms,logstash-terms[]
 
 [[glossary-field]] field ::


### PR DESCRIPTION
This PR adds the terms "feature importance" and "feature influence" to the Elastic Stack Glossary (https://www.elastic.co/guide/en/elastic-stack-glossary/current/terms.html)

Preview: http://stack-docs_889.docs-preview.app.elstc.co/guide/en/elastic-stack-glossary/master/terms.html