### PR TITLE
[DOCS] Updates path to Kibana highlights

### DIFF
--- a/docs/en/install-upgrade/highlights.asciidoc
+++ b/docs/en/install-upgrade/highlights.asciidoc
@@ -68,6 +68,6 @@ This list summarizes the most important enhancements in {kib} {version}.
 
 :leveloffset: +1
 
-include::{kib-repo-dir}/release-notes/highlights-8.0.0.asciidoc[tag=notable-highlights]
+include::{kib-repo-dir}/user/whats-new.asciidoc[tag=notable-highlights]
 
 :leveloffset: -1


### PR DESCRIPTION
Related to https://github.com/elastic/kibana/pull/68918

The Kibana release highlights have moved, so the Installation and Upgrade Guide needs to seek the tagged sections from their new location.