### PR TITLE
[DOCS] Adds limitation item about inference trained model backward compatibility

### DIFF
--- a/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
@@ -164,8 +164,8 @@ Example:
 
 [float]
 [[dfa-inference-bwc]]
-=== {infer-cap} trained models created in 7.8 are not compatible backwards
+=== {infer-cap} trained models created in 7.8 are not backwards compatible
 
 Inference models created in version 7.8.0 are not backwards compatible with 
 older node versions. In a mixed cluster environment, all nodes must be at 
-least 7.8.0 to use a model stored by a 7.8.0 node.
+least 7.8.0 to use a model created on a 7.8.0 node.

--- a/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
@@ -161,3 +161,11 @@ Example:
   }
 }
 ```
+
+[float]
+[[dfa-inference-bwc]]
+=== {infer-cap} trained models created in 7.8 are not compatible backwards
+
+Inference models created in version 7.8.0 are not backwards compatible with 
+older node versions. In a mixed cluster environment, all nodes must be at 
+least 7.8.0 to use a model stored by a 7.8.0 node.


### PR DESCRIPTION
## Overview

This PR adds a new limitation item to the DFA limitations list about the backward compatibility of the inference trained models created in 7.8.0.

## Dependency note

Merge this PR only after https://github.com/elastic/elasticsearch/pull/55260 merged.