### PR TITLE
[DOCS] Adds ESS APIs to landing page

### DIFF
--- a/docs/en/stack/index-landing-all.adoc
+++ b/docs/en/stack/index-landing-all.adoc
@@ -9,10 +9,10 @@
 :xpack-terms:
 :buildtool:           asciidoctor
 :toc:                 left
-:toclevels:           3
+:toclevels:           4
 :lang:                en
 :beats-repo-dir:      {docdir}/../../../../beats/libbeat/docs
-:es-repo-dir:         {docdir}/../../../../elasticsearch/docs
+:es-repo-dir:         {docdir}/../../../../elasticsearch/docs/reference
 :xes-repo-dir:        {docdir}/../../../../elasticsearch/x-pack/docs/{lang}
 :hadoop-repo-dir:     {docdir}/../../../../elasticsearch-hadoop/docs/src/reference/asciidoc
 :kib-repo-dir:        {docdir}/../../../../kibana/docs

--- a/docs/en/stack/index-landing-all.adoc
+++ b/docs/en/stack/index-landing-all.adoc
@@ -18,8 +18,15 @@
 :kib-repo-dir:        {docdir}/../../../../kibana/docs
 :ls-repo-dir:         {docdir}/../../../../logstash/docs
 :stack-repo-dir:      {docdir}
+:cloud-repo-dir:      {docdir}/../../../../cloud/docs
 :includedir:          {docdir}
 
 include::{docdir}/../../../../docs/shared/versions/stack/master.asciidoc[]
 include::{docdir}/../../../../docs/shared/attributes.asciidoc[]
+
+//Attributes for ESS APIs
+:n:                    {ess}
+:s:                    ESS
+:p:                    ec
+
 include::landing-all.asciidoc[]

--- a/docs/en/stack/index-landing.adoc
+++ b/docs/en/stack/index-landing.adoc
@@ -9,10 +9,10 @@
 :xpack-terms:
 :buildtool:           asciidoctor
 :toc:                 left
-:toclevels:           3
+:toclevels:           4
 :lang:                en
 :beats-repo-dir:      {docdir}/../../../../beats/libbeat/docs
-:es-repo-dir:         {docdir}/../../../../elasticsearch/docs
+:es-repo-dir:         {docdir}/../../../../elasticsearch/docs/reference
 :xes-repo-dir:        {docdir}/../../../../elasticsearch/x-pack/docs/{lang}
 :hadoop-repo-dir:     {docdir}/../../../../elasticsearch-hadoop/docs/src/reference/asciidoc
 :kib-repo-dir:        {docdir}/../../../../kibana/docs

--- a/docs/en/stack/index-landing.adoc
+++ b/docs/en/stack/index-landing.adoc
@@ -17,9 +17,16 @@
 :hadoop-repo-dir:     {docdir}/../../../../elasticsearch-hadoop/docs/src/reference/asciidoc
 :kib-repo-dir:        {docdir}/../../../../kibana/docs
 :ls-repo-dir:         {docdir}/../../../../logstash/docs
+:cloud-repo-dir:      {docdir}/../../../../cloud/docs
 :stack-repo-dir:      {docdir}
 :includedir:          {docdir}
 
 include::{docdir}/../../../../docs/shared/versions/stack/master.asciidoc[]
 include::{docdir}/../../../../docs/shared/attributes.asciidoc[]
+
+//Attributes for ESS APIs
+:n:                    {ess}
+:s:                    ESS
+:p:                    ec
+
 include::landing.asciidoc[]

--- a/docs/en/stack/index-landing.asciidoc
+++ b/docs/en/stack/index-landing.asciidoc
@@ -10,7 +10,7 @@
 :buildtool:           builddocs
 :includedir:          {docdir}
 :beats-repo-dir:      {docdir}/../../../../beats/libbeat/docs
-:es-repo-dir:         {docdir}/../../../../elasticsearch/docs
+:es-repo-dir:         {docdir}/../../../../elasticsearch/docs/reference
 :xes-repo-dir:        {docdir}/../../../../elasticsearch/x-pack/docs/{lang}
 :hadoop-repo-dir:     {docdir}/../../../../elasticsearch-hadoop/docs/src/reference/asciidoc
 :kib-repo-dir:        {docdir}/../../../../kibana/docs

--- a/docs/en/stack/index-landing.asciidoc
+++ b/docs/en/stack/index-landing.asciidoc
@@ -15,9 +15,15 @@
 :hadoop-repo-dir:     {docdir}/../../../../elasticsearch-hadoop/docs/src/reference/asciidoc
 :kib-repo-dir:        {docdir}/../../../../kibana/docs
 :ls-repo-dir:         {docdir}/../../../../logstash/docs
+:cloud-repo-dir:      {docdir}/../../../../cloud/docs
 :stack-repo-dir:      {docdir}
 
 include::{asciidoc-dir}/../../shared/versions/stack/{source_branch}.asciidoc[]
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
+
+//Attributes for ESS APIs
+:n:                    {ess}
+:s:                    ESS
+:p:                    ec
 
 include::landing.asciidoc[]

--- a/docs/en/stack/landing-all.asciidoc
+++ b/docs/en/stack/landing-all.asciidoc
@@ -202,7 +202,7 @@ endif::[]
 ifeval::["{buildtool}" == "gradle"]
 :imagesdir: elasticsearch/docs/reference/monitoring/
 endif::[]
-include::{es-repo-dir}/reference/monitoring/overview.asciidoc[lines=8..-1]
+include::{es-repo-dir}/monitoring/overview.asciidoc[lines=8..-1]
 ifeval::["{buildtool}" == "asciidoctor"]
 :!imagesdir:
 endif::[]
@@ -406,16 +406,20 @@ endif::[]
 [[elasticsearch-apis]]
 === {es} APIs
 
-TBD
+include::{es-repo-dir}/rest-api/index.asciidoc[lines=6..12]
+
+include::{es-repo-dir}/api-conventions.asciidoc[leveloffset=+2]
+
+include::{es-repo-dir}/ml/anomaly-detection/apis/ml-api.asciidoc[leveloffset=+2]
 
 [[ess-apis]]
 === {ess} APIs
 
 include::{cloud-repo-dir}/saas/ec-restful-api.asciidoc[lines=6..15]
 
-include::{cloud-repo-dir}/saas/ec-restful-api.asciidoc[lines=19..328,leveloffset=+2]
+include::{cloud-repo-dir}/saas/ec-restful-api.asciidoc[lines=19..-1,leveloffset=+2]
 
-include::{cloud-repo-dir}/saas/saas-api-swagger.asciidoc[leveloffset=+2]
+include::{cloud-repo-dir}/saas/saas-api-swagger.asciidoc[leveloffset=+3]
 
 [[kibana-apis]]
 === {kib} APIs
@@ -448,7 +452,8 @@ TBD
 [[elasticsearch-settings]]
 === Elasticsearch settings
 
-TBD
+include::{es-repo-dir}/settings/ml-settings.asciidoc[leveloffset=+1]
+
 
 [[elasticsearch-plugins]]
 === Elasticsearch plugins & integrations
@@ -458,7 +463,7 @@ TBD
 [[ml-functions]]
 === Machine learning functions
 
-include::{es-repo-dir}/reference/ml/anomaly-detection/functions.asciidoc[lines=5..-1,leveloffset=+1]
+include::{es-repo-dir}/ml/anomaly-detection/functions.asciidoc[lines=5..-1,leveloffset=+1]
 
 [[ml-modules]]
 === Machine learning modules
@@ -480,7 +485,7 @@ TBD
 
 TBD
 
-[[security-roles]]
+[[built-in-roles]]
 === Security built-in roles
 
 TBD
@@ -490,15 +495,11 @@ include::{xes-repo-dir}/security/authorization/privileges.asciidoc[]
 
 //Omitting Glossary from gradle build due to build issues
 ifeval::["{buildtool}" == "asciidoctor"]
-:es-repo-dir:  {es-repo-dir}/reference
 include::{stack-repo-dir}/../glossary/glossary.asciidoc[leveloffset=+1]
-:!es-repo-dir:
 endif::[]
 
 ifeval::["{buildtool}" == "builddocs"]
-:es-repo-dir:  {es-repo-dir}/reference
 include::{stack-repo-dir}/../glossary/glossary.asciidoc[leveloffset=+1]
-:!es-repo-dir:
 endif::[]
 
 [[release-notes]]

--- a/docs/en/stack/landing-all.asciidoc
+++ b/docs/en/stack/landing-all.asciidoc
@@ -411,7 +411,11 @@ TBD
 [[ess-apis]]
 === {ess} APIs
 
-TBD
+include::{cloud-repo-dir}/saas/ec-restful-api.asciidoc[lines=6..15]
+
+include::{cloud-repo-dir}/saas/ec-restful-api.asciidoc[lines=19..328,leveloffset=+2]
+
+include::{cloud-repo-dir}/saas/saas-api-swagger.asciidoc[leveloffset=+2]
 
 [[kibana-apis]]
 === {kib} APIs

--- a/docs/en/stack/landing.asciidoc
+++ b/docs/en/stack/landing.asciidoc
@@ -412,7 +412,11 @@ TBD
 [[ess-apis]]
 === {ess} APIs
 
-TBD
+include::{cloud-repo-dir}/saas/ec-restful-api.asciidoc[lines=6..15]
+
+include::{cloud-repo-dir}/saas/ec-restful-api.asciidoc[lines=19..328,leveloffset=+2]
+
+include::{cloud-repo-dir}/saas/saas-api-swagger.asciidoc[leveloffset=+2]
 
 [[kibana-apis]]
 === Kibana APIs

--- a/docs/en/stack/landing.asciidoc
+++ b/docs/en/stack/landing.asciidoc
@@ -67,7 +67,7 @@ include::{beats-repo-dir}/release-notes/highlights/highlights.asciidoc[lines=4..
 [[elasticsearch-highlights]]
 === {es} release highlights
 
-include::{es-repo-dir}/reference/release-notes/highlights.asciidoc[lines=6..7]
+include::{es-repo-dir}/release-notes/highlights.asciidoc[lines=6..7]
 
 [[kibana-highlights]]
 === {kib} release highlights
@@ -100,7 +100,7 @@ include::{includedir}/../../../../docs/shared/cloud/ess-getting-started.asciidoc
 TBD
 
 [[admin-guides]]
-== Admin Guides
+== Admin guides
 
 TBD
 
@@ -203,7 +203,7 @@ endif::[]
 ifeval::["{buildtool}" == "gradle"]
 :imagesdir: elasticsearch/docs/reference/monitoring/
 endif::[]
-include::{es-repo-dir}/reference/monitoring/overview.asciidoc[lines=8..-1]
+include::{es-repo-dir}/monitoring/overview.asciidoc[lines=8..-1]
 ifeval::["{buildtool}" == "asciidoctor"]
 :!imagesdir:
 endif::[]
@@ -217,7 +217,7 @@ endif::[]
 TBD
 
 [[analyst-guides]]
-== Analyst Guides
+== Analyst guides
 
 TBD
 
@@ -277,7 +277,7 @@ TBD
 TBD
 
 [[developer-guides]]
-== Developer Guides
+== Developer guides
 
 [[interact]]
 === Interact with Elasticsearch
@@ -315,7 +315,7 @@ TBD
 TBD
 
 [[contributor-guides]]
-== Contributor/Plugin Developer Guides
+== Contributor/Plugin developer guides
 
 [[core-dev]]
 === Core development
@@ -382,7 +382,7 @@ endif::[]
 
 TBD
 
-[[security]]
+[[security-concepts]]
 === Security
 
 include::{xes-repo-dir}/security/authentication/realms.asciidoc[lines=1..53,leveloffset=+1]
@@ -407,19 +407,23 @@ endif::[]
 [[elasticsearch-apis]]
 === {es} APIs
 
-TBD
+include::{es-repo-dir}/rest-api/index.asciidoc[lines=6..12]
+
+include::{es-repo-dir}/api-conventions.asciidoc[leveloffset=+2]
+
+include::{es-repo-dir}/ml/anomaly-detection/apis/ml-api.asciidoc[leveloffset=+2]
 
 [[ess-apis]]
 === {ess} APIs
 
 include::{cloud-repo-dir}/saas/ec-restful-api.asciidoc[lines=6..15]
 
-include::{cloud-repo-dir}/saas/ec-restful-api.asciidoc[lines=19..328,leveloffset=+2]
+include::{cloud-repo-dir}/saas/ec-restful-api.asciidoc[lines=19..-1,leveloffset=+2]
 
-include::{cloud-repo-dir}/saas/saas-api-swagger.asciidoc[leveloffset=+2]
+include::{cloud-repo-dir}/saas/saas-api-swagger.asciidoc[leveloffset=+3]
 
 [[kibana-apis]]
-=== Kibana APIs
+=== {kib} APIs
 
 include::{kib-repo-dir}/user/api.asciidoc[lines=6..12]
 include::{kib-repo-dir}/api/using-api.asciidoc[leveloffset=+2]
@@ -448,7 +452,7 @@ TBD
 [[elasticsearch-settings]]
 === Elasticsearch settings
 
-TBD
+include::{es-repo-dir}/settings/ml-settings.asciidoc[leveloffset=+1]
 
 [[elasticsearch-plugins]]
 === Elasticsearch plugins & integrations
@@ -458,7 +462,7 @@ TBD
 [[ml-functions]]
 === Machine learning functions
 
-include::{es-repo-dir}/reference/ml/anomaly-detection/functions.asciidoc[lines=5..-1,leveloffset=+1]
+include::{es-repo-dir}/ml/anomaly-detection/functions.asciidoc[lines=5..-1,leveloffset=+1]
 
 [[ml-modules]]
 === Machine learning modules
@@ -480,7 +484,7 @@ TBD
 
 TBD
 
-[[security-roles]]
+[[built-in-roles]]
 === Security built-in roles
 
 TBD
@@ -490,15 +494,11 @@ include::{xes-repo-dir}/security/authorization/privileges.asciidoc[]
 
 //Omitting Glossary from gradle build due to build issues
 ifeval::["{buildtool}" == "asciidoctor"]
-:es-repo-dir:  {es-repo-dir}/reference
 include::{stack-repo-dir}/../glossary/glossary.asciidoc[leveloffset=+1]
-:!es-repo-dir:
 endif::[]
 
 ifeval::["{buildtool}" == "builddocs"]
-:es-repo-dir:  {es-repo-dir}/reference
 include::{stack-repo-dir}/../glossary/glossary.asciidoc[leveloffset=+1]
-:!es-repo-dir:
 endif::[]
 
 

--- a/docs/en/stack/redirects-landing.adoc
+++ b/docs/en/stack/redirects-landing.adoc
@@ -198,3 +198,8 @@ See {ml-docs}/ml-configuring-transform.html[Transforming data with script fields
 === Available regions, deployment templates and instance configurations
 
 See {cloud}/{p}-regions-templates-instances.html[Available regions, deployment templates and instance configurations].
+
+[role="exclude",id="ec-api-swagger"]
+=== API reference documentation
+
+See {cloud}/ec-api-swagger.html[API reference documentation].

--- a/docs/en/stack/redirects-landing.adoc
+++ b/docs/en/stack/redirects-landing.adoc
@@ -194,12 +194,113 @@ See {ref}/mapping-roles.html[Mapping users and groups to roles].
 
 See {ml-docs}/ml-configuring-transform.html[Transforming data with script fields].
 
+[role="exclude",id="cluster-update-settings"]
+=== Cluster update settings API
+
+See {ref}/cluster-update-settings.html[Cluster update settings API].
+
+[role="exclude",id="request-body-search-script-fields"]
+=== Script fields
+
+See {ref}/search-request-body.html#request-body-search-script-fields[Script fields].
+
+[role="exclude",id="http-clients-secondary-authorization"]
+=== Secondary authorization
+
+See {ref}/http-clients.html#http-clients-secondary-authorization[Secondary authorization].
+
+[role="exclude",id="modules-http"]
+=== HTTP
+
+See {ref}/modules-http.html[HTTP].
+
+[role="exclude",id="indices-aliases"]
+=== Update index alias API
+
+See {ref}/indices-aliases.html[Update index alias API].
+
+[role="exclude",id="index-hidden"]
+=== Index.hidden
+
+See {ref}/index-modules.html#index-hidden[Index.hidden].
+
+[role="exclude",id="elasticsearch-croneval"]
+=== elasticsearch-croneval
+
+See {ref}/elasticsearch-croneval.html[elasticsearch-croneval].
+
+[role="exclude",id="docs"]
+=== Document APIs
+
+TBD
+
+[role="exclude",id="query-dsl-range-query"]
+=== Range query
+
+TBD
+
+
+[role="exclude",id="search-aggregations-bucket-daterange-aggregation"]
+=== Date range aggregation
+
+TBD
+
+[role="exclude",id="get-source-filtering"]
+=== Source filtering
+
+TBD
+
+[role="exclude",id="query-dsl-geo-distance-query"]
+=== Geo-distance query
+
+TBD
+
+[role="exclude",id="search-multi-search"]
+=== Multi search API
+
+TBD
+
+[role="exclude",id="docs-multi-get"]
+=== Multi get (mget) API
+
+TBD
+
+[role="exclude",id="ml-df-analytics-apis"]
+=== {ml-cap} {dfanalytics} APIs
+
+TBD
+
+[role="exclude",id="indices-analyze"]
+=== Analyze API
+
+TBD
+
+[role="exclude",id="analysis-analyzers"]
+=== Built-in analyzer reference
+
+TBD
+
+[role="exclude",id="analysis-charfilters"]
+=== Character filters reference
+
+TBD
+
+[role="exclude",id="analysis-pattern-replace-charfilter"]
+=== Pattern replace char filter
+
+TBD
+
+[role="exclude",id="analysis-tokenizers"]
+=== Tokenizer reference
+
+TBD
+
+[role="exclude",id="analysis-tokenfilters"]
+=== Token filter reference
+
+TBD
+
 [role="exclude",id="{p}-regions-templates-instances"]
 === Available regions, deployment templates and instance configurations
 
 See {cloud}/{p}-regions-templates-instances.html[Available regions, deployment templates and instance configurations].
-
-[role="exclude",id="ec-api-swagger"]
-=== API reference documentation
-
-See {cloud}/ec-api-swagger.html[API reference documentation].

--- a/docs/en/stack/redirects-landing.adoc
+++ b/docs/en/stack/redirects-landing.adoc
@@ -193,3 +193,8 @@ See {ref}/mapping-roles.html[Mapping users and groups to roles].
 === Transforming data with script fields
 
 See {ml-docs}/ml-configuring-transform.html[Transforming data with script fields].
+
+[role="exclude",id="{p}-regions-templates-instances"]
+=== Available regions, deployment templates and instance configurations
+
+See {cloud}/{p}-regions-templates-instances.html[Available regions, deployment templates and instance configurations].


### PR DESCRIPTION
This PR drafts the inclusion of the ESS APIs (https://www.elastic.co/guide/en/cloud/current/ec-restful-api.html) in the landing page.

The following PR must be merged first: https://github.com/elastic/elasticsearch/pull/57390