### PR TITLE
remove unnecessary options for elasticsearch-setup-passwords

### DIFF
--- a/docs/en/getting-started/get-started-docker.asciidoc
+++ b/docs/en/getting-started/get-started-docker.asciidoc
@@ -154,11 +154,7 @@ and join the lines before running this command.
 ["source","sh"]
 ----
 docker exec es01 /bin/bash -c "bin/elasticsearch-setup-passwords \
-auto --batch \
--Expack.security.http.ssl.certificate=certificates/es01/es01.crt \
--Expack.security.http.ssl.certificate_authorities=certificates/ca/ca.crt \
--Expack.security.http.ssl.key=certificates/es01/es01.key \
---url https://es01:9200"
+auto --batch --url https://es01:9200"
 ----
 
 IMPORTANT: Make a note of the generated passwords. 


### PR DESCRIPTION
Removing `xpack.security.http.ssl.*` options because the following error occurs when running `elasticsearch-setup-passwords` with these.

```
ERROR: setting [xpack.security.http.ssl.certificate] already set, saw [certificates/es01/es01.crt] and [/usr/share/elasticsearch/config/certificates/es01/es01.crt]
```