### PR TITLE
[7.6] removes winlogbeat from linux ml job (#908)

### DIFF
--- a/docs/en/siem/machine-learning.asciidoc
+++ b/docs/en/siem/machine-learning.asciidoc
@@ -273,8 +273,7 @@ authentication attempts.
 +
 Beats required on hosts:
 
-* Auditbeat (Windows and Linux)
-* Winlogbeat (Windows)
+* Auditbeat (Linux)
 
 +
 Required ECS fields:


### PR DESCRIPTION
Backports the following commits to 7.6:
 - removes winlogbeat from linux ml job (#908)