### PR TITLE
variables in shell formatting are not expanded

### DIFF
--- a/docs/en/ingest-management/getting-started.asciidoc
+++ b/docs/en/ingest-management/getting-started.asciidoc
@@ -183,7 +183,7 @@ that directory.
 ----
 ./elastic-agent enroll KIBANA_URL ENROLLMENT_KEY
 
-The {agent} is currently in Experimental and should not be used in production
+The Elastic Agent is currently in Experimental and should not be used in production
 This will replace your current settings. Do you want to continue? [Y/n]:
 ----
 


### PR DESCRIPTION
hi - @dedemorton is this a normal thing or something new-ish?  In the 'shell' formatting usage the {agent} variable is not expanded to 'Elastic Agent' so I did this up.  

I don't know the ascii-docs format hardly at ll, if its not the right way to fix, thats ok - we can fix it better, just seemed easy to propose this in case it is right.  :)
 - should it get merged to master first and then to 7.8?  that's the usual process, I know...  update this if appropriate.  or i can, thanks much.

screenshot:
<img width="629" alt="Screen Shot 2020-06-16 at 6 51 17 PM" src="https://user-images.githubusercontent.com/12970373/84835955-bfa66e00-b002-11ea-99c6-b5319ee07e9f.png">

