### PR TITLE
[DOCS] Modifies instruction in ML getting started to reflect UI changes

### DIFF
--- a/docs/en/stack/ml/get-started/get-started-prereqs.asciidoc
+++ b/docs/en/stack/ml/get-started/get-started-prereqs.asciidoc
@@ -22,8 +22,8 @@ user that has authority to manage {anomaly-jobs}. See <<setup>>.
 
 . {kibana-ref}/add-sample-data.html[Add the sample data sets that ship with {kib}]. 
 
-.. Click the {kib} logo in the upper left hand corner of your browser to navigate
-to the {kib} home page.
+.. Click the Elastic logo in the upper left hand corner of your browser to 
+navigate to the {kib} home page.
 
 .. Click *Load a data set and a Kibana dashboard*.
 


### PR DESCRIPTION
## Summary

This PR modifies the 3rd step of the Prerequisites section of ML getting started to reflect recent changes on the UI.
The changes apply to 7.8, 7.x, and 8.0. Version 7.7 still uses the Kibana logo.
### Preview

[Prerequisites](https://stack-docs_1179.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-getting-started.html)