### PR TITLE
[7.8] Temporarily comment out overview (#1157)

### DIFF
--- a/docs/en/ingest-management/index.asciidoc
+++ b/docs/en/ingest-management/index.asciidoc
@@ -6,7 +6,7 @@ include::{docs-root}/shared/versions/stack/{source_branch}.asciidoc[]
 
 include::{docs-root}/shared/attributes.asciidoc[]
 
-include::overview.asciidoc[leveloffset=+1]
+//include::overview.asciidoc[leveloffset=+1]
 
 include::getting-started.asciidoc[leveloffset=+1]
 


### PR DESCRIPTION
Backports the following commits to 7.8:
 - Temporarily comment out overview (#1157)