### PR TITLE
[ML] adding multi-field limitation for inference + analytics

### DIFF
--- a/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
@@ -140,14 +140,14 @@ only selecting fields that are relevant for analysis.
 [[dfa-inference-multi-field]]
 === Analytics training on multi-field values may affect {infer}
 
-{dfanalytics-jobs-cap} will dynamically select the best field when multi-field
-values are included. This means that if a multi-field `foo` is included for training,
-the `foo.keyword` is actually used instead. This poses a complication for {infer} with
+{dfanalytics-jobs-cap} dynamically select the best field when multi-field
+values are included. For example, if a multi-field `foo` is included for training,
+the `foo.keyword` is actually used. This poses a complication for {infer} with
 the inference processor. Documents supplied to ingest pipelines are not mapped. Consequently,
 only the field `foo` is present. This means that a model trained with the field `foo.keyword`
-will not take the field `foo` into account.
+does not take the field `foo` into account.
 
-A work around is by using the `field_mappings` parameter in the inference processor.
+You can work around this limitation by using the `field_mappings` parameter in the inference processor.
 
 Example:
 ```

--- a/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
@@ -135,3 +135,29 @@ If a reduction in runtime is important to you, try strategies such as disabling
 feature importance, using a smaller {transform}, setting 
 {ref}/put-dfanalytics.html#ml-hyperparam-optimization[hyperparameter] values, or 
 only selecting fields that are relevant for analysis.
+
+[float]
+[[dfa-inference-multi-field]]
+=== Analytics training on multi-field values may affect {infer}
+
+{dfanalytics-jobs-cap} will dynamically select the best field when multi-field
+values are included. This means that if a multi-field `foo` is included for training,
+the `foo.keyword` is actually used instead. This poses a complication for {infer} with
+the inference processor. Documents supplied to ingest pipelines are not mapped. Consequently,
+only the field `foo` is present. This means that a model trained with the field `foo.keyword`
+will not take the field `foo` into account.
+
+A work around is by using the `field_mappings` parameter in the inference processor.
+
+Example:
+```
+{
+  "inference": {
+    "model_id": "my_model_with_multi-fields",
+    "field_mappings": {
+      "foo": "foo.keyword"
+    },
+    "inference_config": { "regression": {} }
+  }
+}
+```


### PR DESCRIPTION
Adds limitation to data frame analytics explaining training on multi-field fields and how that affects inference.

Preview: http://stack-docs_920.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-dfa-limitations.html