### PR TITLE
[DOCS] Removes outdated inference related limitation item

### DIFF
--- a/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
@@ -135,31 +135,6 @@ feature importance, reducing the amount of training data (for example by
 decreasing the training percentage), setting <<hyperparameters,hyperparameter>>
 values, or only selecting fields that are relevant for analysis.
 
-[float]
-[[dfa-inference-multi-field]]
-=== Analytics training on multi-field values may affect {infer}
-
-{dfanalytics-jobs-cap} dynamically select the best field when multi-field
-values are included. For example, if a multi-field `foo` is included for training,
-the `foo.keyword` is actually used. This poses a complication for {infer} with
-the inference processor. Documents supplied to ingest pipelines are not mapped. Consequently,
-only the field `foo` is present. This means that a model trained with the field `foo.keyword`
-does not take the field `foo` into account.
-
-You can work around this limitation by using the `field_mappings` parameter in the inference processor.
-
-Example:
-```
-{
-  "inference": {
-    "model_id": "my_model_with_multi-fields",
-    "field_mappings": {
-      "foo": "foo.keyword"
-    },
-    "inference_config": { "regression": {} }
-  }
-}
-```
 
 [float]
 [[dfa-inference-bwc]]


### PR DESCRIPTION
## Overview

This PR removes an outdated item from the DFA limitations list: `Analytics training on multi-field values may affect inference`.
https://github.com/elastic/elasticsearch/pull/53294 made it irrelevant.