### PR TITLE
[DOCS] Expands the analyzing phase with the analysis specific sub-phases

### DIFF
--- a/docs/en/stack/ml/df-analytics/ml-dfa-phases.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-phases.asciidoc
@@ -7,7 +7,7 @@ cycle, it goes through four main phases:
 
 * reindexing,
 * loading data,
-* analyzing (the sub-phases of this phase are depends on the type of 
+* analyzing,
   {dfanalytics} that you run),
 * writing results.
 
@@ -50,7 +50,7 @@ In this phase, the job generates a {ml} model for analyzing the dataset.
 [discrete]
 ===== {oldetection-cap}
 
-{oldetection-cap} has one sub-phase during analyzing that called 
+{oldetection-cap} jobs have a single analysis phase called `computing_outliers`, in which they identify outliers in the data. 
 `computing_outliers`. This is the phase when the {oldetection} analysis 
 identifies outliers in the loaded data.
 
@@ -58,10 +58,10 @@ identifies outliers in the loaded data.
 [discrete]
 ===== {regression-cap} and {classanalysis}
 
-{regression-cap} and {classification} share the same set of sub-phases. There 
+{regression-cap} and {classification} jobs have four analysis phases:
 are four of them:
 
-* `feature_selection`: In this phase, the process iterates through the available 
+. `feature_selection`: Identifies which fields are significant for the analysis 
   field set to define which fields are significant for the analysis.
 * `coarse_parameter_search`: This is the first part of 
   <<hyperparameters,hyperparameter optimization>> in which the process finds 

--- a/docs/en/stack/ml/df-analytics/ml-dfa-phases.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-phases.asciidoc
@@ -44,9 +44,8 @@ in which they identify outliers in the data.
 
 {regression-cap} and {classification} jobs have four analysis phases:
 
-. `feature_selection`: Identifies which fields are significant for the analysis 
-  field set to define which fields are significant for the analysis.
-. `coarse_parameter_search`: This is the first part of 
+. `feature_selection`: Identifies which fields are significant for the analysis. 
+. `coarse_parameter_search`: The first part of 
   <<hyperparameters,hyperparameter optimization>> in which the process finds 
   suitable values for the hyperparameters that are required to run the analysis. 
 . `fine_tuning_parameters`: After the values of hyperparameters are narrowed 

--- a/docs/en/stack/ml/df-analytics/ml-dfa-phases.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-phases.asciidoc
@@ -44,7 +44,7 @@ in which they identify outliers in the data.
 
 {regression-cap} and {classification} jobs have four analysis phases:
 
-. `feature_selection`: Identifies which fields are significant for the analysis. 
+. `feature_selection`: Identifies which of the supplied fields are most relevant for predicting the dependent variable. 
 . `coarse_parameter_search`: Identifies initial values for undefined 
   hyperparameters.
 . `fine_tuning_parameters`: Identifies final values for undefined 

--- a/docs/en/stack/ml/df-analytics/ml-dfa-phases.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-phases.asciidoc
@@ -3,11 +3,12 @@
 === How a {dfanalytics-job} works
 
 A {dfanalytics-job} is essentially a persistent {es} task. During its life 
-cycle, it goes through four phases:
+cycle, it goes through four main phases:
 
 * reindexing,
 * loading data,
-* analyzing,
+* analyzing (the sub-phases of this phase are depends on the type of 
+  {dfanalytics} that you run),
 * writing results.
 
 Let's take a look at the phases one-by-one.
@@ -29,8 +30,8 @@ Once the destination index is built, the {dfanalytics-job} task calls the {es}
 ==== Loading data
 
 After the reindexing is finished, the job fetches the needed data from the 
-destination index. It converts the data into the format that the analysis process 
-expects, then sends it to the analysis process.
+destination index. It converts the data into the format that the analysis 
+process expects, then sends it to the analysis process.
 
 
 [discrete]
@@ -38,8 +39,31 @@ expects, then sends it to the analysis process.
 
 When all the required data is loaded, the analyzing phase begins. The exact 
 process always depends on the type of {dfanalytics} – for example, 
-{classification} or {oldetection} – that is executed. This is the phase when the 
-job generates a {ml} model for analyzing the dataset.
+{classification} or {oldetection} – that is executed, you can find the 
+description of these processes below ordered by analysis type. The analyzing 
+phase is not reported in the `phase` property of the 
+{ref}/get-dfanalytics-stats.html[Get {dfanalytics-jobs} statistics API], the 
+specific sub-phases are reported instead.
+In this phase, the job generates a {ml} model for analyzing the dataset.
+
+
+[discrete]
+===== {oldetection-cap}
+
+{oldetection-cap} has one sub-phase during analyzing that called 
+`computing_outliers`.
+
+
+[discrete]
+===== {regression-cap} and {classanalysis}
+
+{regression-cap} and {classification} share the same set of sub-phases. There 
+are four of them:
+
+* `feature_selection`:
+* `coarse_parameter_search`: 
+* `fine_tuning_parameters`: 
+* `final_training`: 
 
 
 [discrete]

--- a/docs/en/stack/ml/df-analytics/ml-dfa-phases.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-phases.asciidoc
@@ -8,7 +8,6 @@ cycle, it goes through four main phases:
 * reindexing,
 * loading data,
 * analyzing,
-  {dfanalytics} that you run),
 * writing results.
 
 Let's take a look at the phases one-by-one.

--- a/docs/en/stack/ml/df-analytics/ml-dfa-phases.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-phases.asciidoc
@@ -36,40 +36,24 @@ process expects, then sends it to the analysis process.
 [discrete]
 ==== Analyzing
 
-When all the required data is loaded, the analyzing phase begins. The exact 
-process always depends on the type of {dfanalytics} – for example, 
-{classification} or {oldetection} – that is executed, you can find the 
-description of these processes below ordered by analysis type. The analyzing 
-phase is not reported in the `phase` property of the 
-{ref}/get-dfanalytics-stats.html[Get {dfanalytics-jobs} statistics API], the 
-specific sub-phases are reported instead.
-In this phase, the job generates a {ml} model for analyzing the dataset.
+In this phase, the job generates a {ml} model for analyzing the data. The 
+specific phases of analysis vary depending on the type of {dfanalytics-job}.
 
-
-[discrete]
-===== {oldetection-cap}
-
-{oldetection-cap} jobs have a single analysis phase called `computing_outliers`, in which they identify outliers in the data. 
-`computing_outliers`. This is the phase when the {oldetection} analysis 
-identifies outliers in the loaded data.
-
-
-[discrete]
-===== {regression-cap} and {classanalysis}
+{oldetection-cap} jobs have a single analysis phase called `computing_outliers`, 
+in which they identify outliers in the data.
 
 {regression-cap} and {classification} jobs have four analysis phases:
-are four of them:
 
 . `feature_selection`: Identifies which fields are significant for the analysis 
   field set to define which fields are significant for the analysis.
-* `coarse_parameter_search`: This is the first part of 
+. `coarse_parameter_search`: This is the first part of 
   <<hyperparameters,hyperparameter optimization>> in which the process finds 
   suitable values for the hyperparameters that are required to run the analysis. 
-* `fine_tuning_parameters`: After the values of hyperparameters are narrowed 
+. `fine_tuning_parameters`: After the values of hyperparameters are narrowed 
   down to a certain range in the `coarse_parameter_search` phase, the parameters 
   are further refined to an exact value in this second part of hyperparameter 
   optimization.
-* `final_training`: This is the phase where the {ml} model training takes place.
+. `final_training`: This is the phase where the {ml} model training takes place.
 
 
 [discrete]

--- a/docs/en/stack/ml/df-analytics/ml-dfa-phases.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-phases.asciidoc
@@ -48,7 +48,7 @@ in which they identify outliers in the data.
 . `coarse_parameter_search`: Identifies initial values for undefined 
   hyperparameters.
 . `fine_tuning_parameters`: Identifies final values for undefined 
-  hyperparameters. See <<hyperparameter optimization>>.
+  hyperparameters. See <<hyperparameters,hyperparameter optimization>>.
 . `final_training`: Trains the {ml} model.
 
 

--- a/docs/en/stack/ml/df-analytics/ml-dfa-phases.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-phases.asciidoc
@@ -45,13 +45,10 @@ in which they identify outliers in the data.
 {regression-cap} and {classification} jobs have four analysis phases:
 
 . `feature_selection`: Identifies which fields are significant for the analysis. 
-. `coarse_parameter_search`: Identifies initial values for undefined hyperparameters. 
-  <<hyperparameters,hyperparameter optimization>> in which the process finds 
-  suitable values for the hyperparameters that are required to run the analysis. 
-. `fine_tuning_parameters`: Identifies final values for undefined hyperparameters. See <<hyperparameter optimization>>.
-  down to a certain range in the `coarse_parameter_search` phase, the parameters 
-  are further refined to an exact value in this second part of hyperparameter 
-  optimization.
+. `coarse_parameter_search`: Identifies initial values for undefined 
+  hyperparameters.
+. `fine_tuning_parameters`: Identifies final values for undefined 
+  hyperparameters. See <<hyperparameter optimization>>.
 . `final_training`: Trains the {ml} model.
 
 

--- a/docs/en/stack/ml/df-analytics/ml-dfa-phases.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-phases.asciidoc
@@ -45,14 +45,14 @@ in which they identify outliers in the data.
 {regression-cap} and {classification} jobs have four analysis phases:
 
 . `feature_selection`: Identifies which fields are significant for the analysis. 
-. `coarse_parameter_search`: The first part of 
+. `coarse_parameter_search`: Identifies initial values for undefined hyperparameters. 
   <<hyperparameters,hyperparameter optimization>> in which the process finds 
   suitable values for the hyperparameters that are required to run the analysis. 
-. `fine_tuning_parameters`: After the values of hyperparameters are narrowed 
+. `fine_tuning_parameters`: Identifies final values for undefined hyperparameters. See <<hyperparameter optimization>>.
   down to a certain range in the `coarse_parameter_search` phase, the parameters 
   are further refined to an exact value in this second part of hyperparameter 
   optimization.
-. `final_training`: This is the phase where the {ml} model training takes place.
+. `final_training`: Trains the {ml} model.
 
 
 [discrete]

--- a/docs/en/stack/ml/df-analytics/ml-dfa-phases.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-phases.asciidoc
@@ -51,7 +51,8 @@ In this phase, the job generates a {ml} model for analyzing the dataset.
 ===== {oldetection-cap}
 
 {oldetection-cap} has one sub-phase during analyzing that called 
-`computing_outliers`.
+`computing_outliers`. This is the phase when the {oldetection} analysis 
+identifies outliers in the loaded data.
 
 
 [discrete]
@@ -60,10 +61,16 @@ In this phase, the job generates a {ml} model for analyzing the dataset.
 {regression-cap} and {classification} share the same set of sub-phases. There 
 are four of them:
 
-* `feature_selection`:
-* `coarse_parameter_search`: 
-* `fine_tuning_parameters`: 
-* `final_training`: 
+* `feature_selection`: In this phase, the process iterates through the available 
+  field set to define which fields are significant for the analysis.
+* `coarse_parameter_search`: This is the first part of 
+  <<hyperparameters,hyperparameter optimization>> in which the process finds 
+  suitable values for the hyperparameters that are required to run the analysis. 
+* `fine_tuning_parameters`: After the values of hyperparameters are narrowed 
+  down to a certain range in the `coarse_parameter_search` phase, the parameters 
+  are further refined to an exact value in this second part of hyperparameter 
+  optimization.
+* `final_training`: This is the phase where the {ml} model training takes place.
 
 
 [discrete]


### PR DESCRIPTION
## Overview

This PR amends the phase description of the DFA jobs with the analysis type-specific sub-phases of the analyzing phase.

Related PR: https://github.com/elastic/elasticsearch/pull/56107

### Preview

[How a data frame analytics job works](http://stack-docs_1038.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-dfa-phases.html)