### PR TITLE
Edit ingest management overview

### DIFF
--- a/docs/en/ingest-management/index.asciidoc
+++ b/docs/en/ingest-management/index.asciidoc
@@ -7,7 +7,7 @@ include::{docs-root}/shared/versions/stack/{source_branch}.asciidoc[]
 
 include::{docs-root}/shared/attributes.asciidoc[]
 
-//include::overview.asciidoc[leveloffset=+1]
+include::ingest-management-overview.asciidoc[leveloffset=+1]
 
 include::getting-started.asciidoc[leveloffset=+1]
 

--- a/docs/en/ingest-management/index.asciidoc
+++ b/docs/en/ingest-management/index.asciidoc
@@ -9,6 +9,8 @@ include::{docs-root}/shared/attributes.asciidoc[]
 
 include::ingest-management-overview.asciidoc[leveloffset=+1]
 
+include::ingest-management-limitations.asciidoc[leveloffset=+2]
+
 include::getting-started.asciidoc[leveloffset=+1]
 
 include::{beats-repo-dir}/x-pack/elastic-agent/docs/elastic-agent.asciidoc[leveloffset=+1]

--- a/docs/en/ingest-management/ingest-management-limitations.asciidoc
+++ b/docs/en/ingest-management/ingest-management-limitations.asciidoc
@@ -1,0 +1,33 @@
+[[ingest-management-limitations]]
+= Limitations of this release
+
+This is an experimental release and there is no migration path for future
+releases, so **YOU MUST TEST IN A DEDICATED CLUSTER.** In a future release, we
+plan to add support for a new way of managing rolling indices that will make the
+experience easier for users. However, any data stored in this release will not
+be migrated in our next release, and you must wipe any data and settings changed
+in {kib} and {es} to avoid future conflicts. We recommend using a dedicated test
+cluster or deployment that can be deleted when you are done.
+
+{ingest-manager} is currently only available to users with the
+{es-ref}/built-in-roles.html[superuser role]. This role is necessary to create
+indices, install integration assets, and update {agent} configurations. In order
+to use {fleet}, the {agent}s must have a direct network connection to {kib} and
+{es}. It is also possible to run the {agent}s in standalone mode in cases where
+a network connection is not available or not needed.
+
+This feature has several additional limitations at the current time:
+
+*   Support for only 9 integrations (more coming soon)
+*   Support for only {filebeat} and {metricbeat}
+*   We recommend you enroll no more than 100 Agents
+*   No output to {ls}, Kafka, or other remote clusters
+*   No proxy support in {agent}
+*   {kib} must have internet access to download integration packages
+*   No support for advanced {beats} settings like multiline, processors, and so
+on
+*   No custom index templates or pipelines
+*   No support for Kubernetes or Docker autodiscovery
+
+Experimental releases are not officially supported, but we encourage you to
+report issues in our [discuss forum](https://ela.st/agent-discuss).

--- a/docs/en/ingest-management/ingest-management-limitations.asciidoc
+++ b/docs/en/ingest-management/ingest-management-limitations.asciidoc
@@ -10,7 +10,7 @@ in {kib} and {es} to avoid future conflicts. We recommend using a dedicated test
 cluster or deployment that can be deleted when you are done.
 
 {ingest-manager} is currently only available to users with the
-{es-ref}/built-in-roles.html[superuser role]. This role is necessary to create
+{ref}/built-in-roles.html[superuser role]. This role is necessary to create
 indices, install integration assets, and update {agent} configurations. In order
 to use {fleet}, the {agent}s must have a direct network connection to {kib} and
 {es}. It is also possible to run the {agent}s in standalone mode in cases where
@@ -30,4 +30,4 @@ on
 *   No support for Kubernetes or Docker autodiscovery
 
 Experimental releases are not officially supported, but we encourage you to
-report issues in our [discuss forum](https://ela.st/agent-discuss).
+report issues in our https://ela.st/agent-discuss[discuss forum].

--- a/docs/en/ingest-management/ingest-management-overview.asciidoc
+++ b/docs/en/ingest-management/ingest-management-overview.asciidoc
@@ -118,37 +118,3 @@ default.
 When searching your data in {kib}, you can use an
 {kibana-ref}index-patterns.html[index pattern] to search across all or some of
 the indices.
-
-[[limitations]]
-== Limitations of this release
-
-This is an experimental release and there is no migration path for future
-releases, so **YOU MUST TEST IN A DEDICATED CLUSTER.** In a future release, we
-plan to add support for a new way of managing rolling indices that will make the
-experience easier for users. However, any data stored in this release will not
-be migrated in our next release, and you must wipe any data and settings changed
-in {kib} and {es} to avoid future conflicts. We recommend using a dedicated test
-cluster or deployment that can be deleted when you are done.
-
-{ingest-manager} is currently only available to users with the
-{es-ref}/built-in-roles.html[superuser role]. This role is necessary to create
-indices, install integration assets, and update {agent} configurations. In order
-to use {fleet}, the {agent}s must have a direct network connection to {kib} and
-{es}. It is also possible to run the {agent}s in standalone mode in cases where
-a network connection is not available or not needed.
-
-This feature has several additional limitations at the current time:
-
-*   Support for only 9 integrations (more coming soon)
-*   Support for only {filebeat} and {metricbeat}
-*   We recommend you enroll no more than 100 Agents
-*   No output to {ls}, Kafka, or other remote clusters
-*   No proxy support in {agent}
-*   {kib} must have internet access to download integration packages
-*   No support for advanced {beats} settings like multiline, processors, and so
-on
-*   No custom index templates or pipelines
-*   No support for Kubernetes or Docker autodiscovery
-
-Experimental releases are not officially supported, but we encourage you to
-report issues in our [discuss forum](https://ela.st/agent-discuss).

--- a/docs/en/ingest-management/ingest-management-overview.asciidoc
+++ b/docs/en/ingest-management/ingest-management-overview.asciidoc
@@ -116,5 +116,5 @@ their indices this way, and now we are providing this best practice as a
 default.
 
 When searching your data in {kib}, you can use an
-{kibana-ref}index-patterns.html[index pattern] to search across all or some of
+{kibana-ref}/index-patterns.html[index pattern] to search across all or some of
 the indices.

--- a/docs/en/ingest-management/ingest-management-overview.asciidoc
+++ b/docs/en/ingest-management/ingest-management-overview.asciidoc
@@ -1,79 +1,154 @@
 [[ingest-management-overview]]
-== Ingest management overview
+= Ingest management overview
+
+experimental[]
+
+//REVIEWERS: Please confirm that I have the sections here marked correctly with
+//the xpack flag.
 
 [float]
 [[elastic-agent]]
-=== Elastic Agent
+== {agent}
 
-Elastic Agent is a single, unified way to add monitoring for logs, metrics, and other types of data to each host. A single agent will make it easier and faster to deploy across your infrastructure. Additionally, it offers a single, unified configuration to make it easier to add integrations for new data sources.
+//TODO: We use "makes it easier" too frequently in this topic. Clean it up.
+
+{agent} is a single, unified way to add monitoring for logs, metrics, and
+other types of data to each host. A single agent makes it easier and faster
+to deploy monitoring across your infrastructure. The agent's single, unified
+configuration makes it easier to add integrations for new data sources.
 
 [float]
+[role="xpack"]
 [[ingest-manager]]
-=== Ingest Manager
+== {ingest-manager}
 
-Ingest Manager provides a web-based UI in Kibana to add and manage integrations for popular services and platforms, as well as manage a fleet of Elastic Agents. Our integrations not only provide an easy way to add new sources of data, but they also ship with out of the box assets like dashboards, visualizations, and pipelines to extract structured fields out of logs. This makes it easier to get insights within seconds.
+{ingest-manager} provides a web-based UI in {kib} to add and manage integrations
+for popular services and platforms, as well as manage a fleet of {agent}s. Our
+integrations provide an easy way to add new sources of data, plus they ship
+with out-of-the-box assets like dashboards, visualizations, and pipelines to
+extract structured fields out of logs. This makes it easier to get insights
+within seconds.
 
 [role="screenshot"]
 image::images/integrations.png[Integrations page]
 
 [float]
+[role="xpack"]
 [[configuring-integrations]]
-=== Configuring Integrations
+== {integrations} in {ingest-manager}
 
-We provide a web-based UI for configuring integrations with your data sources. This can include popular services and platforms like Nginx or AWS, as well as many generic input types like log files.
+{ingest-manager} provides a web-based UI for configuring integrations with your
+data sources. This includes popular services and platforms like Nginx or AWS,
+as well as many generic input types like log files.
 
-The Elastic Agent configuration allows you to configure any number of integrations for data sources. The Agent configuration can be applied to multiple Agents. This makes it even easier to manage configuration at scale.
+The {agent} configuration allows you to use any number of integrations for
+data sources. You can apply the {agent} configuration to multiple agents,
+making it even easier to manage configuration at scale.
 
 [role="screenshot"]
 image::images/data-source.png[Configuring a data source]
 
-You may define a data source by supplying a name and description. You can then configure inputs for logs and metrics, such as the path to your Nginx access logs. When you are done, you may save the data source to update the Agent configuration. The next time enrolled Agents check in, they will receive the update. Having those configurations automatically deployed is more convenient than doing it yourself using SSH, Ansible playbooks, etc.
+You define a data source by supplying a name and description. Then you
+configure inputs for logs and metrics, such as the path to your Nginx access
+logs. When you're done, you save the data source to update the {agent}
+configuration. The next time enrolled agents check in, they receive the update.
+Having the configurations automatically deployed is more convenient
+than doing it yourself by using SSH, Ansible playbooks, or some other tool.
 
-If you prefer infrastructure as code, you may prefer to use YAML files and APIs. Ingest Manager has an API-first design and anything you can do in the UI you can also do using the API. This makes it easy to automate and integrate with other systems.
+If you prefer infrastructure as code, you may use YAML files and APIs.
+{ingest-manager} has an API-first design. Anything you can do in the UI, you
+can also do using the API. This makes it easy to automate and integrate with
+other systems.
 
 [float]
+[role="xpack"]
 [[central-management]]
-=== Central management in Fleet
+== Central management in {fleet}
 
-You can see the state of all your Elastic Agents on the Fleet page. Here you can see which agents are online, which have errors, and the last time they checked in. You can also see the version of the Agent binary and configuration. 
+You can see the state of all your {agent}s on the {fleet} page. Here you can see
+which agents are online, which have errors, and the last time they checked in.
+You can also see the version of the {agent} binary and configuration. 
 
 [role="screenshot"]
-image::images/fleet.png[Fleet page]
+image::images/fleet.png[{fleet} page]
 
-Fleet serves as the communication channel back to the Elastic Agents. Agents check in for the latest updates on a regular basis. You can have any number of Agents enrolled into each Agent configuration, which allows you to scale up to thousands of hosts. When you make a change to an Agent configuration, all the Agents receive the update during their next check in. You no longer have to distribute configuration updates yourself using SSH, Ansible playbooks, or other configuration methods. 
+{fleet} serves as the communication channel back to the {agent}s. Agents check
+in for the latest updates on a regular basis. You can have any number of agents
+enrolled into each agent configuration, which allows you to scale up to
+thousands of hosts. When you make a change to an agent configuration, all the
+agents receive the update during their next check-in. You no longer have to
+distribute configuration updates yourself using SSH, Ansible playbooks, or other
+configuration methods.
 
 [float]
 [[data-streams]]
 === Data streams make index management easier
 
-The data collected by Elastic Agents is stored in indices that are more granular than you’d get by default with Filebeat. The advantages are that it gives users more visibility into the sources of data volume, and control over lifecycle management policies and index permissions. We call these new indices “data streams” and we will have more improvements on this concept in future releases.
+The data collected by {agent} is stored in indices that are more granular than
+you’d get by default with {filebeat}. This gives you more visibility into the
+sources of data volume, and control over lifecycle management policies and index
+permissions. These indices are called _data streams_. We will have more
+improvements on this concept in future releases.
 
-In the screenshot below, you can see we’ve broken out the data streams (or indices) by dataset, type, and namespace. The dataset is defined by the integration and describes the fields and other settings for each index. For example, you might have one dataset for process metrics with a field describing whether the process is running or not. Another dataset for disk I/O metrics will have a field describing the number of bytes read. This solves the issue of having indices with hundreds or thousands of fields because we only need to store a small number of fields in each index. This makes them more compact with faster autocomplete, and as an added bonus the discover page will only show relevant fields.
+As you can see in the following screen, each data stream (or index) is broken
+out by dataset, type, and namespace. 
 
 [role="screenshot"]
 image::images/data-streams.png[Data streams page]
 
-Namespaces are user-defined strings that allow you group data any way you like. For example, you might group your data by environment (prod, QA) or by team name. This makes it easier to search the data from a given source using index patterns, or to give users permissions to data by assigning an index pattern to user roles. Many of our customers already organize their indices this way, and now we are providing this best practice as a default out of the box.
+The _dataset_ is defined by the integration and describes the fields and other
+settings for each index. For example, you might have one dataset for process
+metrics with a field describing whether the process is running or not, and
+another dataset for disk I/O metrics with a field describing the number of bytes
+read.
 
-When searching your data in Kibana, you can use an [index pattern](https://www.elastic.co/guide/en/kibana/current/index-patterns.html) to search across all or some of the indices.
+This indexing strategy solves the issue of having indices with hundreds or
+thousands of fields. Because each index stores only a small number of fields,
+the indices are more compact with faster autocomplete. And as an added
+bonus, the Discover page only shows relevant fields.
+
+_Namespaces_ are user-defined strings that allow you to group data any way you
+like. For example, you might group your data by environment (`prod`, `QA`) or by
+team name. Using a namespace makes it easier to search the data from a given
+source by using index patterns, or to give users permissions to data by
+assigning an index pattern to user roles. Many of our customers already organize
+their indices this way, and now we are providing this best practice as a
+default.
+
+When searching your data in {kib}, you can use an
+{kibana-ref}index-patterns.html[index pattern] to search across all or some of
+the indices.
 
 [[limitations]]
 == Limitations of this release
 
-This is an experimental release and there is no migration path for future releases, so **YOU MUST TEST IN A DEDICATED CLUSTER.** In a future release, we plan to add support for a new way of managing rolling indices that will make the experience easier for users. However, any data stored in this release will not be migrated in our next release and you must wipe any data and settings changed in Kibana and Elasticsearch to avoid future conflicts. We recommend using a dedicated test cluster or deployment that can be deleted when you are done.
+This is an experimental release and there is no migration path for future
+releases, so **YOU MUST TEST IN A DEDICATED CLUSTER.** In a future release, we
+plan to add support for a new way of managing rolling indices that will make the
+experience easier for users. However, any data stored in this release will not
+be migrated in our next release, and you must wipe any data and settings changed
+in {kib} and {es} to avoid future conflicts. We recommend using a dedicated test
+cluster or deployment that can be deleted when you are done.
 
-Ingest Manager is currently only available to users with the [superuser role](https://www.elastic.co/guide/en/elasticsearch/reference/current/built-in-roles.html). This role is necessary to create indices, install integration assets, and update Agent configurations. In order to use Fleet, the Elastic Agents must have a direct network connection to Kibana and Elasticsearch. It is also possible to run the Elastic Agents in standalone mode in cases where a network connection is not available or not needed.
+{ingest-manager} is currently only available to users with the
+{es-ref}/built-in-roles.html[superuser role]. This role is necessary to create
+indices, install integration assets, and update {agent} configurations. In order
+to use {fleet}, the {agent}s must have a direct network connection to {kib} and
+{es}. It is also possible to run the {agent}s in standalone mode in cases where
+a network connection is not available or not needed.
 
 This feature has several additional limitations at the current time:
+
 *   Support for only 9 integrations (more coming soon)
-*   Support for only Filebeat and Metricbeat
+*   Support for only {filebeat} and {metricbeat}
 *   We recommend you enroll no more than 100 Agents
-*   No output to Logstash, Kafka, or other remote clusters
-*   No proxy support in Elastic Agent
-*   Kibana must have internet access to download integration packages
-*   No support for advanced Beats settings like multi-line, processors, etc.
+*   No output to {ls}, Kafka, or other remote clusters
+*   No proxy support in {agent}
+*   {kib} must have internet access to download integration packages
+*   No support for advanced {beats} settings like multiline, processors, and so
+on
 *   No custom index templates or pipelines
-*   No support for Kubernetes or Docker auto-discover
+*   No support for Kubernetes or Docker autodiscovery
 
-Experimental releases are not officially supported, but we encourage you to report issues in our [discuss forum](https://ela.st/agent-discuss).
-
+Experimental releases are not officially supported, but we encourage you to
+report issues in our [discuss forum](https://ela.st/agent-discuss).

--- a/docs/en/ingest-management/overview.asciidoc
+++ b/docs/en/ingest-management/overview.asciidoc
@@ -2,7 +2,8 @@
 [role="xpack"]
 = Overview
 
-//TODO: Add overview. Need to reconcile with Jason's content.
+//TODO: Delete this topic, but decide whether we want to describe the stack
+//components somewhere in the other docs.
 
 Ingest Management enables ...
 


### PR DESCRIPTION
Summary of changes:

* Edit to conform to Elastic style guidelines.
* Modify asciidoc markup (I made structural changes that necessitated this)
* Add line breaks (makes for easier diffs in the future)
* Move limitations to a separate topic so one topic = one html page

Open question: Do we want limitations at the same level as the overview or nested under it as it is now? 

(Sorry that the diff doesn't show changes very well, but I made a lot of changes, so please read all the text.)
