### PR TITLE
[DOCS] Fix link to Kibana breaking changes

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -80,7 +80,7 @@ include::{hadoop-repo-dir}/appendix/breaking.adoc[tag=notable-v7-breaking-change
 There are no user-facing breaking changes in {kib} 7.7.0. For breaking changes
 in previous versions, go to {kibana-ref}/breaking-changes.html[{kib} breaking changes].
 
-//include::{kib-repo-dir}/migration/migrate_7_2.asciidoc[tag=notable-breaking-changes]
+include::{kib-repo-dir}/migration/migrate_7_7.asciidoc[tag=notable-breaking-changes]
 
 [[logstash-breaking-changes]]
 === {ls} breaking changes


### PR DESCRIPTION
This PR updates the link to the Kibana breaking changes in the Installation and Upgrade Guide.

Depends on https://github.com/elastic/kibana/pull/65591