### PR TITLE
[DOCS] Adds loss function description to regression conceptual docs

### DIFF
--- a/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
@@ -117,10 +117,9 @@ the number of outliers in the data, and so on.
 You can determine which loss function to be used during {reganalysis} though the 
 {ref}/put-dfanalytics.html[create {dfanalytics-jobs} API]. The default is mean 
 squared error (`mse`). If you choose `msle` or `huber`, you can also set up a 
-parameter for the loss function which is `t` (defaults to `1.0`) for `msle` and 
-`ẟ` (defaults to `1.0`) for `huber`. With these parameters, you can further 
-refine the behavior of the chosen functions. There is no parameter to manually 
-set up for `mse`.
+parameter for the loss function. With the parameter, you can further refine the 
+behavior of the chosen functions. There is no parameter to manually set up for 
+`mse`.
 
 TIP: The default loss function parameter values work fine for most of the cases. 
 It is highly recommended to use the default values, unless you fully understand 

--- a/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
@@ -127,6 +127,43 @@ low MSE value on the training data set and a high MSE value on the testing
 data set. For more information about the evaluation metrics, see 
 <<ml-dfanalytics-regression-evaluation>>.
 
+
+[discrete]
+[[regression-lossfunction]]
+==== Loss functions in {regression}
+
+Loss function is for measuring how well a given {ml} model fits to the specific 
+data set. The loss function boils down all the different aspects of the model to 
+a single number. This value makes it possible to compare the performance of the 
+various models. The bigger the difference between the prediction and the ground 
+truth, the higher the value of the loss function. Eventually, it helps you 
+decide which model is more suitable for your needs. Loss functions are also used 
+automatically in <<hyperparameters,hyperparameter optimization>> and when 
+training the decision trees.
+
+In the {stack}, there are three different types of loss function:
+
+* https://en.wikipedia.org/wiki/Mean_squared_error[mean squared error (`mse`)]
+* mean squared logarithmic error (`msle`; a variation of `mse`)
+* https://en.wikipedia.org/wiki/Huber_loss#Pseudo-Huber_loss_function[Pseudo-Huber loss (`huber`)]
+
+The different types of loss function calculate the model error differently. It 
+means that the loss function that is appropriate for your case highly depends on 
+the value distribution in your data set, the problem that you want to model, the 
+number of outliers in the data, and so on.
+
+You can determine which loss function to be used during {reganalysis} though the 
+{ref}/put-dfanalytics.html[create {dfanalytics-jobs} API]. The default is mean 
+squared error (`mse`). If you choose `msle` or `huber`, you can also set up a 
+parameter for the loss function which is `t` (defaults to `1.0`) for `msle` and 
+`ẟ` (defaults to `1.0`) for `huber`. With these offset parameters, you can 
+further refine the behavor of the chosen functions. There is no parameter to 
+manually set up for `mse`.
+
+TIP: Unless you fully understand the purpose of the different loss functions, it 
+is highly recommended that you leave it unset and use the default parameters.
+
+
 ==== Further readings
 
 https://github.com/elastic/examples/tree/master/Machine%20Learning/Feature%20Importance[Feature importance for {dfanalytics} (Jupyter notebook)]

--- a/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
@@ -88,8 +88,8 @@ gradient boosting methodologies.
 [[dfa-regression-lossfunction]]
 ===== Loss functions for {regression} analyses
 
-Loss function is for measuring how well a given {ml} model fits the specific 
-data set. The loss function boils down all the different aspects of the model to 
+Loss function measures how well a given {ml} model fits the specific 
+data set. The loss function boils down all the different under- and overestimations of the model to 
 a single number. The bigger the difference between the prediction and the ground 
 truth, the higher the value of the loss function. Loss functions are used 
 automatically in the background during 
@@ -103,9 +103,9 @@ In the {stack}, there are three different types of loss function:
 * mean squared logarithmic error (`msle`; a variation of `mse`)
 * https://en.wikipedia.org/wiki/Huber_loss#Pseudo-Huber_loss_function[Pseudo-Huber loss (`huber`)]
 
-The various types of loss function calculate the model error differently. It 
+The various types of loss function calculate the prediction error differently. It 
 means that which loss function is appropriate for your case highly depends on 
-the value distribution in your data set, the problem that you want to model, the 
+the target distribution in your data set, the problem that you want to model, the 
 number of outliers in the data, and so on.
 
 You can determine which loss function to be used during {reganalysis} though the 
@@ -116,8 +116,7 @@ parameter for the loss function which is `t` (defaults to `1.0`) for `msle` and
 refine the behavior of the chosen functions. There is no parameter to manually 
 set up for `mse`.
 
-TIP: Unless you fully understand the purpose of the different loss functions, it 
-is highly recommended that you leave it unset and use the default parameters.
+TIP: The default loss function parameter values work fine for most of the cases, so unless you fully understand the impact of the different loss function parameters, it is highly recommended that you use the default values.
 
 
 [[dfa-regression-feature-importance]]

--- a/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
@@ -88,11 +88,11 @@ gradient boosting methodologies.
 [[dfa-regression-lossfunction]]
 ===== Loss functions for {regression} analyses
 
-A loss function measures how well a given {ml} model fits the specific 
-data set. It boils down all the different under- and 
-overestimations of the model to a single number. The bigger the difference 
-between the prediction and the ground truth, the higher the value of the loss 
-function. Loss functions are used automatically in the background during 
+A loss function measures how well a given {ml} model fits the specific data set. 
+It boils down all the different under- and overestimations of the model to a 
+single number, known as the prediction error. The bigger the difference between 
+the prediction and the ground truth, the higher the value of the loss function. 
+Loss functions are used automatically in the background during 
 <<hyperparameters,hyperparameter optimization>> and when training the decision 
 trees to compare the performance of various iterations of the model.
 
@@ -109,16 +109,14 @@ Use it when you want to prevent the model trying to fit the outliers instead of
 regular data.
 
 The various types of loss function calculate the prediction error differently. 
-The appropriate loss function for your use case depends on 
-the target distribution in your data set, the problem that you want to model, 
-the number of outliers in the data, and so on.
+The appropriate loss function for your use case depends on the target 
+distribution in your data set, the problem that you want to model, the number of 
+outliers in the data, and so on.
 
-You can specify the loss function to be used during {reganalysis} though the 
-{ref}/put-dfanalytics.html[create {dfanalytics-jobs} API]. The default is mean 
-squared error (`mse`). If you choose `msle` or `huber`, you can also set up a 
-parameter for the loss function. With the parameter, you can further refine the 
-behavior of the chosen functions. There is no parameter to manually set up for 
-`mse`.
+You can specify the loss function to be used during {reganalysis} when you 
+create the {dfanalytics-job}. The default is mean squared error (`mse`). If you 
+choose `msle` or `huber`, you can also set up a parameter for the loss function. 
+With the parameter, you can further refine the behavior of the chosen functions.
 
 TIP: The default loss function parameter values work fine for most of the cases. 
 It is highly recommended to use the default values, unless you fully understand 

--- a/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
@@ -132,7 +132,7 @@ data set. For more information about the evaluation metrics, see
 [[regression-lossfunction]]
 ==== Loss functions for {regression} analyses
 
-Loss function is for measuring how well a given {ml} model fits to the specific 
+Loss function is for measuring how well a given {ml} model fits the specific 
 data set. The loss function boils down all the different aspects of the model to 
 a single number. This value makes it possible to compare the performance of the 
 various models. The bigger the difference between the prediction and the ground 
@@ -147,8 +147,8 @@ In the {stack}, there are three different types of loss function:
 * mean squared logarithmic error (`msle`; a variation of `mse`)
 * https://en.wikipedia.org/wiki/Huber_loss#Pseudo-Huber_loss_function[Pseudo-Huber loss (`huber`)]
 
-The different types of loss function calculate the model error differently. It 
-means that the loss function that is appropriate for your case highly depends on 
+The various types of loss function calculate the model error differently. It 
+means that which loss function is appropriate for your case highly depends on 
 the value distribution in your data set, the problem that you want to model, the 
 number of outliers in the data, and so on.
 
@@ -157,7 +157,7 @@ You can determine which loss function to be used during {reganalysis} though the
 squared error (`mse`). If you choose `msle` or `huber`, you can also set up a 
 parameter for the loss function which is `t` (defaults to `1.0`) for `msle` and 
 `ẟ` (defaults to `1.0`) for `huber`. With these offset parameters, you can 
-further refine the behavor of the chosen functions. There is no parameter to 
+further refine the behavior of the chosen functions. There is no parameter to 
 manually set up for `mse`.
 
 TIP: Unless you fully understand the purpose of the different loss functions, it 

--- a/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
@@ -130,7 +130,7 @@ data set. For more information about the evaluation metrics, see
 
 [discrete]
 [[regression-lossfunction]]
-==== Loss functions in {regression}
+==== Loss functions for {regression} analyses
 
 Loss function is for measuring how well a given {ml} model fits to the specific 
 data set. The loss function boils down all the different aspects of the model to 

--- a/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
@@ -88,14 +88,13 @@ gradient boosting methodologies.
 [[dfa-regression-lossfunction]]
 ===== Loss functions for {regression} analyses
 
-Loss function measures how well a given {ml} model fits the specific 
-data set. The loss function boils down all the different under- and 
+A loss function measures how well a given {ml} model fits the specific 
+data set. It boils down all the different under- and 
 overestimations of the model to a single number. The bigger the difference 
 between the prediction and the ground truth, the higher the value of the loss 
 function. Loss functions are used automatically in the background during 
 <<hyperparameters,hyperparameter optimization>> and when training the decision 
-trees to compare the various iterations of the model and decide which iteration 
-performs better. 
+trees to compare the performance of various iterations of the model.
 
 In the {stack}, there are three different types of loss function:
 
@@ -107,14 +106,14 @@ cases where the target values are all positive with a long tail distribution
 (for example, prices or population).
 * https://en.wikipedia.org/wiki/Huber_loss#Pseudo-Huber_loss_function[Pseudo-Huber loss (`huber`)]:
 Use it when you want to prevent the model trying to fit the outliers instead of 
-fit regular data.
+regular data.
 
 The various types of loss function calculate the prediction error differently. 
-It means that which loss function is appropriate for your case highly depends on 
+The appropriate loss function for your use case depends on 
 the target distribution in your data set, the problem that you want to model, 
 the number of outliers in the data, and so on.
 
-You can determine which loss function to be used during {reganalysis} though the 
+You can specify the loss function to be used during {reganalysis} though the 
 {ref}/put-dfanalytics.html[create {dfanalytics-jobs} API]. The default is mean 
 squared error (`mse`). If you choose `msle` or `huber`, you can also set up a 
 parameter for the loss function. With the parameter, you can further refine the 

--- a/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
@@ -89,24 +89,30 @@ gradient boosting methodologies.
 ===== Loss functions for {regression} analyses
 
 Loss function measures how well a given {ml} model fits the specific 
-data set. The loss function boils down all the different under- and overestimations of the model to 
-a single number. The bigger the difference between the prediction and the ground 
-truth, the higher the value of the loss function. Loss functions are used 
-automatically in the background during 
+data set. The loss function boils down all the different under- and 
+overestimations of the model to a single number. The bigger the difference 
+between the prediction and the ground truth, the higher the value of the loss 
+function. Loss functions are used automatically in the background during 
 <<hyperparameters,hyperparameter optimization>> and when training the decision 
 trees to compare the various iterations of the model and decide which iteration 
 performs better. 
 
 In the {stack}, there are three different types of loss function:
 
-* https://en.wikipedia.org/wiki/Mean_squared_error[mean squared error (`mse`)]
-* mean squared logarithmic error (`msle`; a variation of `mse`)
-* https://en.wikipedia.org/wiki/Huber_loss#Pseudo-Huber_loss_function[Pseudo-Huber loss (`huber`)]
+* https://en.wikipedia.org/wiki/Mean_squared_error[mean squared error (`mse`)]: 
+It is the default choice when no additional information about the data set is 
+available.
+* mean squared logarithmic error (`msle`; a variation of `mse`): It is for 
+cases where the target values are all positive with a long tail distribution 
+(for example, prices or population).
+* https://en.wikipedia.org/wiki/Huber_loss#Pseudo-Huber_loss_function[Pseudo-Huber loss (`huber`)]:
+Use it when you want to prevent the model trying to fit the outliers at the cost 
+of fitting regular data.
 
 The various types of loss function calculate the prediction error differently. It 
 means that which loss function is appropriate for your case highly depends on 
-the target distribution in your data set, the problem that you want to model, the 
-number of outliers in the data, and so on.
+the target distribution in your data set, the problem that you want to model, 
+the number of outliers in the data, and so on.
 
 You can determine which loss function to be used during {reganalysis} though the 
 {ref}/put-dfanalytics.html[create {dfanalytics-jobs} API]. The default is mean 

--- a/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
@@ -122,7 +122,9 @@ parameter for the loss function which is `t` (defaults to `1.0`) for `msle` and
 refine the behavior of the chosen functions. There is no parameter to manually 
 set up for `mse`.
 
-TIP: The default loss function parameter values work fine for most of the cases, so unless you fully understand the impact of the different loss function parameters, it is highly recommended that you use the default values.
+TIP: The default loss function parameter values work fine for most of the cases. 
+It is highly recommended to use the default values, unless you fully understand 
+the impact of the different loss function parameters.
 
 
 [[dfa-regression-feature-importance]]

--- a/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
@@ -85,6 +85,41 @@ gradient boosting methodologies.
 //end::regression-algorithms[]
 
 
+[[dfa-regression-lossfunction]]
+===== Loss functions for {regression} analyses
+
+Loss function is for measuring how well a given {ml} model fits the specific 
+data set. The loss function boils down all the different aspects of the model to 
+a single number. This value makes it possible to compare the performance of the 
+various models. The bigger the difference between the prediction and the ground 
+truth, the higher the value of the loss function. Eventually, it helps you 
+decide which model is more suitable for your needs. Loss functions are also used 
+automatically in <<hyperparameters,hyperparameter optimization>> and when 
+training the decision trees.
+
+In the {stack}, there are three different types of loss function:
+
+* https://en.wikipedia.org/wiki/Mean_squared_error[mean squared error (`mse`)]
+* mean squared logarithmic error (`msle`; a variation of `mse`)
+* https://en.wikipedia.org/wiki/Huber_loss#Pseudo-Huber_loss_function[Pseudo-Huber loss (`huber`)]
+
+The various types of loss function calculate the model error differently. It 
+means that which loss function is appropriate for your case highly depends on 
+the value distribution in your data set, the problem that you want to model, the 
+number of outliers in the data, and so on.
+
+You can determine which loss function to be used during {reganalysis} though the 
+{ref}/put-dfanalytics.html[create {dfanalytics-jobs} API]. The default is mean 
+squared error (`mse`). If you choose `msle` or `huber`, you can also set up a 
+parameter for the loss function which is `t` (defaults to `1.0`) for `msle` and 
+`ẟ` (defaults to `1.0`) for `huber`. With these offset parameters, you can 
+further refine the behavior of the chosen functions. There is no parameter to 
+manually set up for `mse`.
+
+TIP: Unless you fully understand the purpose of the different loss functions, it 
+is highly recommended that you leave it unset and use the default parameters.
+
+
 [[dfa-regression-feature-importance]]
 ==== {feat-imp-cap}
 
@@ -121,41 +156,6 @@ which do not generalize to new data. A model that overfits the data has a
 low MSE value on the training data set and a high MSE value on the testing 
 data set. For more information about the evaluation metrics, see 
 <<ml-dfanalytics-regression-evaluation>>.
-
-
-[[regression-lossfunction]]
-==== Loss functions for {regression} analyses
-
-Loss function is for measuring how well a given {ml} model fits the specific 
-data set. The loss function boils down all the different aspects of the model to 
-a single number. This value makes it possible to compare the performance of the 
-various models. The bigger the difference between the prediction and the ground 
-truth, the higher the value of the loss function. Eventually, it helps you 
-decide which model is more suitable for your needs. Loss functions are also used 
-automatically in <<hyperparameters,hyperparameter optimization>> and when 
-training the decision trees.
-
-In the {stack}, there are three different types of loss function:
-
-* https://en.wikipedia.org/wiki/Mean_squared_error[mean squared error (`mse`)]
-* mean squared logarithmic error (`msle`; a variation of `mse`)
-* https://en.wikipedia.org/wiki/Huber_loss#Pseudo-Huber_loss_function[Pseudo-Huber loss (`huber`)]
-
-The various types of loss function calculate the model error differently. It 
-means that which loss function is appropriate for your case highly depends on 
-the value distribution in your data set, the problem that you want to model, the 
-number of outliers in the data, and so on.
-
-You can determine which loss function to be used during {reganalysis} though the 
-{ref}/put-dfanalytics.html[create {dfanalytics-jobs} API]. The default is mean 
-squared error (`mse`). If you choose `msle` or `huber`, you can also set up a 
-parameter for the loss function which is `t` (defaults to `1.0`) for `msle` and 
-`ẟ` (defaults to `1.0`) for `huber`. With these offset parameters, you can 
-further refine the behavior of the chosen functions. There is no parameter to 
-manually set up for `mse`.
-
-TIP: Unless you fully understand the purpose of the different loss functions, it 
-is highly recommended that you leave it unset and use the default parameters.
 
 
 ==== Further readings

--- a/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
@@ -106,8 +106,8 @@ available.
 cases where the target values are all positive with a long tail distribution 
 (for example, prices or population).
 * https://en.wikipedia.org/wiki/Huber_loss#Pseudo-Huber_loss_function[Pseudo-Huber loss (`huber`)]:
-Use it when you want to prevent the model trying to fit the outliers at the cost 
-of fitting regular data.
+Use it when you want to prevent the model trying to fit the outliers instead of 
+fit regular data.
 
 The various types of loss function calculate the prediction error differently. It 
 means that which loss function is appropriate for your case highly depends on 

--- a/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
@@ -109,8 +109,8 @@ cases where the target values are all positive with a long tail distribution
 Use it when you want to prevent the model trying to fit the outliers instead of 
 fit regular data.
 
-The various types of loss function calculate the prediction error differently. It 
-means that which loss function is appropriate for your case highly depends on 
+The various types of loss function calculate the prediction error differently. 
+It means that which loss function is appropriate for your case highly depends on 
 the target distribution in your data set, the problem that you want to model, 
 the number of outliers in the data, and so on.
 

--- a/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
@@ -90,12 +90,12 @@ gradient boosting methodologies.
 
 Loss function is for measuring how well a given {ml} model fits the specific 
 data set. The loss function boils down all the different aspects of the model to 
-a single number. This value makes it possible to compare the performance of the 
-various models. The bigger the difference between the prediction and the ground 
-truth, the higher the value of the loss function. Eventually, it helps you 
-decide which model is more suitable for your needs. Loss functions are also used 
-automatically in <<hyperparameters,hyperparameter optimization>> and when 
-training the decision trees.
+a single number. The bigger the difference between the prediction and the ground 
+truth, the higher the value of the loss function. Loss functions are used 
+automatically in the background during 
+<<hyperparameters,hyperparameter optimization>> and when training the decision 
+trees to compare the various iterations of the model and decide which iteration 
+performs better. 
 
 In the {stack}, there are three different types of loss function:
 
@@ -112,9 +112,9 @@ You can determine which loss function to be used during {reganalysis} though the
 {ref}/put-dfanalytics.html[create {dfanalytics-jobs} API]. The default is mean 
 squared error (`mse`). If you choose `msle` or `huber`, you can also set up a 
 parameter for the loss function which is `t` (defaults to `1.0`) for `msle` and 
-`ẟ` (defaults to `1.0`) for `huber`. With these offset parameters, you can 
-further refine the behavior of the chosen functions. There is no parameter to 
-manually set up for `mse`.
+`ẟ` (defaults to `1.0`) for `huber`. With these parameters, you can further 
+refine the behavior of the chosen functions. There is no parameter to manually 
+set up for `mse`.
 
 TIP: Unless you fully understand the purpose of the different loss functions, it 
 is highly recommended that you leave it unset and use the default parameters.

--- a/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
@@ -32,7 +32,6 @@ on. All of these factors can be considered _features_; they are measurable
 properties or characteristics of the phenomenon we're studying.
 
 
-[discrete]
 [[dfa-regression-features]]
 ==== {feature-vars-cap}
 
@@ -54,7 +53,6 @@ algorithm:
 Arrays are not supported.
 
 
-[discrete]
 [[dfa-regression-supervised]]
 ==== Training the {regression} model
 
@@ -77,7 +75,6 @@ predictions are combined.
 you must restart the {dfanalytics-job}.
 
 
-[discrete]
 [[dfa-regression-algorithm]]
 ===== {regression-cap} algorithms
 
@@ -88,7 +85,6 @@ gradient boosting methodologies.
 //end::regression-algorithms[]
 
 
-[discrete]
 [[dfa-regression-feature-importance]]
 ==== {feat-imp-cap}
 
@@ -97,7 +93,6 @@ helps to interpret the results in a more subtle way. If you want to learn more
 about {feat-imp}, <<ml-feature-importance,click here>>.
 
 
-[discrete]
 [[dfa-regression-evaluation]]
 ==== Measuring model performance
 
@@ -128,7 +123,6 @@ data set. For more information about the evaluation metrics, see
 <<ml-dfanalytics-regression-evaluation>>.
 
 
-[discrete]
 [[regression-lossfunction]]
 ==== Loss functions for {regression} analyses
 

--- a/docs/en/stack/ml/df-analytics/ml-dfa-concepts.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-concepts.asciidoc
@@ -13,6 +13,7 @@ feature and the corresponding {evaluatedf-api}.
 * <<ml-feature-importance>>
 * <<hyperparameters>>
 
+
 include::dfa-outlierdetection.asciidoc[]
 include::dfa-regression.asciidoc[]
 include::dfa-classification.asciidoc[]


### PR DESCRIPTION
## Overview

This PR expands the regression conceptual documentation with a high-level explanation of loss functions. 

### Preview

[Regression](http://stack-docs_1062.docs-preview.app.elstc.co/guide/en/machine-learning/master/dfa-regression.html#regression-lossfunction)