### PR TITLE
[DOCS] Uncomments Kibana breaking changes

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -90,7 +90,7 @@ coming::[7.8.0]
 This list summarizes the most important breaking changes in {kib} {version}. For
 the complete list, go to {kibana-ref}/breaking-changes.html[{kib} breaking changes].
 
-//include::{kib-repo-dir}/migration/migrate_7_8.asciidoc[tag=notable-breaking-changes]
+include::{kib-repo-dir}/migration/migrate_7_8.asciidoc[tag=notable-breaking-changes]
 
 [[logstash-breaking-changes]]
 === {ls} breaking changes


### PR DESCRIPTION
This PR must be merged after https://github.com/elastic/kibana/pull/68588 is backported to 7.8.

It uncomments the Kibana 7.8 breaking changes in the Installation and Upgrade Guide.