### PR TITLE
[Docs][SIEM]Adds ml rule prerequisites 

### DIFF
--- a/docs/en/siem/detections/detection-engine-intro.asciidoc
+++ b/docs/en/siem/detections/detection-engine-intro.asciidoc
@@ -162,7 +162,7 @@ For *all* deployments (on-premises and hosted):
 ** Write permissions for the `.siem-signals-<space name>` index, such as 
 `create` `create_doc`, `write`, `index`, and `all`
 (see {ref}/security-privileges.html#privileges-list-indices[Indices privileges]).
-** To run and create {ml} rules, you must have the
+** To create {ml} rules, you must have the
 {ref}/built-in-roles.html[`machine_learning_admin`] user role. For on-premises deployments, you must also have the
 https://www.elastic.co/subscriptions[appropriate license].
 

--- a/docs/en/siem/detections/detection-engine-intro.asciidoc
+++ b/docs/en/siem/detections/detection-engine-intro.asciidoc
@@ -162,6 +162,9 @@ For *all* deployments (on-premises and hosted):
 ** Write permissions for the `.siem-signals-<space name>` index, such as 
 `create` `create_doc`, `write`, `index`, and `all`
 (see {ref}/security-privileges.html#privileges-list-indices[Indices privileges]).
+** To run and create {ml} rules, you must have the
+{ref}/built-in-roles.html[`machine_learning_admin`] user role. For on-premises deployments, you must also have the
+https://www.elastic.co/subscriptions[appropriate license].
 
 [float]
 === Resolve UI error messages

--- a/docs/en/siem/detections/detection-engine-intro.asciidoc
+++ b/docs/en/siem/detections/detection-engine-intro.asciidoc
@@ -162,7 +162,7 @@ For *all* deployments (on-premises and hosted):
 ** Write permissions for the `.siem-signals-<space name>` index, such as 
 `create` `create_doc`, `write`, `index`, and `all`
 (see {ref}/security-privileges.html#privileges-list-indices[Indices privileges]).
-** To create {ml} rules, you must have the
+** To create or modify {ml} rules, you must have the
 {ref}/built-in-roles.html[`machine_learning_admin`] user role. For on-premises deployments, you must also have the
 https://www.elastic.co/subscriptions[appropriate license].
 


### PR DESCRIPTION
Adds ml rule creation requirements to the Detections prerequisites as users are having trouble finding this info.

[Preview](https://stack-docs_1230.docs-preview.app.elstc.co/guide/en/siem/guide/master/detection-engine-overview.html#detections-permissions)