### PR TITLE
[Docs][SIEM] 7.7 timeline and reputation link updates

### DIFF
--- a/docs/en/siem/rules-ui-create.asciidoc
+++ b/docs/en/siem/rules-ui-create.asciidoc
@@ -186,7 +186,7 @@ required action from the `Batch actions` menu.
 .. Click *Import rule*.
 .. Drag-and-drop files containing the signal detection rules.
 +
-NOTE: Imported rules must be in an `ndjson` file.
+NOTE: Imported rules must be in a `ndjson` file.
 
 . To export rules:
 .. In the *All rules* table, select the rules you want to export.

--- a/docs/en/siem/rules-ui-create.asciidoc
+++ b/docs/en/siem/rules-ui-create.asciidoc
@@ -186,7 +186,7 @@ required action from the `Batch actions` menu.
 .. Click *Import rule*.
 .. Drag-and-drop files containing the signal detection rules.
 +
-NOTE: Imported rules must be in a `ndjson` file.
+NOTE: Imported rules must be in an `ndjson` file.
 
 . To export rules:
 .. In the *All rules* table, select the rules you want to export.

--- a/docs/en/siem/siem-ui.asciidoc
+++ b/docs/en/siem/siem-ui.asciidoc
@@ -292,7 +292,7 @@ http://ndjson.org[`ndjson`] file.
 * To export one timeline, click the more actions icon in the relevant row and
 then select _Export selected_.
 * To export multiple timelines, select all the required timelines and then click
-*Batch actions* -> _Export selected_.
+*Bulk actions* -> _Export selected_.
 
 . To import timelines, click *Import Timeline* and then select or drap-and-drop
 the timeline `ndjson` file.

--- a/docs/en/siem/siem-ui.asciidoc
+++ b/docs/en/siem/siem-ui.asciidoc
@@ -257,6 +257,25 @@ event. If you see a particular item that interests you, you can drag it to the
 drop area for further introspection.
 
 [float]
+[[import-export-timelines]]
+==== Export and import timelines
+
+You can import and export timelines, which enables importing timelines from one
+{kib} space or instance to another. Exported timelines are saved in an
+http://ndjson.org[`ndjson`] file.
+
+. Go to *SIEM* -> *Timelines*.
+. To export timelines, do one of the following:
+
+* To export one timeline, click the more actions icon in the relevant row and
+then select _Export selected_.
+* To export multiple timelines, select all the required timelines and then click
+*Batch actions* -> _Export selected_.
+
+. To import timelines, click *Import Timeline* and then select or drap-and-drop
+the timeline `ndjson` file.
+
+[float]
 [[other]]
 ==== Other actions
 

--- a/docs/en/siem/siem-ui.asciidoc
+++ b/docs/en/siem/siem-ui.asciidoc
@@ -106,7 +106,7 @@ There are also tabs for viewing and investigating specific types of data:
 external monitoring tools, such as Elastic Endpoint Security
 
 
-*Host details* shows information for a selected host, including
+*Host detail* pages show information for a selected host, including
 Host ID, First Seen timestamp, Last Seen timestamp, IP and MAC addresses, OS,
 versions, machine type, and so forth. Additionally, it contains all the widgets
 and tabs relevant for the selected host.
@@ -141,6 +141,28 @@ There are also tabs for viewing and investigating specific types of data:
 * Anomalies: anomalies discovered by <<machine-learning, machine learning jobs>>
 * <<det-engine-terminology, External alerts>>: alerts received from
 external monitoring tools, such as Elastic Endpoint Security
+
+*IP detail* pages show information for the selected IP address, including
+links to external sites for verifying the IP address's reputation. By default,
+the external sites are https://talosintelligence.com/[TALOS] and
+https://www.virustotal.com/[VIRUSTOTAL]. You can change the displayed
+reputation links in *{kib}* -> *Management* -> *Advanced Settings* ->
+*`siem:ipReputationLinks`*. The `siem:ipReputationLinks` setting contains a
+JSON array with these fields:
+
+* `name`: UI display name.
+* `url_template`: URL of the link. It can include `{{ip}}`, which is placeholder for the IP address you are viewing on the details page.
+
+For example:
+
+[source,json]
+--------------------------------------------------
+[
+  { "name": "virustotal.com", "url_template": "https://www.virustotal.com/gui/search/{{ip}}" },
+  { "name": "dnschecker.org", "url_template": "https://www.dnschecker.org/ip-location.php?ip={{ip}}" },
+  { "name": "talosIntelligence.com", "url_template": "https://talosintelligence.com/reputation_center/lookup?search={{ip}}" }
+]
+--------------------------------------------------
 
 [float]
 [[map-ui]]


### PR DESCRIPTION
Adds info about importing/exporting timelines and configuring displayed reputation links on IP detail pages.

[Timeline preview](http://stack-docs_981.docs-preview.app.elstc.co/guide/en/siem/guide/master/siem-ui-overview.html#import-export-timelines)
[Reputation links preview](http://stack-docs_981.docs-preview.app.elstc.co/guide/en/siem/guide/master/siem-ui-overview.html#network-ui)