### PR TITLE
[DOCS] Adds ML limitation for frozen indices

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/limitations.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/limitations.asciidoc
@@ -264,3 +264,14 @@ occurs.
 * If there is insufficient data to generate any meaningful predictions, an
 error occurs. In general, forecasts that are created early in the learning phase
 of the data analysis are less accurate.
+
+[float]
+[[ml-frozen-limitations]]
+=== Frozen indices are not supported
+
+{ref}/frozen-indices.html[Frozen indices] cannot be used in {anomaly-jobs} or 
+{dfeeds}. This limitation applies irrespective of whether you create the jobs in 
+{kib} or by using APIs. This limitation exists because it's currently not
+possible to specify the `ignore_throttled` query parameter for search requests
+in {dfeeds} or jobs. See
+{ref}/searching_a_frozen_index.html[Searching a frozen index].


### PR DESCRIPTION
This PR adds a limitation to the machine learning anomaly detection documentation with respect to frozen indices. 

Related to https://github.com/elastic/elasticsearch/issues/48056