### PR TITLE
fix hyperlink typo for Beats issues

### DIFF
--- a/docs/en/ingest-management/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting.asciidoc
@@ -13,7 +13,7 @@ here. If your question isn't answered here, please review open issues in the
 following GitHub repositories:
 
 * https://github.com/elastic/kibana/issues[{kib}]
-* https://github.com/elastic/beats/issuess[{beats}]
+* https://github.com/elastic/beats/issues[{beats}]
 * https://github.com/elastic/package-registry/issues[{package-registry}]
 
 Contact us in the https://ela.st/ingest-manager-feedback[discuss forum]. Your feedback is very


### PR DESCRIPTION
@dedemorton FYI - let me know if you need anything more.  I'll keep reviewing.

Beats 'issues' link linked to:
https://github.com/elastic/beats/issuess

screenshot:
<img width="371" alt="Screen Shot 2020-06-15 at 2 52 58 PM" src="https://user-images.githubusercontent.com/12970373/84694930-08352d00-af18-11ea-94b2-453f9b1a9434.png">
