### PR TITLE
[DOCS] Changes link in Anomaly Detection API quick reference

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/api-quickref.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/api-quickref.asciidoc
@@ -12,7 +12,7 @@ All {ml} {anomaly-detect} endpoints have the following base:
 
 The main resources can be accessed with a variety of endpoints:
 
-* {ref}/ml-apis.html#ml-api-job-endpoint[+/anomaly_detectors/+]: Create and manage {anomaly-jobs}
+* {ref}/ml-apis.html#ml-api-anomaly-job-endpoint[+/anomaly_detectors/+]: Create and manage {anomaly-jobs}
 * {ref}/ml-apis.html#ml-api-calendar-endpoint[+/calendars/+]: Create and manage calendars and scheduled events
 * {ref}/ml-apis.html#ml-api-datafeed-endpoint[+/datafeeds/+]: Select data from {es} to be analyzed
 * {ref}/ml-apis.html#ml-api-filter-endpoint[+/filters/+]: Create and manage filters for custom rules


### PR DESCRIPTION
## Overview

This PR changes the URL of the `/anomaly_detectors/` from
`/ml-apis.html#ml-api-job-endpoint`
to
`/ml-apis.html#ml-api-anomaly-job-endpoint`.

#### Preview

[API quick reference](http://stack-docs_1100.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-api-quickref.html)