### PR TITLE
Adds alphabetical links to Glossary

### DIFF
--- a/docs/en/glossary/glossary.asciidoc
+++ b/docs/en/glossary/glossary.asciidoc
@@ -3,47 +3,49 @@
 
 <<a-glos>> | <<b-glos>> | <<c-glos>> | <<d-glos>> | <<e-glos>> | <<f-glos>> | <<g-glos>> | <<h-glos>> | <<i-glos>> | <<j-glos>> | K | <<l-glos>> | <<m-glos>> | <<n-glos>> | <<o-glos>> | <<p-glos>> | <<q-glos>> | <<r-glos>> | <<s-glos>> | <<t-glos>> | U | V | <<w-glos>> | X | Y | <<z-glos>>
 
-[[a-glos]] A::
+[discrete]
+[[a-glos]]
+=== A
 
-[[glossary-admin-console]] administration console:::
+[[glossary-admin-console]] administration console::
 A component of {ece} that provides the API server for the
 <<glossary-cloud-ui,Cloud UI>>. Also syncs cluster and allocator data from
 ZooKeeper to {es}.
 //Source: Cloud
 
-[[glossary-allocator]] allocator:::
+[[glossary-allocator]] allocator::
 Manages hosts that contain {es} and {kib} nodes. Controls the lifecycle of these
 nodes by creating new <<glossary-container,containers>> and managing the nodes
 within these containers when requested. Used to scale the capacity of your {ece}
 installation.
 //Source: Cloud
 
-[[glossary-analysis]] analysis:::
+[[glossary-analysis]] analysis::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=analysis-def]
 --
 
-[[glossary-anomaly-detection-job]] {anomaly-job}:::
+[[glossary-anomaly-detection-job]] {anomaly-job}::
 {anomaly-jobs-cap} contain the configuration information and metadata
 necessary to perform an analytics task. See
 {ml-docs}/ml-jobs.html[{ml-jobs-cap}] and the
 {ref}/ml-put-job.html[create {anomaly-job} API].
 //Source: X-Pack
 
-[[glossary-api-key]] API key:::
+[[glossary-api-key]] API key::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=api-key-def]
 --
 
-[[glossary-auto-follow-pattern]] auto-follow pattern:::
+[[glossary-auto-follow-pattern]] auto-follow pattern::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=auto-follow-pattern-def]
 --
 
-[[glossary-zone]] availability zone:::
+[[glossary-zone]] availability zone::
 Contains resources available to a {ece} installation that are isolated from
 other availability zones to safeguard against failure. Could be a rack, a server
 zone or some other logical constraint that creates a failure boundary. In a
@@ -53,13 +55,15 @@ entire availability zone. Also see
 {ece-ref}/ece-ha.html[Fault Tolerance (High Availability)].
 //Source: Cloud
 
-[[b-glos]] B::
+[discrete]
+[[b-glos]]
+=== B
 
-[[glossary-beats-runner]] beats runner:::
+[[glossary-beats-runner]] beats runner::
 Used to send {filebeat} and {metricbeat} information to the logging cluster.
 //Source: Cloud
 
-[[glossary-ml-bucket]] bucket:::
+[[glossary-ml-bucket]] bucket::
 The {ml-features} use the concept of a bucket to divide the time series into
 batches for processing. The _bucket span_ is part of the configuration
 information for {anomaly-jobs}. It defines the time interval that is used to
@@ -70,25 +74,27 @@ data, the typical duration of the anomalies, and the frequency at which alerting
 is required.
 //Source: X-Pack
 
-[[c-glos]] C::
+[discrete]
+[[c-glos]]
+=== C
 
-[[glossary-client-forwarder]] client forwarder:::
+[[glossary-client-forwarder]] client forwarder::
 Used for secure internal communications between various components of {ece} and
 ZooKeeper.
 //Source: Cloud
 
-[[glossary-cloud-ui]] Cloud UI:::
+[[glossary-cloud-ui]] Cloud UI::
 Provides web-based access to manage your {ece} installation, supported by the
 <<glossary-admin-console,administration console>>.
 //Source: Cloud
 
-[[glossary-cluster]] cluster:::
+[[glossary-cluster]] cluster::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=cluster-def]
 --
 
-[[glossary-codec-plugin]] codec plugin:::
+[[glossary-codec-plugin]] codec plugin::
 A Logstash <<glossary-plugin,plugin>> that changes the data representation
 of an <<glossary-event,event>>. Codecs are essentially stream filters that
 can operate as part of an input or output. Codecs enable you to separate the
@@ -96,13 +102,13 @@ transport of messages from the serialization process. Popular codecs include
 json, msgpack, and plain (text).
 //Source: Logstash
 
-[[glossary-cold-phase]] cold phase:::
+[[glossary-cold-phase]] cold phase::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=cold-phase-def]
 --
 
-[[glossary-conditional]] conditional:::
+[[glossary-conditional]] conditional::
 A control flow that executes certain actions based on whether a statement
 (also called a condition) is true or false. Logstash supports `if`,
 `else if`, and `else` statements. You can use conditional statements to
@@ -110,7 +116,7 @@ apply filters and send events to a specific output based on conditions that
 you specify.
 //Source: Logstash
 
-[[glossary-constructor]] constructor:::
+[[glossary-constructor]] constructor::
 Directs <<glossary-allocator,allocators>> to manage containers of {es} and {kib}
 nodes and maximizes the utilization of allocators. Monitors plan change requests
 from the Cloud UI and determines how to transform the existing cluster. In a
@@ -119,38 +125,40 @@ availability zones to ensure that the cluster can survive the failure of an
 entire availability zone.
 //Source: Cloud
 
-[[glossary-container]] container:::
+[[glossary-container]] container::
 Includes an instance of {ece} software and its dependencies. Used to provision
 similar environments, to assign a guaranteed share of host resources to nodes,
 and to simplify operational effort in {ece}.
 //Source: Cloud
 
-[[glossary-coordinator]] coordinator:::
+[[glossary-coordinator]] coordinator::
 Consists of a logical grouping of some {ece} services and acts as a distributed
 coordination system and resource scheduler.
 //Source: Cloud
 
-[[glossary-ccr]] {ccr} (CCR):::
+[[glossary-ccr]] {ccr} (CCR)::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=ccr-def]
 --
 
-[[glossary-ccs]] {ccs} (CCS):::
+[[glossary-ccs]] {ccs} (CCS)::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=ccs-def]
 --
 
-[[d-glos]] D::
+[discrete]
+[[d-glos]]
+=== D
 
-[[glossary-ml-datafeed]] datafeed:::
+[[glossary-ml-datafeed]] datafeed::
 {anomaly-jobs-cap} can analyze either a one-off batch of data or continuously in
 real time. {dfeeds-cap} retrieve data from {es} for analysis. Alternatively, you
 can post data from any source directly to a {ml} API.
 //Source: X-Pack
 
-[[glossary-dataframe-job]] {dfanalytics-job}:::
+[[glossary-dataframe-job]] {dfanalytics-job}::
 {dfanalytics-jobs-cap} contain the configuration information and metadata
 necessary to perform {ml} analytics tasks on a source index and store the
 outcome in a destination index. See
@@ -158,60 +166,64 @@ outcome in a destination index. See
 {ref}/put-dfanalytics.html[create {dfanalytics-job} API].
 //Source: X-Pack
 
-[[glossary-data-stream]] data stream:::
+[[glossary-data-stream]] data stream::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=data-stream-def]
 --
 
-[[glossary-delete-phase]] delete phase:::
+[[glossary-delete-phase]] delete phase::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=delete-phase-def]
 --
 
-[[glossary-ml-detector]] detector:::
+[[glossary-ml-detector]] detector::
 As part of the configuration information that is associated with {anomaly-jobs},
 detectors define the type of analysis that needs to be done. They also specify
 which fields to analyze. You can have more than one detector in a job, which is
 more efficient than running multiple jobs against the same data.
 //Source: X-Pack
 
-[[glossary-director]] director:::
+[[glossary-director]] director::
 Manages the <<glossary-zookeeper,ZooKeeper>> datastore. This role is often
 shared with the <<glossary-coordinator,coordinator>>, though in production
 deployments it can be separated.
 //Source: Cloud
 
-[[glossary-document]] document:::
+[[glossary-document]] document::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=document-def]
 --
 
-[[e-glos]] E::
+[discrete]
+[[e-glos]]
+=== E
 
-[[glossary-ecs]] Elastic Common Schema (ECS):::
+[[glossary-ecs]] Elastic Common Schema (ECS)::
 A document schema for Elasticsearch, for use cases such as logging and metrics.
 ECS defines a common set of fields, their datatype, and gives guidance on their
 correct usage. ECS is used to improve uniformity of event data coming from
 different sources.
 
-[[glossary-event]] event:::
+[[glossary-event]] event::
 A single unit of information, containing a timestamp plus additional data. An
 event arrives via an input, and is subsequently parsed, timestamped, and
 passed through the Logstash <<glossary-pipeline,pipeline>>.
 //Source: Logstash
 
-[[f-glos]] F::
+[discrete]
+[[f-glos]]
+=== F
 
-[[glossary-feature-influence]] feature influence:::
+[[glossary-feature-influence]] feature influence::
 In {oldetection}, feature influence scores indicate which features of a data
 point contribute to its outlier behavior. See
 {ml-docs}/dfa-outlier-detection.html#dfa-feature-influence[Feature influence].
 //Source: X-Pack
 
-[[glossary-feature-importance]] feature importance:::
+[[glossary-feature-importance]] feature importance::
 In supervised {ml} methods such as {regression} and {classification}, feature
 importance indicates the degree to which a specific feature affects a prediction.
 See
@@ -220,7 +232,7 @@ and
 {ml-docs}/dfa-classification.html#dfa-classification-feature-importance[{classification-cap} feature importance].
 //Source: X-Pack
 
-[[glossary-field]] field:::
+[[glossary-field]] field::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=field-def]
@@ -233,7 +245,7 @@ properties.
 //Source: Logstash
 --
 
-[[glossary-field-reference]] field reference:::
+[[glossary-field-reference]] field reference::
 A reference to an event <<glossary-field,field>>. This reference may appear in
 an output block or filter block in the Logstash config file. Field references
 are typically wrapped in square (`[]`) brackets, for example `[fieldname]`. If
@@ -242,13 +254,13 @@ the field name. To refer to a nested field, you specify the full path to that
 field: `[top-level field][nested field]`.
 //Source: Logstash
 
-[[glossary-filter]] filter:::
+[[glossary-filter]] filter::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=filter-def]
 --
 
-[[glossary-filter-plugin]] filter plugin:::
+[[glossary-filter-plugin]] filter plugin::
 A Logstash <<glossary-plugin,plugin>> that performs intermediary processing on
 an <<glossary-event,event>>. Typically, filters act upon event data after it
 has been ingested via inputs, by mutating, enriching, and/or modifying the
@@ -257,181 +269,199 @@ depending on the characteristics of the event. Popular filter plugins include
 grok, mutate, drop, clone, and geoip. Filter stages are optional.
 //Source: Logstash
 
-[[glossary-flush]] flush:::
+[[glossary-flush]] flush::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=flush-def]
 --
 
-[[glossary-follower-index]] follower index:::
+[[glossary-follower-index]] follower index::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=follower-index-def]
 --
 
-[[glossary-frozen-index]] frozen index:::
+[[glossary-frozen-index]] frozen index::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=frozen-index-def]
 --
 
-[[g-glos]] G::
+[discrete]
+[[g-glos]]
+=== G
 
-[[glossary-gem]] gem:::
+[[glossary-gem]] gem::
 A self-contained package of code that's hosted on
 https://rubygems.org[RubyGems.org]. Logstash <<glossary-plugin,plugins>> are
 packaged as Ruby Gems. You can use the Logstash
 <<glossary-plugin-manager,plugin manager>> to manage Logstash gems.
 //Source: Logstash
 
-[[h-glos]] H::
+[discrete]
+[[h-glos]]
+=== H
 
-[[glossary-hot-phase]] hot phase:::
+[[glossary-hot-phase]] hot phase::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=hot-phase-def]
 --
 
-[[glossary-hot-thread]] hot thread:::
+[[glossary-hot-thread]] hot thread::
 A Java thread that has high CPU usage and executes for a longer than normal
 period of time.
 //Source: Logstash
 
-[[i-glos]] I::
+[discrete]
+[[i-glos]]
+=== I
 
-[[glossary-id]] ID:::
+[[glossary-id]] ID::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=id-def]
 --
 
-[[glossary-index]] index:::
+[[glossary-index]] index::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=index-def]
 --
 
-[[glossary-index-alias]] index alias:::
+[[glossary-index-alias]] index alias::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=index-alias-def]
 --
 
-[[glossary-index-lifecycle]] index lifecycle:::
+[[glossary-index-lifecycle]] index lifecycle::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=index-lifecycle-def]
 --
 
-[[glossary-index-lifecycle-policy]] index lifecycle policy:::
+[[glossary-index-lifecycle-policy]] index lifecycle policy::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=index-lifecycle-policy-def]
 --
 
-[[glossary-index-pattern]] index pattern:::
+[[glossary-index-pattern]] index pattern::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=index-pattern-def]
 --
 
-[[glossary-indexer]] indexer:::
+[[glossary-indexer]] indexer::
 A Logstash instance that is tasked with interfacing with an {es} cluster in
 order to index <<glossary-event,event>> data.
 //Source: Logstash
 
-[[glossary-influencer]] influencer:::
+[[glossary-influencer]] influencer::
 Influencers are entities that might have contributed to an anomaly in a specific
 bucket in an {anomaly-job}. For more information, see
 {ml-docs}/ml-influencers.html[Influencers].
 //Source: X-Pack
 
-[[glossary-input-plugin]] input plugin:::
+[[glossary-input-plugin]] input plugin::
 A Logstash <<glossary-plugin,plugin>> that reads <<glossary-event,event>> data
 from a specific source. Input plugins are the first stage in the Logstash
 event processing <<glossary-pipeline,pipeline>>. Popular input plugins include
 file, syslog, redis, and beats.
 //Source: Logstash
 
-[[j-glos]] J::
+[discrete]
+[[j-glos]]
+=== J
 
-[[glossary-ml-job]][[glossary-job]] job:::
+[[glossary-ml-job]][[glossary-job]] job::
 {ml-cap} jobs contain the configuration information and metadata
 necessary to perform an analytics task. There are two types:
 <<glossary-anomaly-detection-job,{anomaly-jobs}>> and
 <<glossary-dataframe-job,{dfanalytics-jobs}>>. See also <<glossary-rollup-job>>.
 //Source: X-Pack
 
-[[l-glos]] L::
+[discrete]
+[[l-glos]]
+=== L
 
-[[glossary-leader-index]] leader index:::
+[[glossary-leader-index]] leader index::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=leader-index-def]
 --
 
-[[glossary-local-cluster]] local cluster:::
+[[glossary-local-cluster]] local cluster::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=local-cluster-def]
 --
 
-[[m-glos]] M::
+[discrete]
+[[m-glos]]
+=== M
 
-[[glossary-ml-nodes]] machine learning node:::
+[[glossary-ml-nodes]] machine learning node::
 A {ml} node is a node that has `xpack.ml.enabled` and `node.ml` set to `true`,
 which is the default behavior. If you set `node.ml` to `false`, the node can
 service API requests but it cannot run {ml-jobs}. If you want to use
 {ml-features}, there must be at least one {ml} node in your cluster.
 //Source: X-Pack
 
-[[glossary-mapping]] mapping:::
+[[glossary-mapping]] mapping::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=mapping-def]
 --
 
-[[glossary-master-node]] master node:::
+[[glossary-master-node]] master node::
 Handles write requests for the cluster and publishes changes to other nodes in
 an ordered fashion. Each cluster has a single master node which is chosen
 automatically by the cluster and is replaced if the current master node fails.
 Also see <<glossary-node,node>>.
 //Source: Cloud
 
-[[glossary-message-broker]] message broker:::
+[[glossary-message-broker]] message broker::
 Also referred to as a _message buffer_ or _message queue_, a message broker is
 external software (such as Redis, Kafka, or RabbitMQ) that stores messages
 from the Logstash shipper instance as an intermediate store, waiting to be
 processed by the Logstash indexer instance.
 //Source: Logstash
 
-[[glossary-metadata]] @metadata:::
+[[glossary-metadata]] @metadata::
 A special field for storing content that you don't want to include in output
 <<glossary-event,events>>. For example, the `@metadata` field is useful for
 creating transient fields for use in <<glossary-conditional,conditional>>
 statements.
 //Source: Logstash
 
-[[n-glos]] N::
+[discrete]
+[[n-glos]]
+=== N
 
-[[glossary-node]] node:::
+[[glossary-node]] node::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=node-def]
 --
 
-[[o-glos]] O::
+[discrete]
+[[o-glos]]
+=== O
 
-[[glossary-output-plugin]] output plugin:::
+[[glossary-output-plugin]] output plugin::
 A Logstash <<glossary-plugin,plugin>> that writes <<glossary-event,event>> data
 to a specific destination. Outputs are the final stage in the event
 <<glossary-pipeline,pipeline>>. Popular output plugins include elasticsearch,
 file, graphite, and statsd.
 //Source: Logstash
 
-[[p-glos]] P::
+[discrete]
+[[p-glos]]
+=== P
 
-[[glossary-pipeline]] pipeline:::
+[[glossary-pipeline]] pipeline::
 A term used to describe the flow of <<glossary-event,events>> through the
 Logstash workflow. A pipeline typically consists of a series of input, filter,
 and output stages. <<glossary-input-plugin,Input>> stages get data from a source
@@ -442,14 +472,14 @@ write the data to a destination. Inputs and outputs support
 it enters or exits the pipeline without having to use a separate filter.
 //Source: Logstash
 
-[[glossary-plan]] plan:::
+[[glossary-plan]] plan::
 Specifies the configuration and topology of an {es} or {kib} cluster, such as
 capacity, availability, and {es} version, for example. When changing a plan, the
 <<glossary-constructor,constructor>> determines how to transform the existing
 cluster into the pending plan.
 //Source: Cloud
 
-[[glossary-plugin]] plugin:::
+[[glossary-plugin]] plugin::
 A self-contained software package that implements one of the stages in the
 Logstash event processing <<glossary-pipeline,pipeline>>. The list of available
 plugins includes <<glossary-input-plugin,input plugins>>,
@@ -461,191 +491,203 @@ define the stages of an event processing <<glossary-pipeline,pipeline>>
 by configuring plugins.
 //Source: Logstash
 
-[[glossary-plugin-manager]] plugin manager:::
+[[glossary-plugin-manager]] plugin manager::
 Accessed via the `bin/logstash-plugin` script, the plugin manager enables
 you to manage the lifecycle of <<glossary-plugin,plugins>> in your Logstash
 deployment. You can install, remove, and upgrade plugins by using the
 plugin manager Command Line Interface (CLI).
 //Source: Logstash
 
-[[glossary-primary-shard]] primary shard:::
+[[glossary-primary-shard]] primary shard::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=primary-shard-def]
 --
 
-[[glossary-proxy]] proxy:::
+[[glossary-proxy]] proxy::
 A highly available, TLS-enabled proxy layer that routes user requests, mapping
 cluster IDs that are passed in request URLs for the container to the cluster
 nodes handling the user requests.
 //Source: Cloud
 
-[[q-glos]] Q::
+[discrete]
+[[q-glos]]
+=== Q
 
-[[glossary-query]] query:::
+[[glossary-query]] query::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=query-def]
 --
 
-[[r-glos]] R::
+[discrete]
+[[r-glos]]
+=== R
 
-[[glossary-recovery]] recovery:::
+[[glossary-recovery]] recovery::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=recovery-def]
 --
 
-[[glossary-reindex]] reindex:::
+[[glossary-reindex]] reindex::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=reindex-def]
 --
 
-[[glossary-remote-cluster]] remote cluster:::
+[[glossary-remote-cluster]] remote cluster::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=remote-cluster-def]
 --
 
-[[glossary-replica-shard]] replica shard:::
+[[glossary-replica-shard]] replica shard::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=replica-shard-def]
 --
 
-[[glossary-roles-token]] roles token:::
+[[glossary-roles-token]] roles token::
 Enables a host to join an existing {ece} installation and grants permission to
 hosts to hold certain roles, such as the <<glossary-allocator,allocator>> role.
 Used when installing {ece} on additional hosts, a roles token helps secure {ece}
 by making sure that only authorized hosts become part of the installation.
 //Source: Cloud
 
-[[glossary-rollup]] rollup:::
+[[glossary-rollup]] rollup::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=rollup-def]
 --
 
-[[glossary-rollup-index]] rollup index:::
+[[glossary-rollup-index]] rollup index::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=rollup-index-def]
 --
 
-[[glossary-rollup-job]] {rollup-job}:::
+[[glossary-rollup-job]] {rollup-job}::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=rollup-job-def]
 --
 
-[[glossary-routing]] routing:::
+[[glossary-routing]] routing::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=routing-def]
 --
 
-[[glossary-runner]] runner:::
+[[glossary-runner]] runner::
 A local control agent that runs on all hosts, used to deploy local containers
 based on role definitions. Ensures that containers assigned to it exist and are
 able to run, and creates or recreates the containers if necessary.
 //Source: Cloud
 
-[[s-glos]] S::
+[discrete]
+[[s-glos]]
+=== S
 
-[[glossary-services-forwarder]] services forwarder:::
+[[glossary-services-forwarder]] services forwarder::
 Routes data internally in an {ece} installation.
 //Source: Cloud
 
-[[glossary-shard]] shard:::
+[[glossary-shard]] shard::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=shard-def]
 --
 
-[[glossary-shipper]] shipper:::
+[[glossary-shipper]] shipper::
 An instance of Logstash that send events to another instance of Logstash, or
 some other application.
 //Source: Logstash
 
-[[glossary-shrink]] shrink:::
+[[glossary-shrink]] shrink::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=shrink-def]
 --
 
-[[glossary-snapshot]] snapshot:::
+[[glossary-snapshot]] snapshot::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=snapshot-def]
 --
 
-[[glossary-snapshot-lifecycle-policy]] snapshot lifecycle policy:::
+[[glossary-snapshot-lifecycle-policy]] snapshot lifecycle policy::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=snapshot-lifecycle-policy-def]
 --
 
-[[glossary-snapshot-repository]] snapshot repository:::
+[[glossary-snapshot-repository]] snapshot repository::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=snapshot-repository-def]
 --
 
-[[glossary-source_field]] source field:::
+[[glossary-source_field]] source field::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=source-field-def]
 --
 
-[[glossary-split]] split:::
+[[glossary-split]] split::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=split-def]
 --
 
-[[glossary-stunnel]] stunnel:::
+[[glossary-stunnel]] stunnel::
 Securely tunnels all traffic in an {ece} installation.
 //Source: Cloud
 
-[[t-glos]] T::
+[discrete]
+[[t-glos]]
+=== T
 
-[[glossary-term]] term:::
+[[glossary-term]] term::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=term-def]
 --
 
-[[glossary-text]] text:::
+[[glossary-text]] text::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=text-def]
 --
 
-[[glossary-type]] type:::
+[[glossary-type]] type::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=type-def]
 --
 
-[[w-glos]] W::
+[discrete]
+[[w-glos]]
+=== W
 
-[[glossary-warm-phase]] warm phase:::
+[[glossary-warm-phase]] warm phase::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=warm-phase-def]
 --
 
-[[glossary-worker]] worker:::
+[[glossary-worker]] worker::
 The filter thread model used by Logstash, where each worker receives an
 <<glossary-event,event>> and applies all filters, in order, before emitting
 the event to the output queue. This allows scalability across CPUs because
 many filters are CPU intensive.
 //Source: Logstash
 
-[[z-glos]] Z::
+[discrete]
+[[z-glos]]
+=== Z
 
-[[glossary-zookeeper]] ZooKeeper:::
+[[glossary-zookeeper]] ZooKeeper::
 A coordination service for distributed systems used by {ece} to store the state
 of the installation. Responsible for discovery of hosts, resource allocation,
 leader election after failure and high priority notifications.

--- a/docs/en/glossary/glossary.asciidoc
+++ b/docs/en/glossary/glossary.asciidoc
@@ -4,6 +4,14 @@
 <<a_glos>> | <<b_glos>> | <<c_glos>> | <<d_glos>> | <<e_glos>> | <<f_glos>> | <<g_glos>> | <<h_glos>> | <<i_glos>> | <<j_glos>> | K | <<l_glos>> | <<m_glos>> | <<n_glos>> | <<o_glos>> | <<p_glos>> | <<q_glos>> | <<r_glos>> | <<s_glos>> | <<t_glos>> | U | V | <<w_glos>> | X | Y | <<z_glos>>
 
 [discrete]
+[[intro]]
+=== Introduction
+The products in the https://www.elastic.co/products[{stack}]
+are designed to be used together and thus there is common terminology. In the
+exceptional cases where a term has different connotations in specific products
+or domains, those differences are noted in the definition.
+
+[discrete]
 [[a_glos]]
 === A
 

--- a/docs/en/glossary/glossary.asciidoc
+++ b/docs/en/glossary/glossary.asciidoc
@@ -1,17 +1,12 @@
 [[terms]]
 == Terminology
 
-ifdef::logstash-terms[]
+<<a_glos>> | <<b_glos>> | <<c_glos>> | <<d_glos>> | <<e_glos>> | <<f_glos>> | <<g_glos>> | <<h_glos>> | <<i_glos>> | <<j_glos>> | K | <<l_glos>> | <<m_glos>> | <<n_glos>> | <<o_glos>> | <<p_glos>> | <<q_glos>> | <<r_glos>> | <<s_glos>> | <<t_glos>> | U | V | <<w_glos>> | X | Y | <<z_glos>>
 
-[[glossary-metadata]] @metadata ::
+[discrete]
+[[a_glos]]
+=== A
 
-A special field for storing content that you don't want to include in output
-<<glossary-event,events>>. For example, the `@metadata` field is useful for
-creating transient fields for use in <<glossary-conditional,conditional>>
-statements.
-+
-//Source: Logstash
-endif::logstash-terms[]
 ifdef::cloud-terms[]
 
 [[glossary-admin-console]] administration console ::
@@ -83,6 +78,11 @@ entire availability zone. Also see
 +
 //Source: Cloud
 endif::cloud-terms[]
+
+[discrete]
+[[b_glos]]
+=== B
+
 ifdef::cloud-terms[]
 [[glossary-beats-runner]] beats runner ::
 
@@ -105,6 +105,11 @@ is required.
 +
 //Source: X-Pack
 endif::xpack-terms[]
+
+[discrete]
+[[c_glos]]
+=== C
+
 ifdef::cloud-terms[]
 
 [[glossary-client-forwarder]] client forwarder ::
@@ -214,6 +219,11 @@ include::{es-repo-dir}/glossary.asciidoc[tag=ccs-def]
 --
 
 endif::elasticsearch-terms[]
+
+[discrete]
+[[d_glos]]
+=== D
+
 ifdef::xpack-terms[]
 
 [[glossary-ml-datafeed]] datafeed ::
@@ -282,6 +292,10 @@ include::{es-repo-dir}/glossary.asciidoc[tag=document-def]
 
 endif::elasticsearch-terms[]
 
+[discrete]
+[[e_glos]]
+=== E
+
 [[glossary-ecs]] Elastic Common Schema (ECS) ::
 
 A document schema for Elasticsearch, for use cases such as logging and metrics.
@@ -299,6 +313,11 @@ passed through the Logstash <<glossary-pipeline,pipeline>>.
 +
 //Source: Logstash
 endif::logstash-terms[]
+
+[discrete]
+[[f_glos]]
+=== F
+
 ifdef::xpack-terms[]
 [[glossary-feature-influence]] feature influence ::
 
@@ -399,6 +418,10 @@ include::{es-repo-dir}/glossary.asciidoc[tag=frozen-index-def]
 
 endif::elasticsearch-terms[]
 
+[discrete]
+[[g_glos]]
+=== G
+
 ifdef::logstash-terms[]
 
 [[glossary-gem]] gem ::
@@ -410,6 +433,11 @@ packaged as Ruby Gems. You can use the Logstash
 +
 //Source: Logstash
 endif::logstash-terms[]
+
+[discrete]
+[[h_glos]]
+=== H
+
 ifdef::xpack-terms[]
 [[glossary-hot-phase]] hot phase ::
 +
@@ -427,6 +455,11 @@ period of time.
 +
 //Source: Logstash
 endif::logstash-terms[]
+
+[discrete]
+[[i_glos]]
+=== I
+
 ifdef::elasticsearch-terms[]
 
 [[glossary-id]] ID ::
@@ -507,6 +540,11 @@ file, syslog, redis, and beats.
 +
 //Source: Logstash
 endif::logstash-terms[]
+
+[discrete]
+[[j_glos]]
+=== J
+
 ifdef::xpack-terms[]
 
 [[glossary-ml-job]][[glossary-job]] job ::
@@ -518,6 +556,11 @@ necessary to perform an analytics task. There are two types:
 +
 //Source: X-Pack
 endif::xpack-terms[]
+
+[discrete]
+[[l_glos]]
+=== L
+
 ifdef::xpack-terms[]
 [[glossary-leader-index]] leader index ::  
 +
@@ -534,6 +577,11 @@ include::{es-repo-dir}/glossary.asciidoc[tag=local-cluster-def]
 --
 
 endif::elasticsearch-terms[]
+
+[discrete]
+[[m_glos]]
+=== M
+
 ifdef::xpack-terms[]
 
 [[glossary-ml-nodes]]
@@ -577,6 +625,22 @@ processed by the Logstash indexer instance.
 +
 //Source: Logstash
 endif::logstash-terms[]
+ifdef::logstash-terms[]
+
+[[glossary-metadata]] @metadata ::
+
+A special field for storing content that you don't want to include in output
+<<glossary-event,events>>. For example, the `@metadata` field is useful for
+creating transient fields for use in <<glossary-conditional,conditional>>
+statements.
++
+//Source: Logstash
+endif::logstash-terms[]
+
+[discrete]
+[[n_glos]]
+=== N
+
 ifdef::elasticsearch-terms,cloud-terms[]
 
 [[glossary-node]] node ::
@@ -586,6 +650,11 @@ include::{es-repo-dir}/glossary.asciidoc[tag=node-def]
 --
 
 endif::elasticsearch-terms,cloud-terms[]
+
+[discrete]
+[[o_glos]]
+=== O
+
 ifdef::logstash-terms[]
 
 [[glossary-output-plugin]] output plugin ::
@@ -597,6 +666,11 @@ file, graphite, and statsd.
 +
 //Source: Logstash
 endif::logstash-terms[]
+
+[discrete]
+[[p_glos]]
+=== P
+
 ifdef::logstash-terms[]
 
 [[glossary-pipeline]] pipeline ::
@@ -669,6 +743,11 @@ nodes handling the user requests.
 +
 //Source: Cloud
 endif::cloud-terms[]
+
+[discrete]
+[[q_glos]]
+=== Q
+
 ifdef::elasticsearch-terms[]
 [[glossary-query]] query ::
 +
@@ -677,6 +756,11 @@ include::{es-repo-dir}/glossary.asciidoc[tag=query-def]
 --
 
 endif::elasticsearch-terms[]
+
+[discrete]
+[[r_glos]]
+=== R
+
 ifdef::elasticsearch-terms[]
 
 [[glossary-recovery]] recovery ::
@@ -766,6 +850,11 @@ able to run, and creates or recreates the containers if necessary.
 +
 //Source: Cloud
 endif::cloud-terms[]
+
+[discrete]
+[[s_glos]]
+=== S
+
 ifdef::cloud-terms[]
 
 [[glossary-services-forwarder]] services forwarder ::
@@ -854,6 +943,11 @@ Securely tunnels all traffic in an {ece} installation.
 +
 //Source: Cloud
 endif::cloud-terms[]
+
+[discrete]
+[[t_glos]]
+=== T
+
 ifdef::elasticsearch-terms[]
 
 [[glossary-term]] term ::
@@ -881,6 +975,11 @@ include::{es-repo-dir}/glossary.asciidoc[tag=type-def]
 --
 
 endif::elasticsearch-terms[]
+
+[discrete]
+[[w_glos]]
+=== W
+
 ifdef::xpack-terms[]
 
 [[glossary-warm-phase]] warm phase ::
@@ -901,6 +1000,11 @@ many filters are CPU intensive.
 +
 //Source: Logstash
 endif::logstash-terms[]
+
+[discrete]
+[[z_glos]]
+=== Z
+
 ifdef::cloud-terms[]
 
 [[glossary-zookeeper]] ZooKeeper ::

--- a/docs/en/glossary/glossary.asciidoc
+++ b/docs/en/glossary/glossary.asciidoc
@@ -1,66 +1,49 @@
 [[terms]]
 == Terminology
 
-<<a_glos>> | <<b_glos>> | <<c_glos>> | <<d_glos>> | <<e_glos>> | <<f_glos>> | <<g_glos>> | <<h_glos>> | <<i_glos>> | <<j_glos>> | K | <<l_glos>> | <<m_glos>> | <<n_glos>> | <<o_glos>> | <<p_glos>> | <<q_glos>> | <<r_glos>> | <<s_glos>> | <<t_glos>> | U | V | <<w_glos>> | X | Y | <<z_glos>>
+<<a-glos>> | <<b-glos>> | <<c-glos>> | <<d-glos>> | <<e-glos>> | <<f-glos>> | <<g-glos>> | <<h-glos>> | <<i-glos>> | <<j-glos>> | K | <<l-glos>> | <<m-glos>> | <<n-glos>> | <<o-glos>> | <<p-glos>> | <<q-glos>> | <<r-glos>> | <<s-glos>> | <<t-glos>> | U | V | <<w-glos>> | X | Y | <<z-glos>>
 
-[[a_glos]] A ::
+[[a-glos]] A::
 
-ifdef::cloud-terms[]
-
-[[glossary-admin-console]] administration console :::
+[[glossary-admin-console]] administration console:::
 A component of {ece} that provides the API server for the
 <<glossary-cloud-ui,Cloud UI>>. Also syncs cluster and allocator data from
 ZooKeeper to {es}.
 //Source: Cloud
-endif::cloud-terms[]
-ifdef::cloud-terms[]
 
-[[glossary-allocator]] allocator :::
+[[glossary-allocator]] allocator:::
 Manages hosts that contain {es} and {kib} nodes. Controls the lifecycle of these
 nodes by creating new <<glossary-container,containers>> and managing the nodes
 within these containers when requested. Used to scale the capacity of your {ece}
 installation.
-+
 //Source: Cloud
-endif::cloud-terms[]
-ifdef::elasticsearch-terms[]
 
-[[glossary-analysis]] analysis :::
+[[glossary-analysis]] analysis:::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=analysis-def]
 --
 
-endif::elasticsearch-terms[]
-ifdef::xpack-terms[]
-[[glossary-anomaly-detection-job]] {anomaly-job} :::
+[[glossary-anomaly-detection-job]] {anomaly-job}:::
 {anomaly-jobs-cap} contain the configuration information and metadata
 necessary to perform an analytics task. See
 {ml-docs}/ml-jobs.html[{ml-jobs-cap}] and the
 {ref}/ml-put-job.html[create {anomaly-job} API].
-+
 //Source: X-Pack
-endif::xpack-terms[]
-ifdef::elasticsearch-terms[]
 
-[[glossary-api-key]] API key :::
+[[glossary-api-key]] API key:::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=api-key-def]
 --
 
-endif::elasticsearch-terms[]
-ifdef::elasticsearch-terms[]
-
-[[glossary-auto-follow-pattern]] auto-follow pattern :::
+[[glossary-auto-follow-pattern]] auto-follow pattern:::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=auto-follow-pattern-def]
 --
 
-endif::elasticsearch-terms[]
-ifdef::cloud-terms[]
-[[glossary-zone]] availability zone :::
+[[glossary-zone]] availability zone:::
 Contains resources available to a {ece} installation that are isolated from
 other availability zones to safeguard against failure. Could be a rack, a server
 zone or some other logical constraint that creates a failure boundary. In a
@@ -68,21 +51,15 @@ highly available cluster, the nodes of a cluster are spread across two or three
 availability zones to ensure that the cluster can survive the failure of an
 entire availability zone. Also see
 {ece-ref}/ece-ha.html[Fault Tolerance (High Availability)].
-+
 //Source: Cloud
-endif::cloud-terms[]
 
-[[b_glos]] B ::
+[[b-glos]] B::
 
-ifdef::cloud-terms[]
-[[glossary-beats-runner]] beats runner :::
+[[glossary-beats-runner]] beats runner:::
 Used to send {filebeat} and {metricbeat} information to the logging cluster.
-+
 //Source: Cloud
-endif::cloud-terms[]
-ifdef::xpack-terms[]
 
-[[glossary-ml-bucket]] bucket :::
+[[glossary-ml-bucket]] bucket:::
 The {ml-features} use the concept of a bucket to divide the time series into
 batches for processing. The _bucket span_ is part of the configuration
 information for {anomaly-jobs}. It defines the time interval that is used to
@@ -91,536 +68,370 @@ it depends on your data characteristics. When you set the bucket span, take into
 account the granularity at which you want to analyze, the frequency of the input
 data, the typical duration of the anomalies, and the frequency at which alerting
 is required.
-+
 //Source: X-Pack
-endif::xpack-terms[]
 
-[[c_glos]] C ::
+[[c-glos]] C::
 
-ifdef::cloud-terms[]
-[[glossary-client-forwarder]] client forwarder :::
+[[glossary-client-forwarder]] client forwarder:::
 Used for secure internal communications between various components of {ece} and
 ZooKeeper.
-+
 //Source: Cloud
-endif::cloud-terms[]
-ifdef::cloud-terms[]
 
-[[glossary-cloud-ui]] Cloud UI :::
-
+[[glossary-cloud-ui]] Cloud UI:::
 Provides web-based access to manage your {ece} installation, supported by the
 <<glossary-admin-console,administration console>>.
-+
 //Source: Cloud
-endif::cloud-terms[]
-ifdef::elasticsearch-terms,cloud-terms[]
 
-[[glossary-cluster]] cluster :::
+[[glossary-cluster]] cluster:::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=cluster-def]
 --
 
-endif::elasticsearch-terms,cloud-terms[]
-ifdef::logstash-terms[]
-[[glossary-codec-plugin]] codec plugin :::
+[[glossary-codec-plugin]] codec plugin:::
 A Logstash <<glossary-plugin,plugin>> that changes the data representation
 of an <<glossary-event,event>>. Codecs are essentially stream filters that
 can operate as part of an input or output. Codecs enable you to separate the
 transport of messages from the serialization process. Popular codecs include
 json, msgpack, and plain (text).
-+
 //Source: Logstash
-endif::logstash-terms[]
-ifdef::xpack-terms[]
 
-[[glossary-cold-phase]] cold phase :::
+[[glossary-cold-phase]] cold phase:::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=cold-phase-def]
 --
 
-endif::xpack-terms[]
-ifdef::logstash-terms[]
-
-[[glossary-conditional]] conditional :::
+[[glossary-conditional]] conditional:::
 A control flow that executes certain actions based on whether a statement
 (also called a condition) is true or false. Logstash supports `if`,
 `else if`, and `else` statements. You can use conditional statements to
 apply filters and send events to a specific output based on conditions that
 you specify.
-+
 //Source: Logstash
-endif::logstash-terms[]
-ifdef::cloud-terms[]
 
-[[glossary-constructor]] constructor :::
+[[glossary-constructor]] constructor:::
 Directs <<glossary-allocator,allocators>> to manage containers of {es} and {kib}
 nodes and maximizes the utilization of allocators. Monitors plan change requests
 from the Cloud UI and determines how to transform the existing cluster. In a
 highly available installation, places cluster nodes within different
 availability zones to ensure that the cluster can survive the failure of an
 entire availability zone.
-+
 //Source: Cloud
-endif::cloud-terms[]
-ifdef::cloud-terms[]
 
-[[glossary-container]] container :::
+[[glossary-container]] container:::
 Includes an instance of {ece} software and its dependencies. Used to provision
 similar environments, to assign a guaranteed share of host resources to nodes,
 and to simplify operational effort in {ece}.
-+
 //Source: Cloud
-endif::cloud-terms[]
-ifdef::cloud-terms[]
 
-[[glossary-coordinator]] coordinator :::
+[[glossary-coordinator]] coordinator:::
 Consists of a logical grouping of some {ece} services and acts as a distributed
 coordination system and resource scheduler.
-+
 //Source: Cloud
-endif::cloud-terms[]
-ifdef::xpack-terms[]
 
-[[glossary-ccr]] {ccr} (CCR) :::
+[[glossary-ccr]] {ccr} (CCR):::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=ccr-def]
 --
 
-endif::xpack-terms[]
-ifdef::elasticsearch-terms[]
-[[glossary-ccs]] {ccs} (CCS) :::
+[[glossary-ccs]] {ccs} (CCS):::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=ccs-def]
 --
 
-endif::elasticsearch-terms[]
+[[d-glos]] D::
 
-[[d_glos]] D ::
-
-ifdef::xpack-terms[]
-[[glossary-ml-datafeed]] datafeed :::
+[[glossary-ml-datafeed]] datafeed:::
 {anomaly-jobs-cap} can analyze either a one-off batch of data or continuously in
 real time. {dfeeds-cap} retrieve data from {es} for analysis. Alternatively, you
 can post data from any source directly to a {ml} API.
-+
 //Source: X-Pack
-endif::xpack-terms[]
-ifdef::xpack-terms[]
 
-[[glossary-dataframe-job]] {dfanalytics-job} :::
+[[glossary-dataframe-job]] {dfanalytics-job}:::
 {dfanalytics-jobs-cap} contain the configuration information and metadata
 necessary to perform {ml} analytics tasks on a source index and store the
 outcome in a destination index. See
 {ml-docs}//ml-dfa-overview.html[{dfanalytics-cap} overview] and the
 {ref}/put-dfanalytics.html[create {dfanalytics-job} API].
 //Source: X-Pack
-endif::xpack-terms[]
-ifdef::elasticsearch-terms[]
 
-[[glossary-data-stream]] data stream :::
+[[glossary-data-stream]] data stream:::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=data-stream-def]
 --
-endif::elasticsearch-terms[]
-ifdef::xpack-terms[]
 
-[[glossary-delete-phase]] delete phase :::
+[[glossary-delete-phase]] delete phase:::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=delete-phase-def]
 --
 
-endif::xpack-terms[]
-ifdef::xpack-terms[]
-
-[[glossary-ml-detector]] detector :::
+[[glossary-ml-detector]] detector:::
 As part of the configuration information that is associated with {anomaly-jobs},
 detectors define the type of analysis that needs to be done. They also specify
 which fields to analyze. You can have more than one detector in a job, which is
 more efficient than running multiple jobs against the same data.
-+
 //Source: X-Pack
-endif::xpack-terms[]
-ifdef::cloud-terms[]
 
-[[glossary-director]] director :::
+[[glossary-director]] director:::
 Manages the <<glossary-zookeeper,ZooKeeper>> datastore. This role is often
 shared with the <<glossary-coordinator,coordinator>>, though in production
 deployments it can be separated.
-+
 //Source: Cloud
-endif::cloud-terms[]
-ifdef::elasticsearch-terms[]
 
-[[glossary-document]] document :::
+[[glossary-document]] document:::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=document-def]
 --
 
-endif::elasticsearch-terms[]
+[[e-glos]] E::
 
-[[e_glos]] E ::
-
-[[glossary-ecs]] Elastic Common Schema (ECS) :::
+[[glossary-ecs]] Elastic Common Schema (ECS):::
 A document schema for Elasticsearch, for use cases such as logging and metrics.
 ECS defines a common set of fields, their datatype, and gives guidance on their
 correct usage. ECS is used to improve uniformity of event data coming from
 different sources.
 
-ifdef::logstash-terms[]
-[[glossary-event]] event :::
+[[glossary-event]] event:::
 A single unit of information, containing a timestamp plus additional data. An
 event arrives via an input, and is subsequently parsed, timestamped, and
 passed through the Logstash <<glossary-pipeline,pipeline>>.
-+
 //Source: Logstash
-endif::logstash-terms[]
 
-[[f_glos]] F ::
+[[f-glos]] F::
 
-ifdef::xpack-terms[]
-[[glossary-feature-influence]] feature influence :::
+[[glossary-feature-influence]] feature influence:::
 In {oldetection}, feature influence scores indicate which features of a data
 point contribute to its outlier behavior. See
 {ml-docs}/dfa-outlier-detection.html#dfa-feature-influence[Feature influence].
-+
 //Source: X-Pack
-endif::xpack-terms[]
-ifdef::xpack-terms[]
 
-[[glossary-feature-importance]] feature importance :::
+[[glossary-feature-importance]] feature importance:::
 In supervised {ml} methods such as {regression} and {classification}, feature
 importance indicates the degree to which a specific feature affects a prediction.
 See
 {ml-docs}/dfa-regression.html#dfa-regression-feature-importance[{regression-cap} feature importance]
 and 
 {ml-docs}/dfa-classification.html#dfa-classification-feature-importance[{classification-cap} feature importance].
-+
 //Source: X-Pack
-endif::xpack-terms[]
-ifdef::elasticsearch-terms,logstash-terms[]
 
-[[glossary-field]] field :::
+[[glossary-field]] field:::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=field-def]
 
-endif::elasticsearch-terms,logstash-terms[]
-ifdef::logstash-terms[]
 In Logstash, this term refers to an <<glossary-event,event>> property. For
 example, each event in an apache access log has properties, such as a status
 code (200, 404), request path ("/", "index.html"), HTTP verb (GET, POST), client
 IP address, and so on. Logstash uses the term "fields" to refer to these
 properties.
-
 //Source: Logstash
 --
-endif::logstash-terms[]
-ifdef::logstash-terms[]
 
-[[glossary-field-reference]] field reference :::
+[[glossary-field-reference]] field reference:::
 A reference to an event <<glossary-field,field>>. This reference may appear in
 an output block or filter block in the Logstash config file. Field references
 are typically wrapped in square (`[]`) brackets, for example `[fieldname]`. If
 you are referring to a top-level field, you can omit the `[]` and simply use
 the field name. To refer to a nested field, you specify the full path to that
 field: `[top-level field][nested field]`.
-+
 //Source: Logstash
-endif::logstash-terms[]
-ifdef::elasticsearch-terms[]
 
-[[glossary-filter]] filter :::
+[[glossary-filter]] filter:::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=filter-def]
 --
-endif::elasticsearch-terms[]
-ifdef::logstash-terms[]
 
-[[glossary-filter-plugin]] filter plugin :::
+[[glossary-filter-plugin]] filter plugin:::
 A Logstash <<glossary-plugin,plugin>> that performs intermediary processing on
 an <<glossary-event,event>>. Typically, filters act upon event data after it
 has been ingested via inputs, by mutating, enriching, and/or modifying the
 data according to configuration rules. Filters are often applied conditionally
 depending on the characteristics of the event. Popular filter plugins include
 grok, mutate, drop, clone, and geoip. Filter stages are optional.
-+
 //Source: Logstash
-endif::logstash-terms[]
-ifdef::elasticsearch-terms[]
 
-[[glossary-flush]] flush :::
+[[glossary-flush]] flush:::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=flush-def]
 --
-endif::elasticsearch-terms[]
-ifdef::elasticsearch-terms[]
 
-[[glossary-follower-index]] follower index :::
+[[glossary-follower-index]] follower index:::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=follower-index-def]
 --
-endif::elasticsearch-terms[]
-ifdef::elasticsearch-terms[]
 
-[[glossary-frozen-index]] frozen index :::
+[[glossary-frozen-index]] frozen index:::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=frozen-index-def]
 --
-endif::elasticsearch-terms[]
 
-[[g_glos]] G ::
+[[g-glos]] G::
 
-ifdef::logstash-terms[]
-[[glossary-gem]] gem :::
+[[glossary-gem]] gem:::
 A self-contained package of code that's hosted on
 https://rubygems.org[RubyGems.org]. Logstash <<glossary-plugin,plugins>> are
 packaged as Ruby Gems. You can use the Logstash
 <<glossary-plugin-manager,plugin manager>> to manage Logstash gems.
-+
 //Source: Logstash
-endif::logstash-terms[]
 
-[[h_glos]] H ::
+[[h-glos]] H::
 
-ifdef::xpack-terms[]
-[[glossary-hot-phase]] hot phase :::
+[[glossary-hot-phase]] hot phase:::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=hot-phase-def]
 --
-endif::xpack-terms[]
-ifdef::logstash-terms[]
 
-[[glossary-hot-thread]] hot thread :::
+[[glossary-hot-thread]] hot thread:::
 A Java thread that has high CPU usage and executes for a longer than normal
 period of time.
-+
 //Source: Logstash
-endif::logstash-terms[]
 
-[[i_glos]] I ::
+[[i-glos]] I::
 
-ifdef::elasticsearch-terms[]
-[[glossary-id]] ID :::
+[[glossary-id]] ID:::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=id-def]
 --
-endif::elasticsearch-terms[]
-ifdef::elasticsearch-terms[]
 
-[[glossary-index]] index :::
+[[glossary-index]] index:::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=index-def]
 --
-endif::elasticsearch-terms[]
-ifdef::elasticsearch-terms[]
 
-[[glossary-index-alias]] index alias :::
+[[glossary-index-alias]] index alias:::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=index-alias-def]
 --
-endif::elasticsearch-terms[]
-ifdef::xpack-terms[]
 
-[[glossary-index-lifecycle]] index lifecycle :::
+[[glossary-index-lifecycle]] index lifecycle:::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=index-lifecycle-def]
 --
-endif::xpack-terms[]
-ifdef::xpack-terms[]
 
-[[glossary-index-lifecycle-policy]] index lifecycle policy :::
+[[glossary-index-lifecycle-policy]] index lifecycle policy:::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=index-lifecycle-policy-def]
 --
 
-endif::xpack-terms[]
-ifdef::elasticsearch-terms[]
-
-[[glossary-index-pattern]] index pattern :::
+[[glossary-index-pattern]] index pattern:::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=index-pattern-def]
 --
-endif::elasticsearch-terms[]
-ifdef::logstash-terms[]
 
-[[glossary-indexer]] indexer :::
+[[glossary-indexer]] indexer:::
 A Logstash instance that is tasked with interfacing with an {es} cluster in
 order to index <<glossary-event,event>> data.
-+
 //Source: Logstash
-endif::logstash-terms[]
-ifdef::xpack-terms[]
 
-[[glossary-influencer]] influencer :::
+[[glossary-influencer]] influencer:::
 Influencers are entities that might have contributed to an anomaly in a specific
 bucket in an {anomaly-job}. For more information, see
 {ml-docs}/ml-influencers.html[Influencers].
-+
 //Source: X-Pack
-endif::xpack-terms[]
-ifdef::logstash-terms[]
 
-[[glossary-input-plugin]] input plugin :::
+[[glossary-input-plugin]] input plugin:::
 A Logstash <<glossary-plugin,plugin>> that reads <<glossary-event,event>> data
 from a specific source. Input plugins are the first stage in the Logstash
 event processing <<glossary-pipeline,pipeline>>. Popular input plugins include
 file, syslog, redis, and beats.
-+
 //Source: Logstash
-endif::logstash-terms[]
 
-[discrete]
-[[j_glos]]
-=== J
+[[j-glos]] J::
 
-ifdef::xpack-terms[]
-
-[[glossary-ml-job]][[glossary-job]] job ::
-
+[[glossary-ml-job]][[glossary-job]] job:::
 {ml-cap} jobs contain the configuration information and metadata
 necessary to perform an analytics task. There are two types:
 <<glossary-anomaly-detection-job,{anomaly-jobs}>> and
 <<glossary-dataframe-job,{dfanalytics-jobs}>>. See also <<glossary-rollup-job>>.
-+
 //Source: X-Pack
-endif::xpack-terms[]
 
-[discrete]
-[[l_glos]]
-=== L
+[[l-glos]] L::
 
-ifdef::xpack-terms[]
-[[glossary-leader-index]] leader index ::  
+[[glossary-leader-index]] leader index:::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=leader-index-def]
 --
 
-endif::xpack-terms[]
-ifdef::elasticsearch-terms[]
-[[glossary-local-cluster]] local cluster ::
+[[glossary-local-cluster]] local cluster:::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=local-cluster-def]
 --
 
-endif::elasticsearch-terms[]
+[[m-glos]] M::
 
-[discrete]
-[[m_glos]]
-=== M
-
-ifdef::xpack-terms[]
-
-[[glossary-ml-nodes]]
-machine learning node ::
-
+[[glossary-ml-nodes]] machine learning node:::
 A {ml} node is a node that has `xpack.ml.enabled` and `node.ml` set to `true`,
 which is the default behavior. If you set `node.ml` to `false`, the node can
 service API requests but it cannot run {ml-jobs}. If you want to use
 {ml-features}, there must be at least one {ml} node in your cluster.
-+
 //Source: X-Pack
-endif::xpack-terms[]
-ifdef::elasticsearch-terms[]
 
-[[glossary-mapping]] mapping ::
+[[glossary-mapping]] mapping:::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=mapping-def]
 --
 
-endif::elasticsearch-terms[]
-ifdef::cloud-terms[]
-
-[[glossary-master-node]] master node ::
-
+[[glossary-master-node]] master node:::
 Handles write requests for the cluster and publishes changes to other nodes in
 an ordered fashion. Each cluster has a single master node which is chosen
 automatically by the cluster and is replaced if the current master node fails.
 Also see <<glossary-node,node>>.
-+
 //Source: Cloud
-endif::cloud-terms[]
-ifdef::logstash-terms[]
 
-[[glossary-message-broker]] message broker ::
-
+[[glossary-message-broker]] message broker:::
 Also referred to as a _message buffer_ or _message queue_, a message broker is
 external software (such as Redis, Kafka, or RabbitMQ) that stores messages
 from the Logstash shipper instance as an intermediate store, waiting to be
 processed by the Logstash indexer instance.
-+
 //Source: Logstash
-endif::logstash-terms[]
-ifdef::logstash-terms[]
 
-[[glossary-metadata]] @metadata ::
-
+[[glossary-metadata]] @metadata:::
 A special field for storing content that you don't want to include in output
 <<glossary-event,events>>. For example, the `@metadata` field is useful for
 creating transient fields for use in <<glossary-conditional,conditional>>
 statements.
-+
 //Source: Logstash
-endif::logstash-terms[]
 
-[discrete]
-[[n_glos]]
-=== N
+[[n-glos]] N::
 
-ifdef::elasticsearch-terms,cloud-terms[]
-
-[[glossary-node]] node ::
+[[glossary-node]] node:::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=node-def]
 --
 
-endif::elasticsearch-terms,cloud-terms[]
+[[o-glos]] O::
 
-[discrete]
-[[o_glos]]
-=== O
-
-ifdef::logstash-terms[]
-
-[[glossary-output-plugin]] output plugin ::
-
+[[glossary-output-plugin]] output plugin:::
 A Logstash <<glossary-plugin,plugin>> that writes <<glossary-event,event>> data
 to a specific destination. Outputs are the final stage in the event
 <<glossary-pipeline,pipeline>>. Popular output plugins include elasticsearch,
 file, graphite, and statsd.
-+
 //Source: Logstash
-endif::logstash-terms[]
 
-[discrete]
-[[p_glos]]
-=== P
+[[p-glos]] P::
 
-ifdef::logstash-terms[]
-
-[[glossary-pipeline]] pipeline ::
-
+[[glossary-pipeline]] pipeline:::
 A term used to describe the flow of <<glossary-event,events>> through the
 Logstash workflow. A pipeline typically consists of a series of input, filter,
 and output stages. <<glossary-input-plugin,Input>> stages get data from a source
@@ -629,24 +440,16 @@ optional, modify the event data, and <<glossary-output-plugin,output>> stages
 write the data to a destination. Inputs and outputs support
 <<glossary-codec-plugin,codecs>> that enable you to encode or decode the data as
 it enters or exits the pipeline without having to use a separate filter.
-+
 //Source: Logstash
-endif::logstash-terms[]
-ifdef::cloud-terms[]
 
-[[glossary-plan]] plan ::
-
+[[glossary-plan]] plan:::
 Specifies the configuration and topology of an {es} or {kib} cluster, such as
 capacity, availability, and {es} version, for example. When changing a plan, the
 <<glossary-constructor,constructor>> determines how to transform the existing
 cluster into the pending plan.
-+
 //Source: Cloud
-endif::cloud-terms[]
-ifdef::logstash-terms[]
 
-[[glossary-plugin]] plugin ::
-
+[[glossary-plugin]] plugin:::
 A self-contained software package that implements one of the stages in the
 Logstash event processing <<glossary-pipeline,pipeline>>. The list of available
 plugins includes <<glossary-input-plugin,input plugins>>,
@@ -656,308 +459,194 @@ plugins includes <<glossary-input-plugin,input plugins>>,
 <<glossary-gem,gems>> and hosted on https://rubygems.org[RubyGems.org]. You
 define the stages of an event processing <<glossary-pipeline,pipeline>>
 by configuring plugins.
-+
 //Source: Logstash
-endif::logstash-terms[]
-ifdef::logstash-terms[]
 
-[[glossary-plugin-manager]] plugin manager ::
-
+[[glossary-plugin-manager]] plugin manager:::
 Accessed via the `bin/logstash-plugin` script, the plugin manager enables
 you to manage the lifecycle of <<glossary-plugin,plugins>> in your Logstash
 deployment. You can install, remove, and upgrade plugins by using the
 plugin manager Command Line Interface (CLI).
-+
 //Source: Logstash
-endif::logstash-terms[]
-ifdef::elasticsearch-terms[]
 
-[[glossary-primary-shard]] primary shard ::
+[[glossary-primary-shard]] primary shard:::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=primary-shard-def]
 --
 
-endif::elasticsearch-terms[]
-ifdef::cloud-terms[]
-
-[[glossary-proxy]] proxy ::
-
+[[glossary-proxy]] proxy:::
 A highly available, TLS-enabled proxy layer that routes user requests, mapping
 cluster IDs that are passed in request URLs for the container to the cluster
 nodes handling the user requests.
-+
 //Source: Cloud
-endif::cloud-terms[]
 
-[discrete]
-[[q_glos]]
-=== Q
+[[q-glos]] Q::
 
-ifdef::elasticsearch-terms[]
-[[glossary-query]] query ::
+[[glossary-query]] query:::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=query-def]
 --
 
-endif::elasticsearch-terms[]
+[[r-glos]] R::
 
-[discrete]
-[[r_glos]]
-=== R
-
-ifdef::elasticsearch-terms[]
-
-[[glossary-recovery]] recovery ::
+[[glossary-recovery]] recovery:::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=recovery-def]
 --
 
-endif::elasticsearch-terms[]
-ifdef::elasticsearch-terms[]
-
-[[glossary-reindex]] reindex ::
+[[glossary-reindex]] reindex:::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=reindex-def]
 --
 
-endif::elasticsearch-terms[]
-ifdef::xpack-terms[]
-[[glossary-remote-cluster]] remote cluster ::
+[[glossary-remote-cluster]] remote cluster:::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=remote-cluster-def]
 --
 
-endif::xpack-terms[]
-ifdef::elasticsearch-terms[]
-
-[[glossary-replica-shard]] replica shard ::
+[[glossary-replica-shard]] replica shard:::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=replica-shard-def]
 --
 
-endif::elasticsearch-terms[]
-ifdef::cloud-terms[]
-
-[[glossary-roles-token]] roles token ::
-
+[[glossary-roles-token]] roles token:::
 Enables a host to join an existing {ece} installation and grants permission to
 hosts to hold certain roles, such as the <<glossary-allocator,allocator>> role.
 Used when installing {ece} on additional hosts, a roles token helps secure {ece}
 by making sure that only authorized hosts become part of the installation.
-+
 //Source: Cloud
-endif::cloud-terms[]
-ifdef::xpack-terms[]
-[[glossary-rollup]] rollup ::
+
+[[glossary-rollup]] rollup:::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=rollup-def]
 --
 
-endif::xpack-terms[]
-ifdef::xpack-terms[]
-[[glossary-rollup-index]] rollup index ::
+[[glossary-rollup-index]] rollup index:::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=rollup-index-def]
 --
 
-endif::xpack-terms[]
-ifdef::xpack-terms[]
-
-[[glossary-rollup-job]] {rollup-job}::
+[[glossary-rollup-job]] {rollup-job}:::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=rollup-job-def]
 --
-endif::xpack-terms[]
-ifdef::elasticsearch-terms[]
 
-[[glossary-routing]] routing ::
+[[glossary-routing]] routing:::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=routing-def]
 --
 
-endif::elasticsearch-terms[]
-ifdef::cloud-terms[]
-
-[[glossary-runner]] runner ::
-
+[[glossary-runner]] runner:::
 A local control agent that runs on all hosts, used to deploy local containers
 based on role definitions. Ensures that containers assigned to it exist and are
 able to run, and creates or recreates the containers if necessary.
-+
 //Source: Cloud
-endif::cloud-terms[]
 
-[discrete]
-[[s_glos]]
-=== S
+[[s-glos]] S::
 
-ifdef::cloud-terms[]
-
-[[glossary-services-forwarder]] services forwarder ::
-
+[[glossary-services-forwarder]] services forwarder:::
 Routes data internally in an {ece} installation.
-+
 //Source: Cloud
-endif::cloud-terms[]
-ifdef::elasticsearch-terms[]
 
-[[glossary-shard]] shard ::
+[[glossary-shard]] shard:::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=shard-def]
 --
 
-endif::elasticsearch-terms[]
-ifdef::logstash-terms[]
-
-[[glossary-shipper]] shipper ::
-
+[[glossary-shipper]] shipper:::
 An instance of Logstash that send events to another instance of Logstash, or
 some other application.
-+
 //Source: Logstash
-endif::logstash-terms[]
-ifdef::elasticsearch-terms[]
 
-[[glossary-shrink]] shrink ::
+[[glossary-shrink]] shrink:::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=shrink-def]
 --
 
-endif::elasticsearch-terms[]
-ifdef::elasticsearch-terms[]
-
-[[glossary-snapshot]] snapshot ::
+[[glossary-snapshot]] snapshot:::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=snapshot-def]
 --
 
-endif::elasticsearch-terms[]
-ifdef::xpack-terms[]
-
-[[glossary-snapshot-lifecycle-policy]] snapshot lifecycle policy ::
+[[glossary-snapshot-lifecycle-policy]] snapshot lifecycle policy:::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=snapshot-lifecycle-policy-def]
 --
 
-endif::xpack-terms[]
-ifdef::elasticsearch-terms[]
-
-[[glossary-snapshot-repository]] snapshot repository::
+[[glossary-snapshot-repository]] snapshot repository:::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=snapshot-repository-def]
 --
 
-endif::elasticsearch-terms[]
-ifdef::elasticsearch-terms[]
-
-[[glossary-source_field]] source field ::
+[[glossary-source_field]] source field:::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=source-field-def]
 --
 
-endif::elasticsearch-terms[]
-ifdef::elasticsearch-terms[]
-
-[[glossary-split]] split ::
+[[glossary-split]] split:::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=split-def]
 --
 
-endif::elasticsearch-terms[]
-ifdef::cloud-terms[]
-
-[[glossary-stunnel]] stunnel ::
-
+[[glossary-stunnel]] stunnel:::
 Securely tunnels all traffic in an {ece} installation.
-+
 //Source: Cloud
-endif::cloud-terms[]
 
-[discrete]
-[[t_glos]]
-=== T
+[[t-glos]] T::
 
-ifdef::elasticsearch-terms[]
-
-[[glossary-term]] term ::
+[[glossary-term]] term:::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=term-def]
 --
 
-endif::elasticsearch-terms[]
-ifdef::elasticsearch-terms[]
-
-[[glossary-text]] text ::
+[[glossary-text]] text:::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=text-def]
 --
 
-endif::elasticsearch-terms[]
-ifdef::elasticsearch-terms[]
-
-[[glossary-type]] type ::
+[[glossary-type]] type:::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=type-def]
 --
 
-endif::elasticsearch-terms[]
+[[w-glos]] W::
 
-[discrete]
-[[w_glos]]
-=== W
-
-ifdef::xpack-terms[]
-
-[[glossary-warm-phase]] warm phase ::
+[[glossary-warm-phase]] warm phase:::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=warm-phase-def]
 --
 
-endif::xpack-terms[]
-ifdef::logstash-terms[]
-
-[[glossary-worker]] worker ::
-
+[[glossary-worker]] worker:::
 The filter thread model used by Logstash, where each worker receives an
 <<glossary-event,event>> and applies all filters, in order, before emitting
 the event to the output queue. This allows scalability across CPUs because
 many filters are CPU intensive.
-+
 //Source: Logstash
-endif::logstash-terms[]
 
-[discrete]
-[[z_glos]]
-=== Z
+[[z-glos]] Z::
 
-ifdef::cloud-terms[]
-
-[[glossary-zookeeper]] ZooKeeper ::
-
+[[glossary-zookeeper]] ZooKeeper:::
 A coordination service for distributed systems used by {ece} to store the state
 of the installation. Responsible for discovery of hosts, resource allocation,
 leader election after failure and high priority notifications.
-+
 //Source: Cloud
-endif::cloud-terms[]

--- a/docs/en/glossary/glossary.asciidoc
+++ b/docs/en/glossary/glossary.asciidoc
@@ -4,14 +4,6 @@
 <<a_glos>> | <<b_glos>> | <<c_glos>> | <<d_glos>> | <<e_glos>> | <<f_glos>> | <<g_glos>> | <<h_glos>> | <<i_glos>> | <<j_glos>> | K | <<l_glos>> | <<m_glos>> | <<n_glos>> | <<o_glos>> | <<p_glos>> | <<q_glos>> | <<r_glos>> | <<s_glos>> | <<t_glos>> | U | V | <<w_glos>> | X | Y | <<z_glos>>
 
 [discrete]
-[[intro]]
-=== Introduction
-The products in the https://www.elastic.co/products[{stack}]
-are designed to be used together and thus there is common terminology. In the
-exceptional cases where a term has different connotations in specific products
-or domains, those differences are noted in the definition.
-
-[discrete]
 [[a_glos]]
 === A
 

--- a/docs/en/glossary/glossary.asciidoc
+++ b/docs/en/glossary/glossary.asciidoc
@@ -3,24 +3,19 @@
 
 <<a_glos>> | <<b_glos>> | <<c_glos>> | <<d_glos>> | <<e_glos>> | <<f_glos>> | <<g_glos>> | <<h_glos>> | <<i_glos>> | <<j_glos>> | K | <<l_glos>> | <<m_glos>> | <<n_glos>> | <<o_glos>> | <<p_glos>> | <<q_glos>> | <<r_glos>> | <<s_glos>> | <<t_glos>> | U | V | <<w_glos>> | X | Y | <<z_glos>>
 
-[discrete]
-[[a_glos]]
-=== A
+[[a_glos]] A ::
 
 ifdef::cloud-terms[]
 
-[[glossary-admin-console]] administration console ::
-
+[[glossary-admin-console]] administration console :::
 A component of {ece} that provides the API server for the
 <<glossary-cloud-ui,Cloud UI>>. Also syncs cluster and allocator data from
 ZooKeeper to {es}.
-+
 //Source: Cloud
 endif::cloud-terms[]
 ifdef::cloud-terms[]
 
-[[glossary-allocator]] allocator ::
-
+[[glossary-allocator]] allocator :::
 Manages hosts that contain {es} and {kib} nodes. Controls the lifecycle of these
 nodes by creating new <<glossary-container,containers>> and managing the nodes
 within these containers when requested. Used to scale the capacity of your {ece}
@@ -30,7 +25,7 @@ installation.
 endif::cloud-terms[]
 ifdef::elasticsearch-terms[]
 
-[[glossary-analysis]] analysis ::
+[[glossary-analysis]] analysis :::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=analysis-def]
@@ -38,8 +33,7 @@ include::{es-repo-dir}/glossary.asciidoc[tag=analysis-def]
 
 endif::elasticsearch-terms[]
 ifdef::xpack-terms[]
-[[glossary-anomaly-detection-job]] {anomaly-job} ::
-
+[[glossary-anomaly-detection-job]] {anomaly-job} :::
 {anomaly-jobs-cap} contain the configuration information and metadata
 necessary to perform an analytics task. See
 {ml-docs}/ml-jobs.html[{ml-jobs-cap}] and the
@@ -49,7 +43,7 @@ necessary to perform an analytics task. See
 endif::xpack-terms[]
 ifdef::elasticsearch-terms[]
 
-[[glossary-api-key]] API key ::
+[[glossary-api-key]] API key :::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=api-key-def]
@@ -58,7 +52,7 @@ include::{es-repo-dir}/glossary.asciidoc[tag=api-key-def]
 endif::elasticsearch-terms[]
 ifdef::elasticsearch-terms[]
 
-[[glossary-auto-follow-pattern]] auto-follow pattern ::
+[[glossary-auto-follow-pattern]] auto-follow pattern :::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=auto-follow-pattern-def]
@@ -66,8 +60,7 @@ include::{es-repo-dir}/glossary.asciidoc[tag=auto-follow-pattern-def]
 
 endif::elasticsearch-terms[]
 ifdef::cloud-terms[]
-[[glossary-zone]] availability zone ::
-
+[[glossary-zone]] availability zone :::
 Contains resources available to a {ece} installation that are isolated from
 other availability zones to safeguard against failure. Could be a rack, a server
 zone or some other logical constraint that creates a failure boundary. In a
@@ -79,21 +72,17 @@ entire availability zone. Also see
 //Source: Cloud
 endif::cloud-terms[]
 
-[discrete]
-[[b_glos]]
-=== B
+[[b_glos]] B ::
 
 ifdef::cloud-terms[]
-[[glossary-beats-runner]] beats runner ::
-
-Used to send Filebeat and Metricbeat information to the logging cluster.
+[[glossary-beats-runner]] beats runner :::
+Used to send {filebeat} and {metricbeat} information to the logging cluster.
 +
 //Source: Cloud
 endif::cloud-terms[]
 ifdef::xpack-terms[]
 
-[[glossary-ml-bucket]] bucket ::
-
+[[glossary-ml-bucket]] bucket :::
 The {ml-features} use the concept of a bucket to divide the time series into
 batches for processing. The _bucket span_ is part of the configuration
 information for {anomaly-jobs}. It defines the time interval that is used to
@@ -106,14 +95,10 @@ is required.
 //Source: X-Pack
 endif::xpack-terms[]
 
-[discrete]
-[[c_glos]]
-=== C
+[[c_glos]] C ::
 
 ifdef::cloud-terms[]
-
-[[glossary-client-forwarder]] client forwarder ::
-
+[[glossary-client-forwarder]] client forwarder :::
 Used for secure internal communications between various components of {ece} and
 ZooKeeper.
 +
@@ -121,7 +106,7 @@ ZooKeeper.
 endif::cloud-terms[]
 ifdef::cloud-terms[]
 
-[[glossary-cloud-ui]] Cloud UI ::
+[[glossary-cloud-ui]] Cloud UI :::
 
 Provides web-based access to manage your {ece} installation, supported by the
 <<glossary-admin-console,administration console>>.
@@ -130,7 +115,7 @@ Provides web-based access to manage your {ece} installation, supported by the
 endif::cloud-terms[]
 ifdef::elasticsearch-terms,cloud-terms[]
 
-[[glossary-cluster]] cluster ::
+[[glossary-cluster]] cluster :::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=cluster-def]
@@ -138,9 +123,7 @@ include::{es-repo-dir}/glossary.asciidoc[tag=cluster-def]
 
 endif::elasticsearch-terms,cloud-terms[]
 ifdef::logstash-terms[]
-
-[[glossary-codec-plugin]] codec plugin ::
-
+[[glossary-codec-plugin]] codec plugin :::
 A Logstash <<glossary-plugin,plugin>> that changes the data representation
 of an <<glossary-event,event>>. Codecs are essentially stream filters that
 can operate as part of an input or output. Codecs enable you to separate the
@@ -151,7 +134,7 @@ json, msgpack, and plain (text).
 endif::logstash-terms[]
 ifdef::xpack-terms[]
 
-[[glossary-cold-phase]] cold phase ::
+[[glossary-cold-phase]] cold phase :::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=cold-phase-def]
@@ -160,8 +143,7 @@ include::{es-repo-dir}/glossary.asciidoc[tag=cold-phase-def]
 endif::xpack-terms[]
 ifdef::logstash-terms[]
 
-[[glossary-conditional]] conditional ::
-
+[[glossary-conditional]] conditional :::
 A control flow that executes certain actions based on whether a statement
 (also called a condition) is true or false. Logstash supports `if`,
 `else if`, and `else` statements. You can use conditional statements to
@@ -172,8 +154,7 @@ you specify.
 endif::logstash-terms[]
 ifdef::cloud-terms[]
 
-[[glossary-constructor]] constructor ::
-
+[[glossary-constructor]] constructor :::
 Directs <<glossary-allocator,allocators>> to manage containers of {es} and {kib}
 nodes and maximizes the utilization of allocators. Monitors plan change requests
 from the Cloud UI and determines how to transform the existing cluster. In a
@@ -185,8 +166,7 @@ entire availability zone.
 endif::cloud-terms[]
 ifdef::cloud-terms[]
 
-[[glossary-container]] container ::
-
+[[glossary-container]] container :::
 Includes an instance of {ece} software and its dependencies. Used to provision
 similar environments, to assign a guaranteed share of host resources to nodes,
 and to simplify operational effort in {ece}.
@@ -195,8 +175,7 @@ and to simplify operational effort in {ece}.
 endif::cloud-terms[]
 ifdef::cloud-terms[]
 
-[[glossary-coordinator]] coordinator ::
-
+[[glossary-coordinator]] coordinator :::
 Consists of a logical grouping of some {ece} services and acts as a distributed
 coordination system and resource scheduler.
 +
@@ -204,7 +183,7 @@ coordination system and resource scheduler.
 endif::cloud-terms[]
 ifdef::xpack-terms[]
 
-[[glossary-ccr]] {ccr} (CCR)::
+[[glossary-ccr]] {ccr} (CCR) :::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=ccr-def]
@@ -212,7 +191,7 @@ include::{es-repo-dir}/glossary.asciidoc[tag=ccr-def]
 
 endif::xpack-terms[]
 ifdef::elasticsearch-terms[]
-[[glossary-ccs]] {ccs} (CCS)::
+[[glossary-ccs]] {ccs} (CCS) :::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=ccs-def]
@@ -220,14 +199,10 @@ include::{es-repo-dir}/glossary.asciidoc[tag=ccs-def]
 
 endif::elasticsearch-terms[]
 
-[discrete]
-[[d_glos]]
-=== D
+[[d_glos]] D ::
 
 ifdef::xpack-terms[]
-
-[[glossary-ml-datafeed]] datafeed ::
-
+[[glossary-ml-datafeed]] datafeed :::
 {anomaly-jobs-cap} can analyze either a one-off batch of data or continuously in
 real time. {dfeeds-cap} retrieve data from {es} for analysis. Alternatively, you
 can post data from any source directly to a {ml} API.
@@ -235,8 +210,8 @@ can post data from any source directly to a {ml} API.
 //Source: X-Pack
 endif::xpack-terms[]
 ifdef::xpack-terms[]
-[[glossary-dataframe-job]] {dfanalytics-job} ::
 
+[[glossary-dataframe-job]] {dfanalytics-job} :::
 {dfanalytics-jobs-cap} contain the configuration information and metadata
 necessary to perform {ml} analytics tasks on a source index and store the
 outcome in a destination index. See
@@ -244,17 +219,17 @@ outcome in a destination index. See
 {ref}/put-dfanalytics.html[create {dfanalytics-job} API].
 //Source: X-Pack
 endif::xpack-terms[]
-
 ifdef::elasticsearch-terms[]
-[[glossary-data-stream]] data stream::
+
+[[glossary-data-stream]] data stream :::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=data-stream-def]
 --
 endif::elasticsearch-terms[]
-
 ifdef::xpack-terms[]
-[[glossary-delete-phase]] delete phase ::
+
+[[glossary-delete-phase]] delete phase :::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=delete-phase-def]
@@ -263,8 +238,7 @@ include::{es-repo-dir}/glossary.asciidoc[tag=delete-phase-def]
 endif::xpack-terms[]
 ifdef::xpack-terms[]
 
-[[glossary-ml-detector]] detector ::
-
+[[glossary-ml-detector]] detector :::
 As part of the configuration information that is associated with {anomaly-jobs},
 detectors define the type of analysis that needs to be done. They also specify
 which fields to analyze. You can have more than one detector in a job, which is
@@ -274,8 +248,7 @@ more efficient than running multiple jobs against the same data.
 endif::xpack-terms[]
 ifdef::cloud-terms[]
 
-[[glossary-director]] director ::
-
+[[glossary-director]] director :::
 Manages the <<glossary-zookeeper,ZooKeeper>> datastore. This role is often
 shared with the <<glossary-coordinator,coordinator>>, though in production
 deployments it can be separated.
@@ -284,7 +257,7 @@ deployments it can be separated.
 endif::cloud-terms[]
 ifdef::elasticsearch-terms[]
 
-[[glossary-document]] document ::
+[[glossary-document]] document :::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=document-def]
@@ -292,21 +265,16 @@ include::{es-repo-dir}/glossary.asciidoc[tag=document-def]
 
 endif::elasticsearch-terms[]
 
-[discrete]
-[[e_glos]]
-=== E
+[[e_glos]] E ::
 
-[[glossary-ecs]] Elastic Common Schema (ECS) ::
-
+[[glossary-ecs]] Elastic Common Schema (ECS) :::
 A document schema for Elasticsearch, for use cases such as logging and metrics.
 ECS defines a common set of fields, their datatype, and gives guidance on their
 correct usage. ECS is used to improve uniformity of event data coming from
 different sources.
 
 ifdef::logstash-terms[]
-
-[[glossary-event]] event ::
-
+[[glossary-event]] event :::
 A single unit of information, containing a timestamp plus additional data. An
 event arrives via an input, and is subsequently parsed, timestamped, and
 passed through the Logstash <<glossary-pipeline,pipeline>>.
@@ -314,13 +282,10 @@ passed through the Logstash <<glossary-pipeline,pipeline>>.
 //Source: Logstash
 endif::logstash-terms[]
 
-[discrete]
-[[f_glos]]
-=== F
+[[f_glos]] F ::
 
 ifdef::xpack-terms[]
-[[glossary-feature-influence]] feature influence ::
-
+[[glossary-feature-influence]] feature influence :::
 In {oldetection}, feature influence scores indicate which features of a data
 point contribute to its outlier behavior. See
 {ml-docs}/dfa-outlier-detection.html#dfa-feature-influence[Feature influence].
@@ -328,8 +293,8 @@ point contribute to its outlier behavior. See
 //Source: X-Pack
 endif::xpack-terms[]
 ifdef::xpack-terms[]
-[[glossary-feature-importance]] feature importance ::
 
+[[glossary-feature-importance]] feature importance :::
 In supervised {ml} methods such as {regression} and {classification}, feature
 importance indicates the degree to which a specific feature affects a prediction.
 See
@@ -341,11 +306,10 @@ and
 endif::xpack-terms[]
 ifdef::elasticsearch-terms,logstash-terms[]
 
-[[glossary-field]] field ::
+[[glossary-field]] field :::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=field-def]
-
 
 endif::elasticsearch-terms,logstash-terms[]
 ifdef::logstash-terms[]
@@ -360,8 +324,7 @@ properties.
 endif::logstash-terms[]
 ifdef::logstash-terms[]
 
-[[glossary-field-reference]] field reference ::
-
+[[glossary-field-reference]] field reference :::
 A reference to an event <<glossary-field,field>>. This reference may appear in
 an output block or filter block in the Logstash config file. Field references
 are typically wrapped in square (`[]`) brackets, for example `[fieldname]`. If
@@ -373,17 +336,15 @@ field: `[top-level field][nested field]`.
 endif::logstash-terms[]
 ifdef::elasticsearch-terms[]
 
-[[glossary-filter]] filter ::
+[[glossary-filter]] filter :::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=filter-def]
 --
-
 endif::elasticsearch-terms[]
 ifdef::logstash-terms[]
 
-[[glossary-filter-plugin]] filter plugin ::
-
+[[glossary-filter-plugin]] filter plugin :::
 A Logstash <<glossary-plugin,plugin>> that performs intermediary processing on
 an <<glossary-event,event>>. Typically, filters act upon event data after it
 has been ingested via inputs, by mutating, enriching, and/or modifying the
@@ -394,38 +355,34 @@ grok, mutate, drop, clone, and geoip. Filter stages are optional.
 //Source: Logstash
 endif::logstash-terms[]
 ifdef::elasticsearch-terms[]
-[[glossary-flush]] flush ::
+
+[[glossary-flush]] flush :::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=flush-def]
 --
-
 endif::elasticsearch-terms[]
 ifdef::elasticsearch-terms[]
-[[glossary-follower-index]] follower index ::  
+
+[[glossary-follower-index]] follower index :::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=follower-index-def]
 --
-
 endif::elasticsearch-terms[]
 ifdef::elasticsearch-terms[]
-[[glossary-frozen-index]] frozen index ::  
+
+[[glossary-frozen-index]] frozen index :::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=frozen-index-def]
 --
-
 endif::elasticsearch-terms[]
 
-[discrete]
-[[g_glos]]
-=== G
+[[g_glos]] G ::
 
 ifdef::logstash-terms[]
-
-[[glossary-gem]] gem ::
-
+[[glossary-gem]] gem :::
 A self-contained package of code that's hosted on
 https://rubygems.org[RubyGems.org]. Logstash <<glossary-plugin,plugins>> are
 packaged as Ruby Gems. You can use the Logstash
@@ -434,69 +391,60 @@ packaged as Ruby Gems. You can use the Logstash
 //Source: Logstash
 endif::logstash-terms[]
 
-[discrete]
-[[h_glos]]
-=== H
+[[h_glos]] H ::
 
 ifdef::xpack-terms[]
-[[glossary-hot-phase]] hot phase ::
+[[glossary-hot-phase]] hot phase :::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=hot-phase-def]
 --
-
 endif::xpack-terms[]
 ifdef::logstash-terms[]
 
-[[glossary-hot-thread]] hot thread ::
-
+[[glossary-hot-thread]] hot thread :::
 A Java thread that has high CPU usage and executes for a longer than normal
 period of time.
 +
 //Source: Logstash
 endif::logstash-terms[]
 
-[discrete]
-[[i_glos]]
-=== I
+[[i_glos]] I ::
 
 ifdef::elasticsearch-terms[]
-
-[[glossary-id]] ID ::
+[[glossary-id]] ID :::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=id-def]
 --
-
 endif::elasticsearch-terms[]
 ifdef::elasticsearch-terms[]
 
-[[glossary-index]] index ::
+[[glossary-index]] index :::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=index-def]
 --
-
 endif::elasticsearch-terms[]
 ifdef::elasticsearch-terms[]
 
-[[glossary-index-alias]] index alias ::
+[[glossary-index-alias]] index alias :::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=index-alias-def]
 --
-
 endif::elasticsearch-terms[]
 ifdef::xpack-terms[]
-[[glossary-index-lifecycle]] index lifecycle ::
+
+[[glossary-index-lifecycle]] index lifecycle :::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=index-lifecycle-def]
 --
-
 endif::xpack-terms[]
 ifdef::xpack-terms[]
-[[glossary-index-lifecycle-policy]] index lifecycle policy ::
+
+[[glossary-index-lifecycle-policy]] index lifecycle policy :::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=index-lifecycle-policy-def]
@@ -504,25 +452,24 @@ include::{es-repo-dir}/glossary.asciidoc[tag=index-lifecycle-policy-def]
 
 endif::xpack-terms[]
 ifdef::elasticsearch-terms[]
-[[glossary-index-pattern]] index pattern ::
+
+[[glossary-index-pattern]] index pattern :::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=index-pattern-def]
 --
-
 endif::elasticsearch-terms[]
 ifdef::logstash-terms[]
 
-[[glossary-indexer]] indexer ::
-
+[[glossary-indexer]] indexer :::
 A Logstash instance that is tasked with interfacing with an {es} cluster in
 order to index <<glossary-event,event>> data.
 +
 //Source: Logstash
 endif::logstash-terms[]
 ifdef::xpack-terms[]
-[[glossary-influencer]] influencer ::
 
+[[glossary-influencer]] influencer :::
 Influencers are entities that might have contributed to an anomaly in a specific
 bucket in an {anomaly-job}. For more information, see
 {ml-docs}/ml-influencers.html[Influencers].
@@ -531,8 +478,7 @@ bucket in an {anomaly-job}. For more information, see
 endif::xpack-terms[]
 ifdef::logstash-terms[]
 
-[[glossary-input-plugin]] input plugin ::
-
+[[glossary-input-plugin]] input plugin :::
 A Logstash <<glossary-plugin,plugin>> that reads <<glossary-event,event>> data
 from a specific source. Input plugins are the first stage in the Logstash
 event processing <<glossary-pipeline,pipeline>>. Popular input plugins include

--- a/docs/en/glossary/index.asciidoc
+++ b/docs/en/glossary/index.asciidoc
@@ -11,5 +11,4 @@ include::{docs-root}/shared/attributes.asciidoc[]
 
 :es-repo-dir:          {elasticsearch-root}/docs/reference
 
-include::intro.asciidoc[]
 include::glossary.asciidoc[]

--- a/docs/en/glossary/index.asciidoc
+++ b/docs/en/glossary/index.asciidoc
@@ -1,11 +1,6 @@
 [[elastic-glossary]]
 = Elastic Glossary
 
-:cloud-terms:          true
-:elasticsearch-terms:  true
-:logstash-terms:       true
-:xpack-terms:          true
-
 include::{docs-root}/shared/versions/stack/{source_branch}.asciidoc[]
 include::{docs-root}/shared/attributes.asciidoc[]
 

--- a/docs/en/glossary/intro.asciidoc
+++ b/docs/en/glossary/intro.asciidoc
@@ -1,7 +1,0 @@
-[[intro]]
-== Introduction
-
-The products in the https://www.elastic.co/products[Elastic Stack]
-are designed to be used together and thus there is common terminology across
-the stack. In the exceptional cases where a term has different connotations in
-specific products or domains, those differences are noted in the definition.


### PR DESCRIPTION
Depends on https://github.com/elastic/kibana/pull/69721 and https://github.com/elastic/docs/pull/1875

This PR adds alphabetical sections and links to the Glossary (https://www.elastic.co/guide/en/elastic-stack-glossary/current/index.html). It also moves the "Introduction" page into the "Terminology" page, so that there's only one page in this book.

### Preview

https://stack-docs_1214.docs-preview.app.elstc.co/guide/en/elastic-stack-glossary/master/terms.html