### PR TITLE
Use es03 cert for es03 node in docker

### DIFF
--- a/docs/en/getting-started/docker/elastic-docker-tls.yml
+++ b/docs/en/getting-started/docker/elastic-docker-tls.yml
@@ -86,7 +86,7 @@ services:
       - xpack.security.http.ssl.enabled=true
       - xpack.security.http.ssl.key=$CERTS_DIR/es03/es03.key
       - xpack.security.http.ssl.certificate_authorities=$CERTS_DIR/ca/ca.crt
-      - xpack.security.http.ssl.certificate=$CERTS_DIR/es02/es02.crt
+      - xpack.security.http.ssl.certificate=$CERTS_DIR/es03/es03.crt
       - xpack.security.transport.ssl.enabled=true
       - xpack.security.transport.ssl.verification_mode=certificate 
       - xpack.security.transport.ssl.certificate_authorities=$CERTS_DIR/ca/ca.crt


### PR DESCRIPTION
A small fix that sets the correct http certificate for es03 node in docker.