### PR TITLE
[7.8] fix hyperlink typo for Beats issues (#1172)

### DIFF
--- a/docs/en/ingest-management/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting.asciidoc
@@ -11,7 +11,7 @@ here. If your question isn't answered here, please review open issues in the
 following GitHub repositories:
 
 * https://github.com/elastic/kibana/issues[{kib}]
-* https://github.com/elastic/beats/issuess[{beats}]
+* https://github.com/elastic/beats/issues[{beats}]
 * https://github.com/elastic/package-registry/issues[{package-registry}]
 
 Contact us in the https://ela.st/ingest-manager-feedback[discuss forum]. Your feedback is very


### PR DESCRIPTION
Backports the following commits to 7.8:
 - fix hyperlink typo for Beats issues (#1172)