### PR TITLE
[DOCS] Removes [discrete] attributes from anomaly detection docs

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/buckets.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/buckets.asciidoc
@@ -21,7 +21,7 @@ The bucket span has two purposes: it dictates over what time span to look for an
 The bucket span has a significant impact on the analysis. When you’re trying to determine what value to use, take into account the granularity at which you want to perform the analysis, the frequency of the input data, the duration of typical anomalies, and the frequency at which alerting is required.
 ////
 
-[discrete]
+
 [[ml-bucket-results]]
 ==== Bucket results
 

--- a/docs/en/stack/ml/anomaly-detection/influencers.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/influencers.asciidoc
@@ -38,7 +38,7 @@ TIP: As a best practice, do not pick too many influencers. For example, you
 generally do not need more than three. If you pick many influencers, the results
 can be overwhelming and there is a small overhead to the analysis.
 
-[discrete]
+
 [[ml-influencer-results]]
 ==== Influencer results
 


### PR DESCRIPTION
## Overview

This PR removes the [discrete] attributes from the anomaly detection documentation pages (level 3 and below). With this change, the sub-section titles of the pages will appear on the right sidebar under the "On this page" header.

### Preview

* [Buckets](http://stack-docs_1079.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-buckets.html)
* [Influencers](http://stack-docs_1079.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-influencers.html)