### PR TITLE
[7.6] corrects tuning prebuilt rules section title (#910)

### DIFF
--- a/docs/en/siem/tune-rule-signals.asciidoc
+++ b/docs/en/siem/tune-rule-signals.asciidoc
@@ -1,8 +1,8 @@
 [[tuning-detection-signals]]
-== Tuning detection rules
+== Tuning prebuilt detection rules
 
-In the {siem-app}, detection rules can be tuned to produce the best possible
-set of actionable signals. To reduce the noise level, you can:
+In the {siem-app}, prebuilt detection rules can be tuned to produce the best
+possible set of actionable signals. To reduce the noise level, you can:
 
 * Disable detection rules that rarely produce actionable signals because they 
 match local expected behavior, workflows, or policy exceptions.
@@ -12,7 +12,7 @@ actionable signals.
 * Clone and modify detection rule risk scores, and use branching logic to map 
 higher risk scores to higher priority workflows.
 
-For details about tuning rules for specific categories, see:
+For details about tuning prebuilt rules for specific categories, see:
 
 * <<tune-authorized-processes>>
 * <<tune-windows-rules>>


### PR DESCRIPTION
Backports the following commits to 7.6:
 - corrects tuning prebuilt rules section title (#910)