### PR TITLE
[7.x] Fix broken link to docs about configuring beats input in Logstash

### DIFF
--- a/docs/en/stack/redirects.asciidoc
+++ b/docs/en/stack/redirects.asciidoc
@@ -13,7 +13,7 @@ See {stack-gs}/get-started-elastic-stack.html[Getting started with the {stack}].
 [[logstash-setup]]
 === Configure Logstash to listen for Beats input
 
-See {stack-gs}/get-started-elastic-stack.html#logstash-setup[Configure Logstash to listen for Beats input].
+See {logstash-ref}/plugins-inputs-beats.html[Beats input plugin].
 
 [role="exclude",id="xpack-security"]
 === Securing the {stack}


### PR DESCRIPTION
Required to fix build error in https://github.com/elastic/stack-docs/pull/1105.