### PR TITLE
[7.8] [Docs][SIEM]Adds ml rule prerequisites  (#1230)

### DIFF
--- a/docs/en/siem/detections/detection-engine-intro.asciidoc
+++ b/docs/en/siem/detections/detection-engine-intro.asciidoc
@@ -162,6 +162,9 @@ For *all* deployments (on-premises and hosted):
 ** Write permissions for the `.siem-signals-<space name>` index, such as 
 `create` `create_doc`, `write`, `index`, and `all`
 (see {ref}/security-privileges.html#privileges-list-indices[Indices privileges]).
+** To create or modify {ml} rules, you must have the
+{ref}/built-in-roles.html[`machine_learning_admin`] user role. For on-premises deployments, you must also have the
+https://www.elastic.co/subscriptions[appropriate license].
 
 [float]
 === Resolve UI error messages


### PR DESCRIPTION
Backports the following commits to 7.8:
 - [Docs][SIEM]Adds ml rule prerequisites  (#1230)