### PR TITLE
[DOCS] Adds ML related blog posts to the anomaly detection examples page

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/examples.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/examples.asciidoc
@@ -19,6 +19,26 @@ The scenarios in this section describe some best practices for generating useful
 * <<ml-configuring-transform>>
 * <<ml-delayed-data-detection>>
 
+[discrete]
+[[anomaly-examples-blog-posts]]
+=== {anomaly-detect-cap} examples in blog posts
+
+The blog posts listed below show how to get the most out of Elastic {ml} 
+{anomaly-detect}.
+
+* https://www.elastic.co/blog/sizing-machine-learning-with-elasticsearch[Sizing for {ml} with {es}]
+* https://www.elastic.co/blog/filtering-input-data-to-refine-machine-learning-jobs[Filtering input data to refine {ml-jobs}]
+* https://www.elastic.co/blog/temporal-vs-population-analysis-in-elastic-machine-learning[Temporal vs. population analysis in Elastic {ml}]
+* https://www.elastic.co/blog/using-elasticsearch-and-machine-learning-for-it-operations[Using {es} and {ml} for IT Operations]
+* https://www.elastic.co/blog/using-machine-learning-and-elasticsearch-for-security-analytics-deep-dive[Using {ml} and {es} for security analytics]
+* https://www.elastic.co/blog/augmenting-results-with-user-annotations-for-elastic-machine-learning[User annotations for Elastic {ml}]
+* https://www.elastic.co/blog/custom-elasticsearch-aggregations-for-machine-learning-jobs[Custom {es} aggregations for {ml-jobs}]
+* https://www.elastic.co/blog/analysing-linux-auditd-anomalies-with-auditbeat-and-elastic-stack-machine-learning[Analysing Linux auditd anomalies with Auditbeat and {ml}]
+* https://www.elastic.co/blog/how-to-optimize-elasticsearch-machine-learning-job-configurations-using-job-validation[How to optimize {es} {ml} job configurations using job validation]
+* https://www.elastic.co/blog/interpretability-in-ml-identifying-anomalies-influencers-root-causes[Interpretability in {ml}: Identifying anomalies, influencers, and root causes]
+
+
+
 include::{es-repo-dir}/ml/anomaly-detection/customurl.asciidoc[]
 
 include::{es-repo-dir}/ml/anomaly-detection/aggregations.asciidoc[]


### PR DESCRIPTION
This PR adds URLs of ML related blog posts to the anomaly detection example page.

Preview: http://stack-docs_905.docs-preview.app.elstc.co/guide/en/machine-learning/master/anomaly-examples.html