### PR TITLE
[7.x] Get agent docs building (#1163)

### DIFF
--- a/docs/en/ingest-management/index.asciidoc
+++ b/docs/en/ingest-management/index.asciidoc
@@ -1,4 +1,5 @@
 :doctype: book
+:beats-repo-dir: {beats-root}
 
 = Ingest Management Guide
 
@@ -10,7 +11,7 @@ include::{docs-root}/shared/attributes.asciidoc[]
 
 include::getting-started.asciidoc[leveloffset=+1]
 
-//include::{beats-repo-dir}/x-pack/elastic-agent/docs/elastic-agent.asciidoc[leveloffset=+1]
+include::{beats-repo-dir}/x-pack/elastic-agent/docs/elastic-agent.asciidoc[leveloffset=+1]
 
 include::troubleshooting.asciidoc[leveloffset=+1]
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Get agent docs building (#1163)