### PR TITLE
[DOCS] Removes [discrete] attributes from DFA docs

### DIFF
--- a/docs/en/stack/ml/df-analytics/dfa-classification.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-classification.asciidoc
@@ -28,7 +28,6 @@ about field selection, see the
 {ref}/explain-dfanalytics.html[explain data frame analytics API].
 
 
-[discrete]
 [[dfa-classification-supervised]]
 ==== Training the {classification} model
 
@@ -65,7 +64,7 @@ that is approximately balanced. That is to say, ideally your data set should
 have a similar number of data points for each class.
 ////
 
-[discrete]
+
 [[dfa-classification-algorithm]]
 ===== {classification-cap} algorithms
 
@@ -80,7 +79,6 @@ previous tree.
 //end::classification-algorithms[]
 
 
-[discrete]
 [[dfa-classification-performance]]
 ==== {classification-cap} performance
 
@@ -103,14 +101,13 @@ fields that are not relevant from the analysis by specifying `excludes` patterns
 in the `analyzed_fields` object when configuring the {dfanalytics-job}.  
  
 
-[discrete]
 [[dfa-classification-interpret]]
 ==== Interpreting {classification} results
 
 The following sections help you understand and interpret the results of a 
 {classanalysis}.
 
-[discrete]
+
 [[dfa-classification-class-probability]]
 ===== `class_probability`
 
@@ -123,7 +120,6 @@ in your destination index. See the
 section in the {classification} example.
 
 
-[discrete]
 [[dfa-classification-class-score]]
 ===== `class_score`
 
@@ -152,7 +148,6 @@ actual `class 0` predicted `class 1` errors, or in other words, a slight
 degradation of the overall accuracy.
 
 
-[discrete]
 [[dfa-classification-feature-importance]]
 ===== {feat-imp-cap}
 
@@ -161,8 +156,6 @@ helps to interpret the results in a more subtle way. If you want to learn more
 about {feat-imp}, <<ml-feature-importance,click here>>. 
 
 
-
-[discrete]
 [[dfa-classification-evaluation]]
 ==== Measuring model performance
 

--- a/docs/en/stack/ml/df-analytics/dfa-outlierdetection.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-outlierdetection.asciidoc
@@ -16,7 +16,7 @@ are unusual compared to the majority of the data points.
 You can create {oldetection} {dfanalytics-jobs} in {kib} or by using the
 {ref}/put-dfanalytics.html[create {dfanalytics-jobs} API].
 
-[discrete]
+
 [[dfa-outlier-algorithms]]
 ==== {oldetection-cap} algorithms
 
@@ -82,7 +82,7 @@ IMPORTANT: {oldetection-cap} is a batch analysis, it runs against your data
 once. If new data comes into the index, you need to do the analysis again on the 
 altered data.
 
-[discrete]
+
 [[dfa-feature-influence]]
 ==== Feature influence
 

--- a/docs/en/stack/ml/df-analytics/evaluatedf-api.asciidoc
+++ b/docs/en/stack/ml/df-analytics/evaluatedf-api.asciidoc
@@ -24,7 +24,7 @@ the field must indicate whether the given data point really is an outlier or
 not. The {evaluatedf-api} evaluates the performance of the {dfanalytics} against 
 this manually provided ground truth.
 
-[discrete]
+
 [[ml-dfanalytics-binary-soft-classification]]
 ==== {binarysc-cap} evaluation
 
@@ -37,7 +37,7 @@ evaluation type offers the following metrics to evaluate the model performance:
 * recall
 * receiver operating characteristic (ROC) curve.
 
-[discrete]
+
 [[ml-dfanalytics-confusion-matrix]]
 ===== Confusion matrix
 
@@ -66,7 +66,7 @@ with an {olscore} higher than 0.5 will be considered as outliers.
 To take this complexity into account, the {evaluatedf-api} returns the confusion 
 matrix at different thresholds (by default, 0.25, 0.5, and 0.75).
 
-[discrete]
+
 [[ml-dfanalytics-precision-recall]]
 ===== Precision and recall
 
@@ -87,7 +87,7 @@ positives and false negatives (TP/(TP+FN)).
 As was the case for the confusion matrix, you also need to define different 
 threshold levels for computing precision and recall.
 
-[discrete]
+
 [[ml-dfanalytics-roc]]
 ===== Receiver operating characteristic curve
 
@@ -103,7 +103,6 @@ positive rate (`tpr`) at the different threshold levels, so you can visualize
 the algorithm performance by using these values.
 
 
-[discrete]
 [[ml-dfanalytics-regression-evaluation]]
 ==== {regression-cap} evaluation
 
@@ -115,7 +114,6 @@ performance:
 * R-squared (R^2^)
 
 
-[discrete]
 [[ml-dfanalytics-mse]]
 ===== Mean squared error
 
@@ -125,7 +123,6 @@ between the true value and the value that the {regression} model predicted.
 the {reganalysis} model is performing.
 
 
-[discrete]
 [[ml-dfanalytics-r-sqared]]
 ===== R-squared
 
@@ -138,7 +135,6 @@ value of 0.5 for R^2^ would indicate that, the predictions are 1 - 0.5^(1/2)^
 (about 30%) closer to true values than their mean.
 
 
-[discrete]
 [[ml-dfanalytics-classification]]
 ==== {classification-cap} evaluation
 
@@ -149,7 +145,6 @@ performance:
 * Multiclass confusion matrix
 
 
-[discrete]
 [[ml-dfanalytics-mccm]]
 ===== Multiclass confusion matrix
 

--- a/docs/en/stack/ml/df-analytics/flightdata-classification.asciidoc
+++ b/docs/en/stack/ml/df-analytics/flightdata-classification.asciidoc
@@ -15,6 +15,7 @@ concepts, see <<dfa-classification>>.
 TIP: If you want to view this example in a Jupyter notebook,
 https://github.com/elastic/examples/tree/master/Machine%20Learning/Analytics%20Jupyter%20Notebooks[click here].
 
+
 [[flightdata-classification-data]]
 ==== Preparing your data
 
@@ -86,6 +87,7 @@ accessible. However, the data has been manually created and contains some
 inconsistencies. For example, a flight can be both delayed and canceled. This is
 a good reminder that the quality of your input data affects the quality of your
 results.
+
 
 [[flightdata-classification-model]]
 ==== Creating a {classification} model
@@ -365,6 +367,7 @@ data point to the class with the highest score maximizes the minimum recall of
 any class.
 ////
 ====
+
 
 [[flightdata-classification-evaluate]]
 ==== Evaluating {classification} results

--- a/docs/en/stack/ml/df-analytics/flightdata-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/flightdata-regression.asciidoc
@@ -12,6 +12,7 @@ between the fields in your data in order to predict the value of a
 _dependent variable_, which in this case is the numeric `FlightDelayMins` field.
 For an overview of these concepts, see <<dfa-regression>>.
 
+
 [[flightdata-regression-data]]
 ==== Preparing your data
 
@@ -83,6 +84,7 @@ accessible. However, the data has been manually created and contains some
 inconsistencies. For example, a flight can be both delayed and canceled. This is
 a good reminder that the quality of your input data affects the quality of your
 results.
+
 
 [[flightdata-regression-model]]
 ==== Creating a {regression} model
@@ -274,6 +276,7 @@ The API call returns the following response:
 ----
 ====
 --
+
 
 [[flightdata-regression-results]]
 ==== Viewing {regression} results

--- a/docs/en/stack/ml/df-analytics/ml-dfa-phases.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-phases.asciidoc
@@ -13,7 +13,6 @@ cycle, it goes through four main phases:
 Let's take a look at the phases one-by-one.
 
 
-[discrete]
 ==== Reindexing
 
 During the reindexing phase the documents from the source index or indices are 
@@ -25,7 +24,6 @@ Once the destination index is built, the {dfanalytics-job} task calls the {es}
 {ref}/docs-reindex.html[Reindex API] to launch the reindexing task.
 
 
-[discrete]
 ==== Loading data
 
 After the reindexing is finished, the job fetches the needed data from the 
@@ -33,7 +31,6 @@ destination index. It converts the data into the format that the analysis
 process expects, then sends it to the analysis process.
 
 
-[discrete]
 ==== Analyzing
 
 In this phase, the job generates a {ml} model for analyzing the data. The 
@@ -52,7 +49,6 @@ in which they identify outliers in the data.
 . `final_training`: Trains the {ml} model.
 
 
-[discrete]
 ==== Writing results
 
 After the loaded data is analyzed, the analysis process sends back the results. 

--- a/docs/en/stack/ml/df-analytics/ml-feature-importance.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-feature-importance.asciidoc
@@ -29,7 +29,7 @@ NOTE: The number of {feat-imp} values for each document might be less than the
 `num_top_feature_importance_values` property value. For example, it returns only 
 features that had a positive or negative effect on the prediction.
 
-[discrete]
+
 ==== Further readings
 
 https://www.elastic.co/blog/feature-importance-for-data-frame-analytics-with-elastic-machine-learning[{feat-imp-cap} for {dfanalytics} with Elastic {ml}]

--- a/docs/en/stack/ml/df-analytics/ml-inference.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-inference.asciidoc
@@ -20,7 +20,6 @@ trained the model on, and get a prediction.
 Let's take a closer look at the machinery behind {infer}.
 
 
-[discrete]
 [[ml-inference-models]]
 ==== Trained {ml} models as functions
 
@@ -36,7 +35,6 @@ determine the language of text. {lang-ident-cap} supports 109 languages. For
 more information and configuration details, check the <<ml-lang-ident>> page.
 
 
-[discrete]
 [[ml-inference-processor]]
 ==== {infer-cap} processor
 

--- a/docs/en/stack/ml/df-analytics/ml-lang-ident.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-lang-ident.asciidoc
@@ -187,6 +187,7 @@ The request returns the following response:
 <1> Contains scores for the most probable languages.
 <2> The ISO identifier of the language with the highest probability.
 
+
 ==== Further readings
 
 https://www.elastic.co/blog/multilingual-search-using-language-identification-in-elasticsearch[Multilingual search using language identification in Elasticsearch]


### PR DESCRIPTION
## Overview

This PR removes the [discrete] attributes from the DFA documentation pages (level 3 and below). With this change, the sub-section titles of the pages will appear on the right sidebar under the "On this page" header.

### Preview

* [Classification](http://stack-docs_1070.docs-preview.app.elstc.co/guide/en/machine-learning/master/dfa-classification.html)
* [Outlier detection](http://stack-docs_1070.docs-preview.app.elstc.co/guide/en/machine-learning/master/dfa-outlier-detection.html)
* [DFA phases](http://stack-docs_1070.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-dfa-phases.html)
* [Evaluating DFA](http://stack-docs_1070.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-dfanalytics-evaluate.html)
* [Feature importance](http://stack-docs_1070.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-feature-importance.html)
* [Inference](http://stack-docs_1070.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-inference.html)