### PR TITLE
[DOCS] Enables mathematical formulate in DFA chapter and adds markup to a formula

### DIFF
--- a/docs/en/stack/ml/df-analytics/dfa-classification.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-classification.asciidoc
@@ -134,7 +134,7 @@ non-negative and its definition is:
 
 stem:[\text{class_score(class 0)} = 0.5 / (1.0 - k) * probability(class 0)]
 
-stem:[[\text{class_score(class 1)}= 0.5 / k * probability(class 1)]
+stem:[\text{class_score(class 1)}= 0.5 / k * probability(class 1)]
 
 Here, `k` is a positive constant less than one. It represents the predicted 
 probability of `class 1` for a data point at which to label it `class 1` and is 

--- a/docs/en/stack/ml/df-analytics/dfa-classification.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-classification.asciidoc
@@ -132,11 +132,9 @@ are denoted `class 0` and `class 1`, then the value of `class_score` is always
 non-negative and its definition is:
 
 
-`class_score (class 0)` 
 stem:[\text{class_score(class 0)} = 0.5 / (1.0 - k) * probability(class 0)]
 
-`class\_score (class 1)` 
-stem:[= 0.5 / k * probability(class 1)]
+stem:[[\text{class_score(class 1)}= 0.5 / k * probability(class 1)]
 
 Here, `k` is a positive constant less than one. It represents the predicted 
 probability of `class 1` for a data point at which to label it `class 1` and is 

--- a/docs/en/stack/ml/df-analytics/dfa-classification.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-classification.asciidoc
@@ -133,7 +133,7 @@ non-negative and its definition is:
 
 
 `class_score (class 0)` 
-stem:[= 0.5 / (1.0 - k) * probability(class 0)]
+stem:[\text{class_score(class 0)} = 0.5 / (1.0 - k) * probability(class 0)]
 
 `class\_score (class 1)` 
 stem:[= 0.5 / k * probability(class 1)]

--- a/docs/en/stack/ml/df-analytics/dfa-classification.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-classification.asciidoc
@@ -131,10 +131,12 @@ so it can be less than or greater than 0.5. For example, suppose our two classes
 are denoted `class 0` and `class 1`, then the value of `class_score` is always 
 non-negative and its definition is:
 
-```
-class_score(class 0) = 0.5 / (1.0 - k) * probability(class 0)
-class_score(class 1) = 0.5 / k * probability(class 1)
-```
+
+`class_score (class 0)` 
+stem:[= 0.5 / (1.0 - k) * probability(class 0)]
+
+`class\_score (class 1)` 
+stem:[= 0.5 / k * probability(class 1)]
 
 Here, `k` is a positive constant less than one. It represents the predicted 
 probability of `class 1` for a data point at which to label it `class 1` and is 

--- a/docs/en/stack/ml/df-analytics/index.asciidoc
+++ b/docs/en/stack/ml/df-analytics/index.asciidoc
@@ -1,6 +1,8 @@
 [role="xpack"]
 [[ml-dfanalytics]]
 = {dfanalytics-cap}
+:stem:
+
 
 [partintro]	
 --


### PR DESCRIPTION
## Overview

This PR enables mathematical formulae in the data frame analytics chapter of the ML book and adds the required markup to the formula in the classification conceptual docs to render it correctly.

AsciiMath can be enabled by adding `:stem:` to the index.asciidoc of the chapter/book.

```
= Section title
:stem:
```
Use the following notation for the formulae:

```
stem:[sum_(i=1)^n i^3=((n(n+1))/2)^2]
```
For a centered block:

```
[stem]
++++
x/x={(1,if x!=0),(text{undefined},if x=0):}
++++
``` 

### Preview

[Classification](http://stack-docs_1091.docs-preview.app.elstc.co/guide/en/machine-learning/master/dfa-classification.html#dfa-classification-class-score)