### PR TITLE
[7.x] Change links to refactored Beats getting started docs (#1234)

### DIFF
--- a/docs/en/getting-started/get-started-stack.asciidoc
+++ b/docs/en/getting-started/get-started-stack.asciidoc
@@ -384,14 +384,14 @@ Started documentation:
 [options="header"]
 |=======================
 |Elastic {beats} | To capture
-|{auditbeat-ref}/auditbeat-getting-started.html[{auditbeat}] |Audit data
-|{filebeat-ref}/filebeat-getting-started.html[{filebeat}] |Log files
-|{functionbeat-ref}/functionbeat-getting-started.html[{functionbeat}] |Cloud data
-|{heartbeat-ref}/heartbeat-getting-started.html[{heartbeat}] |Availability monitoring
-|{journalbeat-ref}/journalbeat-getting-started.html[{journalbeat}] |Systemd journals
-|{metricbeat-ref}/metricbeat-getting-started.html[{metricbeat}] |Metrics
-|{packetbeat-ref}/packetbeat-getting-started.html[{packetbeat}] |Network traffic
-|{winlogbeat-ref}/winlogbeat-getting-started.html[{winlogbeat}] |Windows event logs
+|{auditbeat-ref}/auditbeat-installation-configuration.html[{auditbeat}] |Audit data
+|{filebeat-ref}/filebeat-installation-configuration.html[{filebeat}] |Log files
+|{functionbeat-ref}/functionbeat-installation-configuration.html[{functionbeat}] |Cloud data
+|{heartbeat-ref}/heartbeat-installation-configuration.html[{heartbeat}] |Availability monitoring
+|{journalbeat-ref}/journalbeat-installation-configuration.html[{journalbeat}] |Systemd journals
+|{metricbeat-ref}/metricbeat-installation-configuration.html[{metricbeat}] |Metrics
+|{packetbeat-ref}/packetbeat-installation-configuration.html[{packetbeat}] |Network traffic
+|{winlogbeat-ref}/winlogbeat-installation-configuration.html[{winlogbeat}] |Windows event logs
 |=======================
 
 

--- a/docs/en/siem/installation.asciidoc
+++ b/docs/en/siem/installation.asciidoc
@@ -84,17 +84,16 @@ If your data source isn't in the list, or you want to install {beats} the old
 fashioned way:
 
 * *{filebeat} and {filebeat} modules.* See the
-{filebeat-ref}/filebeat-modules-quickstart.html[{filebeat} modules quick start]
+{filebeat-ref}/filebeat-installation-configuration.html[{filebeat} quick start]
 and enable modules for the events you want to collect. If there is no module
-for the events you want to collect, see the
-{filebeat-ref}/filebeat-getting-started.html[{filebeat} getting started] to
-learn how to configure inputs.
+for the events you want to collect, see
+{filebeat-ref}/configuration-filebeat-options.html[Configure inputs].
 
-* *Auditbeat.* See {auditbeat-ref}/auditbeat-getting-started.html[{auditbeat} getting started].
+* *Auditbeat.* See {auditbeat-ref}/auditbeat-installation-configuration.html[{auditbeat} quick start].
 
-* *Winlogbeat.* See {winlogbeat-ref}/winlogbeat-getting-started.html[{winlogbeat} getting started].
+* *Winlogbeat.* See {winlogbeat-ref}/winlogbeat-installation-configuration.html[{winlogbeat} quick start].
 
-* *Packetbeat.* See {packetbeat-ref}/packetbeat-getting-started.html[{packetbeat} getting started].
+* *Packetbeat.* See {packetbeat-ref}/packetbeat-installation-configuration.html[{packetbeat} quick start].
 
 [float]
 === Enable modules and configuration options


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Change links to refactored Beats getting started docs (#1234)