### PR TITLE
[DOCS] Uncomments Kibana release highlights

### DIFF
--- a/docs/en/install-upgrade/highlights.asciidoc
+++ b/docs/en/install-upgrade/highlights.asciidoc
@@ -65,10 +65,8 @@ coming::[7.7.0]
 
 This list summarizes the most important enhancements in {kib} {version}.
 
-////
 :leveloffset: +1
 
-include::{kib-repo-dir}/release-notes/highlights-7.3.0.asciidoc[tag=notable-highlights]
+include::{kib-repo-dir}/release-notes/highlights-7.7.0.asciidoc[tag=notable-highlights]
 
 :leveloffset: -1
-////

--- a/docs/en/install-upgrade/highlights.asciidoc
+++ b/docs/en/install-upgrade/highlights.asciidoc
@@ -61,8 +61,6 @@ include::{es-repo-dir}/reference/release-notes/highlights-7.7.0.asciidoc[tag=not
 <titleabbrev>{kib}</titleabbrev>
 ++++
 
-coming::[7.7.0]
-
 This list summarizes the most important enhancements in {kib} {version}.
 
 :leveloffset: +1


### PR DESCRIPTION
Related to https://github.com/elastic/kibana/pull/63748

This PR uncomments the Kibana 7.7.0 release highlights in the Installation and Upgrade Guide.

Preview: http://stack-docs_995.docs-preview.app.elstc.co/guide/en/elastic-stack/7.7/kibana-higlights.html