### PR TITLE
[DOCS] Changes field_mappings to field_map in lang ident example

### DIFF
--- a/docs/en/stack/ml/df-analytics/ml-lang-ident.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-lang-ident.asciidoc
@@ -100,7 +100,7 @@ POST _ingest/pipeline/_simulate
                      "num_top_classes":5 <2>
                   }
                },
-               "field_mappings":{
+               "field_map":{
 
                }
             }


### PR DESCRIPTION
This PR changes the `field_mappings` resource name to `field_map` in the language identification example.

Related PR: https://github.com/elastic/elasticsearch/pull/53433