### PR TITLE
[DOCS] Fix endif in Glossary

### DIFF
--- a/docs/en/glossary/glossary.asciidoc
+++ b/docs/en/glossary/glossary.asciidoc
@@ -319,7 +319,7 @@ ifdef::elasticsearch-terms,logstash-terms[]
 include::{es-repo-dir}/glossary.asciidoc[tag=field-def]
 
 
-ifdef::elasticsearch-terms,logstash-terms[]
+endif::elasticsearch-terms,logstash-terms[]
 ifdef::logstash-terms[]
 In Logstash, this term refers to an <<glossary-event,event>> property. For
 example, each event in an apache access log has properties, such as a status


### PR DESCRIPTION
This PR fixes a mismatched ifdef ... endif pair in the Glossary.