### PR TITLE
[7.8] [DOCS] Document encryption key setting needed by Fleet (#1224)

### DIFF
--- a/docs/en/ingest-management/getting-started.asciidoc
+++ b/docs/en/ingest-management/getting-started.asciidoc
@@ -35,25 +35,29 @@ your own hardware].
 
 * A user with the superuser role. See {ref}/built-in-roles.html[Built-in roles].
 
-* On self-managed clusters, the following settings are required. If you're using
-our https://www.elastic.co/cloud/elasticsearch-service[hosted  {ess}] on
-{ecloud}, these settings are already enabled.
+* On self-managed clusters, you must configure security and encryption settings.
+If you're using our https://www.elastic.co/cloud/elasticsearch-service[hosted {ess}]
+on {ecloud}, these settings are already enabled.
 
-** In your {es} configuration, enable: 
+** In your {es} configuration: 
 +
-- {ref}/configuring-security.html[{es} security]. Set `xpack.security.enabled`
-to `true`.
-- {ref}/security-settings.html#api-key-service-settings[API key service]. Set
-`xpack.security.authc.api_key.enabled` to `true`.
+- {ref}/configuring-security.html[Configure {es} security]. Set
+`xpack.security.enabled` to `true`.
+- {ref}/security-settings.html#api-key-service-settings[Enable the built-in API key service].
+Set `xpack.security.authc.api_key.enabled` to `true`.
 
-** In your {kib} configuration, enable:
+** In your {kib} configuration:
 +
-- {kibana-ref}/using-kibana-with-security.html[{kib} security]. Set `xpack.security.enabled`
-to `true`.
-- {kibana-ref}/configuring-tls.html[TLS]. As an alternative, you can disable the
-TLS check by setting `xpack.ingestManager.fleet.tlsCheckDisabled` to `true`. For
-example, you might want to disable TLS checking if {kib} is behind a proxy that
-terminates the SSL connection.
+- {kibana-ref}/using-kibana-with-security.html[Configure {kib} security]. Set
+`xpack.security.enabled` to `true`.
+- {kibana-ref}/configuring-tls.html[Configure TLS]. As an alternative, you can
+disable the TLS check by setting `xpack.ingestManager.fleet.tlsCheckDisabled`
+to `true`. For example, you might want to disable TLS checking if {kib} is
+behind a proxy that terminates the SSL connection.
+- Set `xpack.encryptedSavedObjects.encryptionKey` to any alphanumeric value of
+at least 32 characters. For example:
+`xpack.security.encryptionKey: "something_at_least_32_characters"`. {fleet}
+requires this setting in order to save API keys and encrypt them in {kib}.
 
 [float]
 [[enable-ingest-management]]

--- a/docs/en/ingest-management/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting.asciidoc
@@ -151,7 +151,7 @@ token when you run the `elastic-agent enroll` command.
 
 [float]
 [[es-apikey-failed]]
-== {es} authentication service fails with `Authentication using apikey failed` message
+== {fleet} fails with HTTP 500 error while trying to decrypt API keys
 
 {fleet} requires an encryption key in order to save API keys and encrypt them in
 {kib}. To provide an API key, set the `xpack.encryptedSavedObjects.encryptionKey`

--- a/docs/en/ingest-management/troubleshooting.asciidoc
+++ b/docs/en/ingest-management/troubleshooting.asciidoc
@@ -23,6 +23,7 @@ Contact us in the {im-forum}[discuss forum]. Your feedback is very valuable to u
 * <<ingest-management-setup-fails>>
 * <<ingest-manager-app-crashes>>
 * <<agent-enrollment-timeout>>
+* <<es-apikey-failed>>
 
 **Frequently asked questions:**
 
@@ -121,7 +122,7 @@ us in the {im-forum}[discuss forum].
 
 [float]
 [[agent-enrollment-timeout]]
-== {agent} enrollment fails on the host with a `Client.Timeout exceeded` message
+== {agent} enrollment fails on the host with `Client.Timeout exceeded` message
 
 {agent} must be able to connect to the {kib} instance to enroll in {fleet}.
 If the Agent is unable to connect, you will see the following failure:
@@ -147,6 +148,19 @@ the key is valid. To do this:
 that you used to enroll {agent} on your host.
 .. If the secret doesn't match, create a new enrollment token and use the new
 token when you run the `elastic-agent enroll` command.
+
+[float]
+[[es-apikey-failed]]
+== {es} authentication service fails with `Authentication using apikey failed` message
+
+{fleet} requires an encryption key in order to save API keys and encrypt them in
+{kib}. To provide an API key, set the `xpack.encryptedSavedObjects.encryptionKey`
+property in the `kibana.yml` configuration file. For example:
+
+[source,yaml]
+----
+xpack.security.encryptionKey: "something_at_least_32_characters"
+----
 
 [float]
 [[enrolled-agent-not-showing-up]]


### PR DESCRIPTION
Backports the following commits to 7.8:
 - [DOCS] Document encryption key setting needed by Fleet (#1224)