### PR TITLE
[7.7] [Docs][SIEM]Corrects required detections privileges (#1003)

### DIFF
--- a/docs/en/siem/detection-engine-intro.asciidoc
+++ b/docs/en/siem/detection-engine-intro.asciidoc
@@ -142,7 +142,8 @@ when you try to open the *Detections* page.
 If you see this message, a user with these privileges must visit the 
 *Detections* page before you can view signals and rules:
 
-* The `create_index` privilege for the {kib} space (see {ref}/security-privileges.html#privileges-list-indices[Indices privileges]).
+* The `manage` cluster privilege (see {ref}/security-privileges.html[{es} security privileges]).
+* The `create_index` index privilege (see {ref}/security-privileges.html[{es} security privileges]).
 * {kib} space `All` privileges for the `SIEM` feature (see
 {kibana-ref}/xpack-spaces.html#spaces-control-user-access[Feature access based on user privileges]).
 


### PR DESCRIPTION
Backports the following commits to 7.7:
 - [Docs][SIEM]Corrects required detections privileges (#1003)