### PR TITLE
[DOCS] Add placeholders for Observability docs

### DIFF
--- a/docs/en/observability/index.asciidoc
+++ b/docs/en/observability/index.asciidoc
@@ -1,0 +1,12 @@
+:doctype: book
+
+= Observability Guide
+
+include::{docs-root}/shared/versions/stack/{source_branch}.asciidoc[]
+
+include::{docs-root}/shared/attributes.asciidoc[]
+
+include::observability-introduction.asciidoc[]
+
+include::observability-ui.asciidoc[]
+

--- a/docs/en/observability/index.asciidoc
+++ b/docs/en/observability/index.asciidoc
@@ -9,4 +9,3 @@ include::{docs-root}/shared/attributes.asciidoc[]
 include::observability-introduction.asciidoc[]
 
 include::observability-ui.asciidoc[]
-

--- a/docs/en/observability/observability-introduction.asciidoc
+++ b/docs/en/observability/observability-introduction.asciidoc
@@ -1,0 +1,9 @@
+[[observability-introduction]]
+[role="xpack"]
+
+= Observability 
+++++
+<titleabbrev>What is Elastic Observability?</titleabbrev>
+++++
+
+//TODO: Add content

--- a/docs/en/observability/observability-introduction.asciidoc
+++ b/docs/en/observability/observability-introduction.asciidoc
@@ -1,9 +1,36 @@
 [[observability-introduction]]
 [role="xpack"]
-
-= Observability 
-++++
-<titleabbrev>What is Elastic Observability?</titleabbrev>
-++++
+== What is Elastic Observability? 
 
 //TODO: Add content
+
+
+[[observability-get-started]]
+== Get started with the {stack}
+
+To get started...
+
+=== Hosted Elasticsearch Service
+
+=== Install the {stack} yourself
+
+=== Run the {stack} on Docker
+
+=== Run the {stack} on Kubernetes
+
+[float]
+==== Step 1: Install {es}
+
+[float]
+==== Step 2: Install {kib}
+
+[[observability-add-data]]
+== Add observability data 
+
+=== Instrument applications
+
+=== Ingest logs
+
+=== Ingest metrics
+
+=== Ingest uptime data

--- a/docs/en/observability/observability-ui.asciidoc
+++ b/docs/en/observability/observability-ui.asciidoc
@@ -1,0 +1,10 @@
+[[observability-ui]]
+[role="xpack"]
+
+== Observability app
+++++
+<titleabbrev>Overview</titleabbrev>
+++++
+
+//TODO: Add content
+

--- a/docs/en/observability/observability-ui.asciidoc
+++ b/docs/en/observability/observability-ui.asciidoc
@@ -1,10 +1,22 @@
 [[observability-ui]]
 [role="xpack"]
 
-== Observability app
-++++
-<titleabbrev>Overview</titleabbrev>
-++++
+== Monitor observable environments
 
-//TODO: Add content
+Displayed on the Observability *Overview* page are a wide variety of chart
+visualizations that provide you with analytical information on what is
+happening within your environments.
+
+The dashboard is comprised of four components to help you make your environments 
+observable; APM, logs, metrics, and uptime. 
+
+=== Services, transactions, and error rates
+
+=== Log rates
+
+=== System metrics
+
+=== Systems availability 
+
+=== Alerts 
 


### PR DESCRIPTION
This PR adds content placeholders for the forthcoming Observability docs. This directory and the files will be included in the migration of the Logs and Metrics directories to the new Observability repo. 

The following PRs need to be merged before migrating the Logs and Metrics directories:

https://github.com/elastic/stack-docs/pull/1210
https://github.com/elastic/stack-docs/pull/1203

### Related PRs:

https://github.com/elastic/docs/pull/1877
