### PR TITLE
[DOCS] Fixes license management link

### DIFF
--- a/docs/en/getting-started/get-started-stack.asciidoc
+++ b/docs/en/getting-started/get-started-stack.asciidoc
@@ -677,7 +677,7 @@ trial license so you can unlock the full capabilities of the {stack}. To learn
 how, read:
 
 * {ref}/elasticsearch-security.html[Securing the {stack}]
-* {stack-ov}/license-management.html[License Management]
+* {kibana-ref}/managing-licenses.html[License Management]
 
 Want to get up and running quickly with metrics monitoring and
 centralized log analytics? Try out the Metrics app and the Logs app in {kib}.


### PR DESCRIPTION
This PR fixes an outdated links to the Stack Overview book, which is no longer used.