### PR TITLE
[7.8] docs: add APM to release highlights and changes

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -2,7 +2,7 @@
 == Breaking changes
 
 Before you upgrade, you must review the breaking changes for each product you
-use and make the necessary changes so your code is compatible with {version}. 
+use and make the necessary changes so your code is compatible with {version}.
 
 ** <<apm-breaking-changes,APM {version} breaking changes>>
 ** <<beats-breaking-changes,Beats {version} breaking changes>>
@@ -30,10 +30,10 @@ Upgrade Assistant provides information about which {dfeeds} need to be updated.
 
 coming::[7.8.0]
 
-This list summarizes the most important breaking changes in APM. 
-For the complete list, go to {apm-server-ref-70}/breaking-changes.html[APM Server 7.0 breaking changes].
+This list summarizes the most important breaking changes in APM.
+For the complete list, go to {apm-server-ref-v}/breaking-changes.html[APM Server 7.8 breaking changes].
 
-//include::{apm-repo-dir}/apm-breaking-changes.asciidoc[tag=notable-v7-breaking-changes]
+include::{apm-repo-dir}/apm-breaking-changes.asciidoc[tag=notable-v78-breaking-changes]
 
 [[beats-breaking-changes]]
 === Beats breaking changes
@@ -106,4 +106,3 @@ the complete list, go to
 {logstash-ref}/breaking-changes.html[Logstash breaking changes].
 
 include::{ls-repo-dir}/static/breaking-changes.asciidoc[tag=notable-breaking-changes]
-

--- a/docs/en/install-upgrade/highlights.asciidoc
+++ b/docs/en/install-upgrade/highlights.asciidoc
@@ -1,15 +1,14 @@
 [[elastic-stack-highlights]]
-== Highlights 
+== Highlights
 
 Each release brings new features and product improvements. This section
 highlights notable new features and enhancements in {version}.
 
-//** <<apm-highlights,APM>>
+** <<apm-highlights,APM>>
 ** <<beats-highlights,Beats>>
 ** <<elasticsearch-highlights,{es}>>
 ** <<kibana-higlights,{kib}>>
 
-////
 [[apm-highlights]]
 === APM highlights
 ++++
@@ -20,8 +19,7 @@ This list summarizes the most important enhancements in APM.
 For the complete list, go to
 {apm-overview-ref-v}/apm-release-notes.html[APM release highlights].
 
-include::{apm-repo-dir}/apm-release-notes.asciidoc[tag=notable-v7-highlights]
-////
+include::{apm-repo-dir}/apm-release-notes.asciidoc[tag=notable-v78-highlights]
 
 [[beats-highlights]]
 === Beats highlights


### PR DESCRIPTION
Adds APM breaking changes and release highlights to the installation and upgrade guide for `7.8`.

Blocked by https://github.com/elastic/apm-server/pull/3869.