### PR TITLE
Update breaking.asciidoc

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -13,7 +13,7 @@ use and make the necessary changes so your code is compatible with {version}.
 
 [IMPORTANT]
 ===============================
-
+* Make sure you check the breaking changes for each point release up to the desired new version.
 * If you're upgrading from 5.n, make sure you check the breaking changes from
 5.n to 6.n, as well as from 6.n to 7.n!
 * If you are using {ml} {dfeeds} that contain discontinued search or query


### PR DESCRIPTION
The important notes remind the user to check each minor release breaking changes if they are going from 5.x to 7.x, but not from 6.x to 7.x.