### PR TITLE
[7.7] adds link to postman collection example (#1034)

### DIFF
--- a/docs/en/siem/rules-api-overview.asciidoc
+++ b/docs/en/siem/rules-api-overview.asciidoc
@@ -36,6 +36,9 @@ path component to its URL.
 {kibana-ref}/development-basepath.html[Considerations for basePath] describes 
 how to work with and disable the random path component.
 
+TIP: You can view and download a Detections API Postman collection
+https://github.com/elastic/examples/tree/master/Security%20Analytics/SIEM-examples/Detections-API[here].
+
 [float]
 === {kib} space API calls
 


### PR DESCRIPTION
Backports the following commits to 7.7:
 - adds link to postman collection example (#1034)