### PR TITLE
[7.x] fixes terminology and typo (#1200)

### DIFF
--- a/docs/en/siem/detections/api/rules-api-export.asciidoc
+++ b/docs/en/siem/detections/api/rules-api-export.asciidoc
@@ -1,9 +1,9 @@
 [[rules-api-export]]
-=== Exports rules
+=== Export rules
 
 Exports rules to an ndjson file.
 
-NOTE: You cannot export prepackaged rules.
+NOTE: You cannot export prebuilt rules.
 
 ==== Request URL
 

--- a/docs/en/siem/detections/api/rules-api-prebuilt.asciidoc
+++ b/docs/en/siem/detections/api/rules-api-prebuilt.asciidoc
@@ -1,11 +1,11 @@
 [[prebuilt-rules-api]]
 [role="xpack"]
-=== Prepackaged rules
+=== Prebuilt rules
 
 The prepackaged endpoint is for retrieving rule statuses and loading Elastic 
 prebuilt detection rules.
 
-==== Load prepackaged rules
+==== Load prebuilt rules
 
 Loads and updates Elastic prebuilt rules.
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - fixes terminology and typo (#1200)