### PR TITLE
[DOCS] Add ML CPU scheduling limitation

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/limitations.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/limitations.asciidoc
@@ -281,7 +281,7 @@ in {dfeeds} or jobs. See
 [[ml-scheduling-priority]]
 === CPU scheduling improvements apply to Linux and MacOS only
 
-When there are many {ml} jobs running at the same time and there is insufficient
+When there are many {ml} jobs running at the same time and there are insufficient
 CPU resources, the JVM performance must be prioritized so search and indexing
 latency remain acceptable. To that end, when CPU is constrained on Linux and
 MacOS environments, the CPU scheduling priority of native analysis processes is

--- a/docs/en/stack/ml/anomaly-detection/limitations.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/limitations.asciidoc
@@ -276,3 +276,14 @@ of the data analysis are less accurate.
 possible to specify the `ignore_throttled` query parameter for search requests
 in {dfeeds} or jobs. See
 {ref}/searching_a_frozen_index.html[Searching a frozen index].
+
+[discrete]
+[[ml-scheduling-priority]]
+=== CPU scheduling improvements apply to Linux and MacOS only
+
+When there are many {ml} jobs running at the same time and there is insufficient
+CPU resources, the JVM performance must be prioritized so search and indexing
+latency remain acceptable. To that end, when CPU is constrained on Linux and
+MacOS environments, the CPU scheduling priority of native analysis processes is
+reduced to favor the {es} JVM. This improvement does not apply to Windows
+environments.

--- a/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
@@ -168,3 +168,14 @@ Example:
 Inference models created in version 7.8.0 are not backwards compatible with 
 older node versions. In a mixed cluster environment, all nodes must be at 
 least 7.8.0 to use a model created on a 7.8.0 node.
+
+[discrete]
+[[dfa-scheduling-priority]]
+=== CPU scheduling improvements apply to Linux and MacOS only
+
+When there are many {ml} jobs running at the same time and there is insufficient
+CPU resources, the JVM performance must be prioritized so search and indexing
+latency remain acceptable. To that end, when CPU is constrained on Linux and
+MacOS environments, the CPU scheduling priority of native analysis processes is
+reduced to favor the {es} JVM. This improvement does not apply to Windows
+environments.

--- a/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfanalytics-limitations.asciidoc
@@ -173,7 +173,7 @@ least 7.8.0 to use a model created on a 7.8.0 node.
 [[dfa-scheduling-priority]]
 === CPU scheduling improvements apply to Linux and MacOS only
 
-When there are many {ml} jobs running at the same time and there is insufficient
+When there are many {ml} jobs running at the same time and there are insufficient
 CPU resources, the JVM performance must be prioritized so search and indexing
 latency remain acceptable. To that end, when CPU is constrained on Linux and
 MacOS environments, the CPU scheduling priority of native analysis processes is


### PR DESCRIPTION
Related to https://github.com/elastic/ml-cpp/pull/1276 and https://github.com/elastic/ml-cpp/pull/1109

This PR adds a limitation (applicable to both anomaly detection and dataframe analytics jobs) that makes it clear that the CPU scheduling improvements apply only to Linux and MacOS.