### PR TITLE
[7.7] updates prebuilt endpoint rules look back time (#1040)

### DIFF
--- a/docs/en/siem/rule-details/adversary-behavior-detected-elastic-endpoint.asciidoc
+++ b/docs/en/siem/rule-details/adversary-behavior-detected-elastic-endpoint.asciidoc
@@ -17,7 +17,7 @@ External Alerts tab of the SIEM *Detections* page for additional information.
 
 *Runs every*: 10 minutes
 
-*Searches indices from*: now-660s ({ref}/common-options.html#date-math[Date Math format], see also <<rule-schedule, `Additional look-back time`>>)
+*Searches indices from*: now-15m ({ref}/common-options.html#date-math[Date Math format], see also <<rule-schedule, `Additional look-back time`>>)
 
 *Maximum signals per execution*: 100
 

--- a/docs/en/siem/rule-details/credential-dumping-detected-elastic-endpoint.asciidoc
+++ b/docs/en/siem/rule-details/credential-dumping-detected-elastic-endpoint.asciidoc
@@ -17,7 +17,7 @@ External Alerts tab of the SIEM *Detections* page for additional information.
 
 *Runs every*: 10 minutes
 
-*Searches indices from*: now-660s ({ref}/common-options.html#date-math[Date Math format], see also <<rule-schedule, `Additional look-back time`>>)
+*Searches indices from*: now-15m ({ref}/common-options.html#date-math[Date Math format], see also <<rule-schedule, `Additional look-back time`>>)
 
 *Maximum signals per execution*: 100
 

--- a/docs/en/siem/rule-details/credential-dumping-prevented-elastic-endpoint.asciidoc
+++ b/docs/en/siem/rule-details/credential-dumping-prevented-elastic-endpoint.asciidoc
@@ -17,7 +17,7 @@ External Alerts tab of the SIEM *Detections* page for additional information.
 
 *Runs every*: 10 minutes
 
-*Searches indices from*: now-660s ({ref}/common-options.html#date-math[Date Math format], see also <<rule-schedule, `Additional look-back time`>>)
+*Searches indices from*: now-15m ({ref}/common-options.html#date-math[Date Math format], see also <<rule-schedule, `Additional look-back time`>>)
 
 *Maximum signals per execution*: 100
 

--- a/docs/en/siem/rule-details/credential-manipulation-detected-elastic-endpoint.asciidoc
+++ b/docs/en/siem/rule-details/credential-manipulation-detected-elastic-endpoint.asciidoc
@@ -18,7 +18,7 @@ information.
 
 *Runs every*: 10 minutes
 
-*Searches indices from*: now-660s ({ref}/common-options.html#date-math[Date Math format], see also <<rule-schedule, `Additional look-back time`>>)
+*Searches indices from*: now-15m ({ref}/common-options.html#date-math[Date Math format], see also <<rule-schedule, `Additional look-back time`>>)
 
 *Maximum signals per execution*: 100
 

--- a/docs/en/siem/rule-details/credential-manipulation-prevented-elastic-endpoint.asciidoc
+++ b/docs/en/siem/rule-details/credential-manipulation-prevented-elastic-endpoint.asciidoc
@@ -18,7 +18,7 @@ information.
 
 *Runs every*: 10 minutes
 
-*Searches indices from*: now-660s ({ref}/common-options.html#date-math[Date Math format], see also <<rule-schedule, `Additional look-back time`>>)
+*Searches indices from*: now-15m ({ref}/common-options.html#date-math[Date Math format], see also <<rule-schedule, `Additional look-back time`>>)
 
 *Maximum signals per execution*: 100
 

--- a/docs/en/siem/rule-details/exploit-detected-elastic-endpoint.asciidoc
+++ b/docs/en/siem/rule-details/exploit-detected-elastic-endpoint.asciidoc
@@ -17,7 +17,7 @@ Alerts tab of the SIEM *Detections* page for additional information.
 
 *Runs every*: 10 minutes
 
-*Searches indices from*: now-660s ({ref}/common-options.html#date-math[Date Math format], see also <<rule-schedule, `Additional look-back time`>>)
+*Searches indices from*: now-15m ({ref}/common-options.html#date-math[Date Math format], see also <<rule-schedule, `Additional look-back time`>>)
 
 *Maximum signals per execution*: 100
 

--- a/docs/en/siem/rule-details/exploit-prevented-elastic-endpoint.asciidoc
+++ b/docs/en/siem/rule-details/exploit-prevented-elastic-endpoint.asciidoc
@@ -17,7 +17,7 @@ Alerts tab of the SIEM *Detections* page for additional information.
 
 *Runs every*: 10 minutes
 
-*Searches indices from*: now-660s ({ref}/common-options.html#date-math[Date Math format], see also <<rule-schedule, `Additional look-back time`>>)
+*Searches indices from*: now-15m ({ref}/common-options.html#date-math[Date Math format], see also <<rule-schedule, `Additional look-back time`>>)
 
 *Maximum signals per execution*: 100
 

--- a/docs/en/siem/rule-details/malware-detected-elastic-endpoint.asciidoc
+++ b/docs/en/siem/rule-details/malware-detected-elastic-endpoint.asciidoc
@@ -17,7 +17,7 @@ Alerts tab of the SIEM *Detections* page for additional information.
 
 *Runs every*: 10 minutes
 
-*Searches indices from*: now-660s ({ref}/common-options.html#date-math[Date Math format], see also <<rule-schedule, `Additional look-back time`>>)
+*Searches indices from*: now-15m ({ref}/common-options.html#date-math[Date Math format], see also <<rule-schedule, `Additional look-back time`>>)
 
 *Maximum signals per execution*: 100
 

--- a/docs/en/siem/rule-details/malware-prevented-elastic-endpoint.asciidoc
+++ b/docs/en/siem/rule-details/malware-prevented-elastic-endpoint.asciidoc
@@ -17,7 +17,7 @@ Alerts tab of the SIEM *Detections* page for additional information.
 
 *Runs every*: 10 minutes
 
-*Searches indices from*: now-660s ({ref}/common-options.html#date-math[Date Math format], see also <<rule-schedule, `Additional look-back time`>>)
+*Searches indices from*: now-15m ({ref}/common-options.html#date-math[Date Math format], see also <<rule-schedule, `Additional look-back time`>>)
 
 *Maximum signals per execution*: 100
 

--- a/docs/en/siem/rule-details/permission-theft-detected-elastic-endpoint.asciidoc
+++ b/docs/en/siem/rule-details/permission-theft-detected-elastic-endpoint.asciidoc
@@ -17,7 +17,7 @@ External Alerts tab of the SIEM *Detections* page for additional information.
 
 *Runs every*: 10 minutes
 
-*Searches indices from*: now-660s ({ref}/common-options.html#date-math[Date Math format], see also <<rule-schedule, `Additional look-back time`>>)
+*Searches indices from*: now-15m ({ref}/common-options.html#date-math[Date Math format], see also <<rule-schedule, `Additional look-back time`>>)
 
 *Maximum signals per execution*: 100
 

--- a/docs/en/siem/rule-details/permission-theft-prevented-elastic-endpoint.asciidoc
+++ b/docs/en/siem/rule-details/permission-theft-prevented-elastic-endpoint.asciidoc
@@ -17,7 +17,7 @@ External Alerts tab of the SIEM *Detections* page for additional information.
 
 *Runs every*: 10 minutes
 
-*Searches indices from*: now-660s ({ref}/common-options.html#date-math[Date Math format], see also <<rule-schedule, `Additional look-back time`>>)
+*Searches indices from*: now-15m ({ref}/common-options.html#date-math[Date Math format], see also <<rule-schedule, `Additional look-back time`>>)
 
 *Maximum signals per execution*: 100
 

--- a/docs/en/siem/rule-details/process-injection-detected-elastic-endpoint.asciidoc
+++ b/docs/en/siem/rule-details/process-injection-detected-elastic-endpoint.asciidoc
@@ -17,7 +17,7 @@ External Alerts tab of the SIEM *Detections* page for additional information.
 
 *Runs every*: 10 minutes
 
-*Searches indices from*: now-660s ({ref}/common-options.html#date-math[Date Math format], see also <<rule-schedule, `Additional look-back time`>>)
+*Searches indices from*: now-15m ({ref}/common-options.html#date-math[Date Math format], see also <<rule-schedule, `Additional look-back time`>>)
 
 *Maximum signals per execution*: 100
 

--- a/docs/en/siem/rule-details/process-injection-prevented-elastic-endpoint.asciidoc
+++ b/docs/en/siem/rule-details/process-injection-prevented-elastic-endpoint.asciidoc
@@ -17,7 +17,7 @@ External Alerts tab of the SIEM *Detections* page for additional information.
 
 *Runs every*: 10 minutes
 
-*Searches indices from*: now-660s ({ref}/common-options.html#date-math[Date Math format], see also <<rule-schedule, `Additional look-back time`>>)
+*Searches indices from*: now-15m ({ref}/common-options.html#date-math[Date Math format], see also <<rule-schedule, `Additional look-back time`>>)
 
 *Maximum signals per execution*: 100
 

--- a/docs/en/siem/rule-details/ransomware-detected-elastic-endpoint.asciidoc
+++ b/docs/en/siem/rule-details/ransomware-detected-elastic-endpoint.asciidoc
@@ -17,7 +17,7 @@ Alerts tab of the SIEM *Detections* page for additional information.
 
 *Runs every*: 10 minutes
 
-*Searches indices from*: now-660s ({ref}/common-options.html#date-math[Date Math format], see also <<rule-schedule, `Additional look-back time`>>)
+*Searches indices from*: now-15m ({ref}/common-options.html#date-math[Date Math format], see also <<rule-schedule, `Additional look-back time`>>)
 
 *Maximum signals per execution*: 100
 

--- a/docs/en/siem/rule-details/ransomware-prevented-elastic-endpoint.asciidoc
+++ b/docs/en/siem/rule-details/ransomware-prevented-elastic-endpoint.asciidoc
@@ -17,7 +17,7 @@ Alerts tab of the SIEM *Detections* page for additional information.
 
 *Runs every*: 10 minutes
 
-*Searches indices from*: now-660s ({ref}/common-options.html#date-math[Date Math format], see also <<rule-schedule, `Additional look-back time`>>)
+*Searches indices from*: now-15m ({ref}/common-options.html#date-math[Date Math format], see also <<rule-schedule, `Additional look-back time`>>)
 
 *Maximum signals per execution*: 100
 


### PR DESCRIPTION
Backports the following commits to 7.7:
 - updates prebuilt endpoint rules look back time (#1040)