### PR TITLE
[7.x] fixes rules privileges example and typo (#947)

### DIFF
--- a/docs/en/siem/privileges-api-overview.asciidoc
+++ b/docs/en/siem/privileges-api-overview.asciidoc
@@ -30,7 +30,7 @@ Gets user privileges the the {kib} `siem` space:
 
 [source,console]
 --------------------------------------------------
-GET s/siem/api/detection_engine/index
+GET s/siem/api/detection_engine/privileges
 --------------------------------------------------
 // KIBANA
 

--- a/docs/en/siem/rules-api-create.asciidoc
+++ b/docs/en/siem/rules-api-create.asciidoc
@@ -42,7 +42,7 @@ is converted from a third-party security solution. |No, automatically created
 when it is not provided.
 
 |index |String[] |Indices on which the rule functions. |No, defaults to the 
-{siem-soln} indices defined on the {kib} Advanced Setting page (*Kibana* → 
+{siem-soln} indices defined on the {kib} Advanced Settings page (*Kibana* → 
 *Management* → *Advanced Settings* → `siem:defaultIndex`).
 
 |interval |String |Frequency of rule execution, using a

--- a/docs/en/siem/rules-api-update.asciidoc
+++ b/docs/en/siem/rules-api-update.asciidoc
@@ -53,7 +53,7 @@ time. |No, defaults to `now-6m` (analyzes data from 6 minutes before the start
 time).
 
 |index |String[] |Indices on which the rule functions. |No, defaults to the
-{siem-soln} indices defined on the {kib} Advanced Setting page (*Kibana* → 
+{siem-soln} indices defined on the {kib} Advanced Settings page (*Kibana* → 
 *Management* → *Advanced Settings* → `siem:defaultIndex`).
 
 |interval |String |Frequency of rule execution, using a


### PR DESCRIPTION
Backports the following commits to 7.x:
 - fixes rules privileges example and typo (#947)