### PR TITLE
[DOCS] Expand an example from the Docker section of the Getting Started Guide

### DIFF
--- a/docs/en/getting-started/docker/elastic-docker-tls.yml
+++ b/docs/en/getting-started/docker/elastic-docker-tls.yml
@@ -68,6 +68,8 @@ services:
     volumes:
       - data02:/usr/share/elasticsearch/data
       - certs:$CERTS_DIR
+    ports:
+      - 9201:9201
     networks:
       - elastic
       
@@ -99,6 +101,8 @@ services:
     volumes: 
       - data03:/usr/share/elasticsearch/data
       - certs:$CERTS_DIR
+    ports:
+      - 9202:9202
     networks:
       - elastic
   kib01:
@@ -110,7 +114,7 @@ services:
     environment:
       SERVERNAME: localhost
       ELASTICSEARCH_URL: https://es01:9200
-      ELASTICSEARCH_HOSTS: https://es01:9200
+      ELASTICSEARCH_HOSTS: '["https://es01:9200", "https://es02:9201", "https://es03:9202"]'
       ELASTICSEARCH_USERNAME: kibana
       ELASTICSEARCH_PASSWORD: CHANGEME
       ELASTICSEARCH_SSL_CERTIFICATEAUTHORITIES: $CERTS_DIR/ca/ca.crt


### PR DESCRIPTION
Expands the example visible on [this page of the docs](https://www.elastic.co/guide/en/elastic-stack-get-started/current/get-started-docker.html)

Based on [this stackoverflow question](https://stackoverflow.com/questions/62010914/what-is-the-syntax-for-elasticsearch-hosts-in-docker-compose) and a conversation with its author on our public Slack channel, I thought it made sense to flesh out the example to show how to set multiple values in YAML in object format generally and for `ELASTICSEARCH_HOSTS` specifically.