### PR TITLE
[DOCS] Expands forecast limitations

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/limitations.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/limitations.asciidoc
@@ -241,9 +241,10 @@ create jobs in {kib} or by using APIs.
 
 There are some limitations that affect your ability to create a forecast:
 
-* You can generate only three forecasts concurrently. There is no limit to the
-number of forecasts that you retain. Existing forecasts are not overwritten when
-you create new forecasts. Rather, they are automatically deleted when they expire.
+* You can generate only three forecasts per job concurrently. There is no limit 
+to the number of forecasts that you retain. Existing forecasts are not 
+overwritten when you create new forecasts. Rather, they are automatically 
+deleted when they expire.
 * If you use an `over_field_name` property in your {anomaly-job} (that is to say,
 it's a _population job_), you cannot create a forecast.
 * If you use any of the following analytical functions in your {anomaly-job},

--- a/docs/en/stack/ml/anomaly-detection/limitations.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/limitations.asciidoc
@@ -241,8 +241,8 @@ create jobs in {kib} or by using APIs.
 
 There are some limitations that affect your ability to create a forecast:
 
-* You can generate only three forecasts per job concurrently. There is no limit 
-to the number of forecasts that you retain. Existing forecasts are not 
+* You can generate only three forecasts per {anomaly-job} concurrently. There is 
+no limit to the number of forecasts that you retain. Existing forecasts are not 
 overwritten when you create new forecasts. Rather, they are automatically 
 deleted when they expire.
 * If you use an `over_field_name` property in your {anomaly-job} (that is to say,


### PR DESCRIPTION
## Overview

This PR specifies that you can generate three forecasts per job.

### Preview

[Forecasts limitations](url)