### PR TITLE
[7.8] Clean up ingest management docs (#1211)

### DIFF
--- a/docs/en/ingest-management/getting-started.asciidoc
+++ b/docs/en/ingest-management/getting-started.asciidoc
@@ -18,10 +18,7 @@ into problems and need to modify your setup to get this feature running. Please
 do not enable or use {ingest-management} in a production environment.
 // end::experimental-warning[]
 
-For feedback and questions, please contact us in the
-https://ela.st/ingest-manager-feedback[discuss forum].
-
-//TODO: Add link to limitations topic after it is merged. 
+For feedback and questions, please contact us in the {im-forum}[discuss forum].
 
 [float]
 [[ingest-manager-prereqs]]
@@ -146,11 +143,6 @@ image::images/kibana-ingest-manager-configurations-default-with-nginx.png[{inges
 == Step 3: Install and run {agent}
 
 include::{beats-repo-dir}/x-pack/elastic-agent/docs/elastic-agent.asciidoc[tag=agent-install-intro]
-
-//REVIEWERS: I know this section makes the docs longer, but it's easier for users
-//Don't worry too much about the length because I have some code for a tabbed
-//panel that I will use to display this content. I'll follow up later with a PR
-//that adds this code. 
 
 include::{beats-repo-dir}/x-pack/elastic-agent/docs/install-elastic-agent.asciidoc[tag=install-elastic-agent]
 

--- a/docs/en/ingest-management/index.asciidoc
+++ b/docs/en/ingest-management/index.asciidoc
@@ -1,14 +1,12 @@
 :doctype: book
 :beats-repo-dir: {beats-root}
+:im-forum: https://discuss.elastic.co/tags/c/elastic-stack/81/stack-ingest-management
 
 = Ingest Management Guide
 
 include::{docs-root}/shared/versions/stack/{source_branch}.asciidoc[]
 
 include::{docs-root}/shared/attributes.asciidoc[]
-
-//TODO: remove this temporary override after review approval
-:release-state: released
 
 include::ingest-management-overview.asciidoc[leveloffset=+1]
 

--- a/docs/en/ingest-management/ingest-management-limitations.asciidoc
+++ b/docs/en/ingest-management/ingest-management-limitations.asciidoc
@@ -33,4 +33,4 @@ on
 *   No support for Kubernetes or Docker autodiscovery
 
 Experimental releases are not officially supported, but we encourage you to
-report issues in our https://ela.st/agent-discuss[discuss forum].
+report issues in our {im-forum}[discuss forum].

--- a/docs/en/ingest-management/ingest-management-overview.asciidoc
+++ b/docs/en/ingest-management/ingest-management-overview.asciidoc
@@ -8,8 +8,6 @@ experimental[]
 [[elastic-agent]]
 == {agent}
 
-//TODO: We use "makes it easier" too frequently in this topic. Clean it up.
-
 {agent} is a single, unified way to add monitoring for logs, metrics, and
 other types of data to each host. A single Agent makes it easier and faster
 to deploy monitoring across your infrastructure. The Agent's single, unified

--- a/docs/en/ingest-management/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting.asciidoc
@@ -14,8 +14,7 @@ following GitHub repositories:
 * https://github.com/elastic/beats/issues[{beats}]
 * https://github.com/elastic/package-registry/issues[{package-registry}]
 
-Contact us in the https://ela.st/ingest-manager-feedback[discuss forum]. Your feedback is very
-valuable to us.
+Contact us in the {im-forum}[discuss forum]. Your feedback is very valuable to us.
 
 
 **Common problems:**
@@ -118,7 +117,7 @@ To find more about the error, open your browser's development console, navigate
 to the **Network** tab, and refresh the page. One of the requests to the
 {ingest-manager} API will most likely have returned an error. If the error
 message doesn't give you enough information to fix the problem, please contact
-us in the https://ela.st/ingest-manager-feedback[discuss forum].
+us in the {im-forum}[discuss forum].
 
 [float]
 [[agent-enrollment-timeout]]


### PR DESCRIPTION
Backports the following commits to 7.8:
 - Clean up ingest management docs (#1211)