### PR TITLE
Change misleading sentence about required config settings

### DIFF
--- a/docs/en/ingest-management/getting-started.asciidoc
+++ b/docs/en/ingest-management/getting-started.asciidoc
@@ -40,7 +40,7 @@ your own hardware].
 
 * On self-managed clusters, the following settings are required. If you're using
 our https://www.elastic.co/cloud/elasticsearch-service[hosted  {ess}] on
-{ecloud},  the required settings are already enabled.
+{ecloud}, these settings are already enabled.
 
 ** In your {es} configuration, enable: 
 +


### PR DESCRIPTION
Softens the wording so users are not misled into thinking there are no additional config steps required. 