### PR TITLE
[DOCS] Adds ML related blog posts to the DFA examples page

### DIFF
--- a/docs/en/stack/ml/df-analytics/examples.asciidoc
+++ b/docs/en/stack/ml/df-analytics/examples.asciidoc
@@ -31,9 +31,6 @@ The blog posts listed below show how to get the most out of Elastic {ml}
 * https://www.elastic.co/blog/multilingual-search-using-language-identification-in-elasticsearch[Multilingual search using language identification in {es}]
 
 
-
-
-
 include::ecommerce-outliers.asciidoc[]
 
 include::flightdata-regression.asciidoc[]

--- a/docs/en/stack/ml/df-analytics/examples.asciidoc
+++ b/docs/en/stack/ml/df-analytics/examples.asciidoc
@@ -19,7 +19,25 @@ from your data.
 * <<ml-lang-ident>>
 
 
+[discrete]
+[[dfanalytics-examples-blog-posts]]
+=== {dfanalytics-cap} examples in blog posts
+
+The blog posts listed below show how to get the most out of Elastic {ml} 
+{dfanalytics}.
+
+* https://www.elastic.co/blog/catching-malware-with-elastic-outlier-detection[Catching malware with Elastic {oldetection}]
+* https://www.elastic.co/blog/benchmarking-outlier-detection-in-elastic-machine-learning[Benchmarking {oldetection} results in Elastic {ml}]
+* https://www.elastic.co/blog/multilingual-search-using-language-identification-in-elasticsearch[Multilingual search using language identification in {es}]
+
+
+
+
+
 include::ecommerce-outliers.asciidoc[]
+
 include::flightdata-regression.asciidoc[]
+
 include::flightdata-classification.asciidoc[]
+
 include::ml-lang-ident.asciidoc[]


### PR DESCRIPTION
This PR adds URLs of ML related blog posts to the data frame analytics example page.

Preview: http://stack-docs_916.docs-preview.app.elstc.co/guide/en/machine-learning/master/dfanalytics-examples.html