### PR TITLE
[DOCS] Adds tags to the sections about the used algorithms of the different DFA types

### DIFF
--- a/docs/en/stack/ml/df-analytics/dfa-classification.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-classification.asciidoc
@@ -60,10 +60,12 @@ otherwise the {classanalysis} may not provide the best predictions. Read
 [[dfa-classification-algorithm]]
 ===== {classification-cap} algorithms
 
-The ensemble algorithm that we use in the {stack} is a type of boosting called 
-boosted tree regression model which combines multiple weak models into a 
-composite one. We use decision trees to learn to predict the probability that 
-a data point belongs to a certain class.
+//tag::classification-algorithms[]
+The ensemble algorithm that we use in the {stack} for {classification} is a type 
+of boosting called boosted tree regression model which combines multiple weak 
+models into a composite one. We use decision trees to learn to predict the 
+probability that a data point belongs to a certain class.
+//end::classification-algorithms[]
 
 
 [discrete]

--- a/docs/en/stack/ml/df-analytics/dfa-outlierdetection.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-outlierdetection.asciidoc
@@ -20,8 +20,17 @@ You can create {oldetection} {dfanalytics-jobs} in {kib} or by using the
 [[dfa-outlier-algorithms]]
 ==== {oldetection-cap} algorithms
 
+//tag::outlier-detection-algorithms[]
 In the {stack}, we use an ensemble of four different distance and density based 
-{oldetection} methods. By default, you don't need to select the methods or 
+{oldetection} methods:
+
+* distance of K^th^ nearest neighbor
+* distance of K-nearest neighbors
+* local outlier factor (`lof`)
+* local distance-based outlier factor (`ldof`).
+//end::outlier-detection-algorithms[]
+
+By default, you don't need to select the methods or 
 provide any parameters, but you can override the default behavior if you like. 
 The basic assumption of the **distance based methods** is that normal data 
 points – in other words, points that are not outliers – have a lot of neighbors 

--- a/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
@@ -81,9 +81,12 @@ you must restart the {dfanalytics-job}.
 [[dfa-regression-algorithm]]
 ===== {regression-cap} algorithms
 
+//tag::regression-algorithms[]
 The ensemble learning technique that we use in the {stack} is a type of boosting 
 called extreme gradient boost (XGboost) which combines decision trees with 
 gradient boosting methodologies.
+//end::regression-algorithms[]
+
 
 [discrete]
 [[dfa-regression-feature-importance]]


### PR DESCRIPTION
This PR appends tags to the algorithm description sections of the different data frame analytics types. These tags will make it easier to re-use the information in another context via single-sourcing.

Preview: 
* outlier detection: http://stack-docs_941.docs-preview.app.elstc.co/guide/en/machine-learning/master/dfa-outlier-detection.html
* classification: http://stack-docs_941.docs-preview.app.elstc.co/guide/en/machine-learning/master/dfa-classification.html