### PR TITLE
[Docs][SIEM]Removes winlogbeat from the suspicious_login_activity_ecs ml job description

### DIFF
--- a/docs/en/siem/machine-learning.asciidoc
+++ b/docs/en/siem/machine-learning.asciidoc
@@ -273,8 +273,7 @@ authentication attempts.
 +
 Beats required on hosts:
 
-* Auditbeat (Windows and Linux)
-* Winlogbeat (Windows)
+* Auditbeat (Linux)
 
 +
 Required ECS fields:


### PR DESCRIPTION
Winlogbeat was incorrectly listed in the suspicious_login_activity_ecs job description.

[Preview](http://stack-docs_908.docs-preview.app.elstc.co/guide/en/siem/guide/master/prebuilt-ml-jobs.html) 