### PR TITLE
[DOCS] Adds class_score to the classification example

### DIFF
--- a/docs/en/stack/ml/df-analytics/flightdata-classification.asciidoc
+++ b/docs/en/stack/ml/df-analytics/flightdata-classification.asciidoc
@@ -307,7 +307,7 @@ The snippet below shows a part of a document with the annotated results:
 ----
 <1> An array of values specifying the probability of the prediction and the 
 `class_score` for each class. The `top_classes` object contains the predicted 
-classes with the highest probability.
+classes with the highest scores.
 <2> The probability is a value between 0 and 1. The higher the number, the 
 higher the probability that the data point belongs to the named class.  In this 
 example, `false` has a `class_probability` of 0.94 while `true` has only 0.06, 

--- a/docs/en/stack/ml/df-analytics/flightdata-classification.asciidoc
+++ b/docs/en/stack/ml/df-analytics/flightdata-classification.asciidoc
@@ -291,11 +291,13 @@ The snippet below shows a part of a document with the annotated results:
           "ml" : {
             "top_classes" : [ <1>
               {
-                "class_probability" : 0.939335365058496,
+                "class_probability" : 0.939335365058496, <2>
+                "class_score" : 0.6757432490367542, <3>
                 "class_name" : "false"
               },
               {
                 "class_probability" : 0.06066463494150393,
+                "class_score" : 0.06835090015710144,
                 "class_name" : "true"
               }
             ],
@@ -303,12 +305,16 @@ The snippet below shows a part of a document with the annotated results:
             "is_training" : false
           }
 ----
-<1> An array of values specifying the probability of the prediction for each 
-class. The probability is a value between 0 and 1. The higher the number, the 
-higher the probability that the data point belongs to the named class. The 
-`top_classes` object contains the predicted classes with the highest 
-probability. In this example, `false` has a `class_probability` of 0.94 while
-`true` has only 0.06, so the prediction will be `false`.
+<1> An array of values specifying the probability of the prediction and the 
+`class_score` for each class. The `top_classes` object contains the predicted 
+classes with the highest probability.
+<2> The probability is a value between 0 and 1. The higher the number, the 
+higher the probability that the data point belongs to the named class.  In this 
+example, `false` has a `class_probability` of 0.94 while `true` has only 0.06, 
+so the prediction will be `false`.
+<3> The value of `class_score` controls the probability at which a class label 
+is assigned to a datapoint. It works as a function of probability to maximise 
+the minimum recall of any class.
 ====
 
 [[flightdata-classification-evaluate]]

--- a/docs/en/stack/ml/df-analytics/flightdata-classification.asciidoc
+++ b/docs/en/stack/ml/df-analytics/flightdata-classification.asciidoc
@@ -309,7 +309,7 @@ The snippet below shows a part of a document with the annotated results:
 `class_score` for each class. The `top_classes` object contains the predicted 
 classes with the highest scores.
 <2> The probability is a value between 0 and 1. The higher the number, the 
-higher the probability that the data point belongs to the named class.  In this 
+higher the model confident the model is that the data point belongs to the named class.  In this 
 example, `false` has a `class_probability` of 0.94 while `true` has only 0.06, 
 so the prediction will be `false`.
 <3> The value of `class_score` controls the probability at which a class label 

--- a/docs/en/stack/ml/df-analytics/flightdata-classification.asciidoc
+++ b/docs/en/stack/ml/df-analytics/flightdata-classification.asciidoc
@@ -308,12 +308,12 @@ The snippet below shows a part of a document with the annotated results:
 <1> An array of values specifying the probability of the prediction and the 
 `class_score` for each class. The `top_classes` object contains the predicted 
 classes with the highest scores.
-<2> The probability is a value between 0 and 1. The higher the number, the 
-higher the model confident the model is that the data point belongs to the named class.  In this 
+<2> The probability is a value between 0 and 1. The higher the number, the more 
+confident the model is that the data point belongs to the named class.  In this 
 example, `false` has a `class_probability` of 0.94 while `true` has only 0.06, 
 so the prediction will be `false`.
-<3> The value of `class_score` controls the probability at which a class label 
-is assigned to a datapoint. It works as a function of probability to maximise 
+<3> The `class_score` is a function of the probability. It is chosen so that the 
+decision to assign the datapoint to the class with the highest score maximises 
 the minimum recall of any class.
 ====
 


### PR DESCRIPTION
Adds `class_score` and its short explanation to the API response in the example.