### PR TITLE
[DOCS] Clarify trial subscription levels

### DIFF
--- a/docs/en/getting-started/get-started-docker.asciidoc
+++ b/docs/en/getting-started/get-started-docker.asciidoc
@@ -57,10 +57,11 @@ volumes by running `docker-compose down -v`.
 [[get-started-docker-tls]]
 === Run in Docker with TLS enabled 
 
-When security is enabled with a https://www.elastic.co/subscriptions[Gold or Platinum license], 
-Transport Layer Security (TLS) encryption must be configured for the {es} transport layer. 
-While it is possible to use a trial license without setting up TLS,
-we advise securing your stack from the start. 
+If you have a {subscriptions}[Gold (or higher) subscription] and the
+{security-features} are enabled, you must configure Transport Layer Security
+(TLS) encryption for the {es} transport layer. While it is possible to use a
+trial license without setting up TLS, we advise securing your stack from the
+start. 
 
 To get an {es} cluster and {kib} up and running in Docker with security enabled, 
 you can use Docker Compose:

--- a/docs/en/install-upgrade/installing-stack.asciidoc
+++ b/docs/en/install-upgrade/installing-stack.asciidoc
@@ -26,24 +26,21 @@ on are in place.
 
 [discrete]
 [[install-elastic-stack-for-elastic-cloud]]
-=== Installing on Elastic Cloud
+=== Installing on {ecloud}
 
-The https://www.elastic.co/cloud/elasticsearch-service[Elasticsearch Service]
-on Elastic Cloud is the official hosted Elasticsearch and Kibana offering from
-Elastic. The Elasticsearch Service is available on both AWS and GCP.
+The https://www.elastic.co/cloud/elasticsearch-service[{ess}] on {ecloud} is the
+official hosted {es} and {kib} offering from Elastic. The {ess} is available on
+both AWS and GCP.
 
-Installing on Elastic Cloud is easy: a single click creates an Elasticsearch
-cluster configured to the size you want, with or without high availability.
-{xpack} is always installed, so you automatically have the ability to secure
-and monitor your cluster. Kibana can be enabled on a cluster with a click, and
-a number of popular plugins are readily available.
+Installing on {ecloud} is easy: a single click creates an {es} cluster
+configured to the size you want, with or without high availability. The 
+subscription features are always installed, so you automatically have the
+ability to secure and monitor your cluster. {kib} can be enabled on a cluster
+with a click, and a number of popular plugins are readily available.
 
-Some Elastic Cloud features can be used only with a specific
-link:https://www.elastic.co/cloud/as-a-service/subscriptions[subscription level].
-For example, installing custom plugins, dictionaries, and scripts requires a Gold
-or Platinum subscription.
+Some {ecloud} features can be used only with a specific subscription. For more
+information, see https://www.elastic.co/pricing/.
 
-You can {ess-trial}[try out the
-Elasticsearch Service for free]. For more information, see
-{cloud}/ec-getting-started.html[Getting Started with Elastic Cloud].
+You can {ess-trial}[try out the {ess} for free]. For more information, see
+{cloud}/ec-getting-started.html[Getting Started with {ecloud}].
 


### PR DESCRIPTION
Relate: https://github.com/elastic/elasticsearch/pull/58958, https://github.com/elastic/kibana/pull/70636

This PR fixes the documentation that implies a trial licence maps to a platinum subscription. It also improves some licence-related text to align with the style guide and generally tries to avoid stating which licenses are required for specific features in the docs.

Preview:
https://stack-docs_1237.docs-preview.app.elstc.co/diff