### PR TITLE
[7.x] Change misleading sentence about required config settings (#1197)

### DIFF
--- a/docs/en/ingest-management/getting-started.asciidoc
+++ b/docs/en/ingest-management/getting-started.asciidoc
@@ -40,7 +40,7 @@ your own hardware].
 
 * On self-managed clusters, the following settings are required. If you're using
 our https://www.elastic.co/cloud/elasticsearch-service[hosted  {ess}] on
-{ecloud},  the required settings are already enabled.
+{ecloud}, these settings are already enabled.
 
 ** In your {es} configuration, enable: 
 +


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Change misleading sentence about required config settings (#1197)