### PR TITLE
[Docs][SIEM]Corrects required detections privileges

### DIFF
--- a/docs/en/siem/detection-engine-intro.asciidoc
+++ b/docs/en/siem/detection-engine-intro.asciidoc
@@ -142,8 +142,8 @@ when you try to open the *Detections* page.
 If you see this message, a user with these privileges must visit the 
 *Detections* page before you can view signals and rules:
 
-* The `manage` cluster privilege (see {ref}/security-privileges.html#security-privileges.html[{es} security privileges]).
-* The `create_index` index privilege (see {ref}/security-privileges.html#security-privileges.html[{es} security privileges]).
+* The `manage` cluster privilege (see {ref}/security-privileges.html[{es} security privileges]).
+* The `create_index` index privilege (see {ref}/security-privileges.html[{es} security privileges]).
 * {kib} space `All` privileges for the `SIEM` feature (see
 {kibana-ref}/xpack-spaces.html#spaces-control-user-access[Feature access based on user privileges]).
 

--- a/docs/en/siem/detection-engine-intro.asciidoc
+++ b/docs/en/siem/detection-engine-intro.asciidoc
@@ -142,8 +142,8 @@ when you try to open the *Detections* page.
 If you see this message, a user with these privileges must visit the 
 *Detections* page before you can view signals and rules:
 
-* The `manage` cluster privilege (see {ref}/security-privileges.html#security-privileges.html#privileges-list-cluster[Cluster privileges]).
-* The `create_index` index privilege (see {ref}/security-privileges.html#privileges-list-indices[Indices privileges]).
+* The `manage` cluster privilege (see {ref}/security-privileges.html#security-privileges.html[{es} security privileges]).
+* The `create_index` index privilege (see {ref}/security-privileges.html#security-privileges.html[{es} security privileges]).
 * {kib} space `All` privileges for the `SIEM` feature (see
 {kibana-ref}/xpack-spaces.html#spaces-control-user-access[Feature access based on user privileges]).
 

--- a/docs/en/siem/detection-engine-intro.asciidoc
+++ b/docs/en/siem/detection-engine-intro.asciidoc
@@ -142,7 +142,8 @@ when you try to open the *Detections* page.
 If you see this message, a user with these privileges must visit the 
 *Detections* page before you can view signals and rules:
 
-* The `create_index` privilege for the {kib} space (see {ref}/security-privileges.html#privileges-list-indices[Indices privileges]).
+* The `manage` cluster privilege (see {ref}/security-privileges.html#security-privileges.html#privileges-list-cluster[Cluster privileges]).
+* The `create_index` index privilege (see {ref}/security-privileges.html#privileges-list-indices[Indices privileges]).
 * {kib} space `All` privileges for the `SIEM` feature (see
 {kibana-ref}/xpack-spaces.html#spaces-control-user-access[Feature access based on user privileges]).
 


### PR DESCRIPTION
Adds the `manage` cluster privilege, required when visiting Detections for the first time.

[Preview](http://stack-docs_1003.docs-preview.app.elstc.co/guide/en/siem/guide/master/detection-engine-overview.html#_resolve_ui_error_messages)