### PR TITLE
[DOCS] Adds dedicated indices section to job tips with recommendation

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/job-tips.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/job-tips.asciidoc
@@ -109,9 +109,9 @@ increase the size of the {ml} nodes in your cluster.
 [[dedicated-indices]]
 ===== Dedicated indices
 
-For each {anomaly-job}, you can optionally specify a separated index to store 
+For each {anomaly-job}, you can optionally specify a dedicated index to store 
 the {anomaly-detect} results. As {anomaly-jobs} may produce a large amount 
-of results (for example, jobs with small bucket span or with long running 
-period), it is recommended to use a dedicated results index by choosing the 
-**Use dedicated index** option in {kib} or specifying the `results_index_name` 
-via the {ref}/ml-put-job.html[Create {anomaly-jobs} API].
+of results (for example, jobs with many time series, small bucket span, or with 
+long running period), it is recommended to use a dedicated results index by 
+choosing the **Use dedicated index** option in {kib} or specifying the 
+`results_index_name` via the {ref}/ml-put-job.html[Create {anomaly-jobs} API].

--- a/docs/en/stack/ml/anomaly-detection/job-tips.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/job-tips.asciidoc
@@ -10,6 +10,7 @@ provide advice based on the characteristics of your data. By heeding these
 suggestions, you can create jobs that are more likely to produce insightful {ml}
 results.
 
+
 [[bucket-span]]
 ===== Bucket span
 
@@ -23,6 +24,7 @@ NOTE: The bucket span must contain a valid time interval. See
 If you choose a value that is larger than one day or is significantly different 
 than the estimated value, you receive an informational message. For more 
 information about choosing an appropriate bucket span, see <<ml-buckets>>.
+
 
 [[cardinality]]
 ===== Cardinality
@@ -41,6 +43,7 @@ Likewise if you are performing population analysis and the cardinality of the
 `over_field_name` is below 10, you are advised that this might not be a suitable
 field to use. For more information, see <<ml-configuring-pop>>.
 
+
 [[detectors]]
 ===== Detectors
 
@@ -53,10 +56,12 @@ If a job contains duplicate detectors, you also receive an error. Detectors are
 duplicates if they have the same `function`, `field_name`, `by_field_name`, 
 `over_field_name` and `partition_field_name`. 
 
+
 [[influencers]]
 ===== Influencers
 
 See <<ml-influencers>>.
+
 
 [[model-memory-limits]]
 ===== Model memory limits
@@ -99,3 +104,14 @@ If you are using {ece} or the hosted Elasticsearch Service on Elastic Cloud,
 that cannot be allocated to any {ml} nodes in the cluster. If you find that you 
 cannot increase `model_memory_limit` for your {ml} jobs, the solution is to 
 increase the size of the {ml} nodes in your cluster.
+
+
+[[dedicated-indices]]
+===== Dedicated indices
+
+For each {anomaly-job}, you can optionally specify a separated index to store 
+the {anomaly-detect} results. As {anomaly-jobs} may produce a large amount 
+of results (for example, jobs with small bucket span or with long running 
+period), it is recommended to use a dedicated results index by choosing the 
+**Use dedicated index** option in {kib} or specifying the `results_index_name` 
+via the {ref}/ml-put-job.html[Create {anomaly-jobs} API].


### PR DESCRIPTION
## Overview

This PR adds a new section to the ML job tips page which contains a recommendation about the usage of dedicated results indices. 

As on the ML UI, the *Use dedicated index* option is near to the *model memory limit* settings, it seems appropriate to add the new section after the MML section in the tip docs. 

<img width="1241" alt="Screenshot 2020-05-15 at 13 37 46" src="https://user-images.githubusercontent.com/22324794/82047769-b0ef3300-96b3-11ea-952a-a46ba53cbf6b.png">


### Preview

[ML job tips](http://stack-docs_1080.docs-preview.app.elstc.co/guide/en/machine-learning/master/create-jobs.html#job-tips)