### PR TITLE
Change links to refactored Beats getting started docs

### DIFF
--- a/docs/en/getting-started/get-started-stack.asciidoc
+++ b/docs/en/getting-started/get-started-stack.asciidoc
@@ -384,14 +384,14 @@ Started documentation:
 [options="header"]
 |=======================
 |Elastic {beats} | To capture
-|{auditbeat-ref}/auditbeat-getting-started.html[{auditbeat}] |Audit data
-|{filebeat-ref}/filebeat-getting-started.html[{filebeat}] |Log files
-|{functionbeat-ref}/functionbeat-getting-started.html[{functionbeat}] |Cloud data
-|{heartbeat-ref}/heartbeat-getting-started.html[{heartbeat}] |Availability monitoring
-|{journalbeat-ref}/journalbeat-getting-started.html[{journalbeat}] |Systemd journals
-|{metricbeat-ref}/metricbeat-getting-started.html[{metricbeat}] |Metrics
-|{packetbeat-ref}/packetbeat-getting-started.html[{packetbeat}] |Network traffic
-|{winlogbeat-ref}/winlogbeat-getting-started.html[{winlogbeat}] |Windows event logs
+|{auditbeat-ref}/auditbeat-installation-configuration.html[{auditbeat}] |Audit data
+|{filebeat-ref}/filebeat-installation-configuration.html[{filebeat}] |Log files
+|{functionbeat-ref}/functionbeat-installation-configuration.html[{functionbeat}] |Cloud data
+|{heartbeat-ref}/heartbeat-installation-configuration.html[{heartbeat}] |Availability monitoring
+|{journalbeat-ref}/journalbeat-installation-configuration.html[{journalbeat}] |Systemd journals
+|{metricbeat-ref}/metricbeat-installation-configuration.html[{metricbeat}] |Metrics
+|{packetbeat-ref}/packetbeat-installation-configuration.html[{packetbeat}] |Network traffic
+|{winlogbeat-ref}/winlogbeat-installation-configuration.html[{winlogbeat}] |Windows event logs
 |=======================
 
 

--- a/docs/en/gke-on-prem/index.asciidoc
+++ b/docs/en/gke-on-prem/index.asciidoc
@@ -11,7 +11,7 @@ include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 :filebeatautodiscoverdocs: {filebeat-ref}/configuration-autodiscover.html
 :metricbeatmodules: {metricbeat-ref}/metricbeat-modules.html
 :metricbeatautodiscoverdocs: {metricbeat-ref}/configuration-autodiscover.html
-:filebeat-getting-started-view-the-sample-dashboards: {filebeat-ref}/view-kibana-dashboards.html#view-kibana-dashboards
+:filebeat-getting-started-view-the-sample-dashboards: {filebeat-ref}/filebeat-installation-configuration.html#view-data
 :kube-state-metrics: https://github.com/kubernetes/kube-state-metrics
 :k8s-rbac: https://kubernetes.io/docs/reference/access-authn-authz/rbac/
 :guestbook-app: https://cloud.google.com/kubernetes-engine/docs/tutorials/guestbook

--- a/docs/en/siem/installation.asciidoc
+++ b/docs/en/siem/installation.asciidoc
@@ -84,17 +84,16 @@ If your data source isn't in the list, or you want to install {beats} the old
 fashioned way:
 
 * *{filebeat} and {filebeat} modules.* See the
-{filebeat-ref}/filebeat-modules-quickstart.html[{filebeat} modules quick start]
+{filebeat-ref}/filebeat-installation-configuration.html[{filebeat} quick start]
 and enable modules for the events you want to collect. If there is no module
-for the events you want to collect, see the
-{filebeat-ref}/filebeat-installation-configuration.html[{filebeat} getting started] to
-learn how to configure inputs.
+for the events you want to collect, see
+{filebeat-ref}/configuration-filebeat-options.html[Configure inputs].
 
-* *Auditbeat.* See {auditbeat-ref}/auditbeat-installation-configuration.html[{auditbeat} getting started].
+* *Auditbeat.* See {auditbeat-ref}/auditbeat-installation-configuration.html[{auditbeat} quick start].
 
-* *Winlogbeat.* See {winlogbeat-ref}/winlogbeat-installation-configuration.html[{winlogbeat} getting started].
+* *Winlogbeat.* See {winlogbeat-ref}/winlogbeat-installation-configuration.html[{winlogbeat} quick start].
 
-* *Packetbeat.* See {packetbeat-ref}/packetbeat-installation-configuration.html[{packetbeat} getting started].
+* *Packetbeat.* See {packetbeat-ref}/packetbeat-installation-configuration.html[{packetbeat} quick start].
 
 [float]
 === Enable modules and configuration options

--- a/docs/en/siem/installation.asciidoc
+++ b/docs/en/siem/installation.asciidoc
@@ -87,14 +87,14 @@ fashioned way:
 {filebeat-ref}/filebeat-modules-quickstart.html[{filebeat} modules quick start]
 and enable modules for the events you want to collect. If there is no module
 for the events you want to collect, see the
-{filebeat-ref}/filebeat-getting-started.html[{filebeat} getting started] to
+{filebeat-ref}/filebeat-installation-configuration.html[{filebeat} getting started] to
 learn how to configure inputs.
 
-* *Auditbeat.* See {auditbeat-ref}/auditbeat-getting-started.html[{auditbeat} getting started].
+* *Auditbeat.* See {auditbeat-ref}/auditbeat-installation-configuration.html[{auditbeat} getting started].
 
-* *Winlogbeat.* See {winlogbeat-ref}/winlogbeat-getting-started.html[{winlogbeat} getting started].
+* *Winlogbeat.* See {winlogbeat-ref}/winlogbeat-installation-configuration.html[{winlogbeat} getting started].
 
-* *Packetbeat.* See {packetbeat-ref}/packetbeat-getting-started.html[{packetbeat} getting started].
+* *Packetbeat.* See {packetbeat-ref}/packetbeat-installation-configuration.html[{packetbeat} getting started].
 
 [float]
 === Enable modules and configuration options


### PR DESCRIPTION
Updates links to reflect changes added in elastic/beats#19302.

This change applies to 7.9 and later.

Marking as WIP because I want to wait until the observability-docs repo changes are in place before finalizing.