### PR TITLE
[DOCS] Clarifies machine learning nodes

### DIFF
--- a/docs/en/glossary/glossary.asciidoc
+++ b/docs/en/glossary/glossary.asciidoc
@@ -573,7 +573,7 @@ include::{kib-repo-dir}/glossary.asciidoc[tag=lucene-def]
 === M
 
 [[glossary-ml-nodes]] machine learning node::
-A {ml} node is a node that has `xpack.ml.enabled` and `node.roles` set to `ml`.
+A {ml} node is a node that has `xpack.ml.enabled` set to `true` and `ml` in `node.roles`.
 If you want to use {ml-features}, there must be at least one {ml} node in your
 cluster. See {ref}/modules-node.html#ml-node[Machine learning nodes].
 //Source: X-Pack

--- a/docs/en/glossary/glossary.asciidoc
+++ b/docs/en/glossary/glossary.asciidoc
@@ -573,10 +573,9 @@ include::{kib-repo-dir}/glossary.asciidoc[tag=lucene-def]
 === M
 
 [[glossary-ml-nodes]] machine learning node::
-A {ml} node is a node that has `xpack.ml.enabled` and `node.ml` set to `true`,
-which is the default behavior. If you set `node.ml` to `false`, the node can
-service API requests but it cannot run {ml-jobs}. If you want to use
-{ml-features}, there must be at least one {ml} node in your cluster.
+A {ml} node is a node that has `xpack.ml.enabled` and `node.roles` set to `ml`.
+If you want to use {ml-features}, there must be at least one {ml} node in your
+cluster. See {ref}/modules-node.html#ml-node[Machine learning nodes].
 //Source: X-Pack
 
 [[glossary-map]] map::

--- a/docs/en/stack/ml/setup.asciidoc
+++ b/docs/en/stack/ml/setup.asciidoc
@@ -19,7 +19,7 @@ trial of {ess}] in the cloud.
 === Machine learning nodes
 
 To use {ml-features}, there must be at least one {ml} node in your cluster. A
-{ml} node is a node that has `xpack.ml.enabled` and `node.roles` set to `ml`.
+{ml} node is a node that has `xpack.ml.enabled` set to `true` and `ml` in `node.roles`.
 
 If nodes do not have the {ml} role, they cannot run {ml} jobs. If
 `xpack.ml.enabled` is `true`, however, they can service API requests. For more

--- a/docs/en/stack/ml/setup.asciidoc
+++ b/docs/en/stack/ml/setup.asciidoc
@@ -19,13 +19,11 @@ trial of {ess}] in the cloud.
 === Machine learning nodes
 
 To use {ml-features}, there must be at least one {ml} node in your cluster. A
-{ml} node is a node that has `xpack.ml.enabled` and `node.ml` set to `true`,
-which is the default behavior.
+{ml} node is a node that has `xpack.ml.enabled` and `node.roles` set to `ml`.
 
-You can limit which nodes run resource-intensive activity related to {ml} jobs
-by setting `node.ml` to `false` on some nodes. In that case, they can service
-API requests but cannot run {ml} jobs. For more information, see
-{ref}/modules-node.html#ml-node[Machine learning nodes].
+If nodes do not have the {ml} role, they cannot run {ml} jobs. If
+`xpack.ml.enabled` is `true`, however, they can service API requests. For more
+information, see {ref}/modules-node.html#ml-node[Machine learning nodes].
 
 [discrete]
 [[setup-privileges]]


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/54998 and https://github.com/elastic/elasticsearch/pull/59024

This PR changes occurrences of node.ml to node.roles.

### Preview

https://stack-docs_1239.docs-preview.app.elstc.co/guide/en/machine-learning/master/setup.html
https://stack-docs_1239.docs-preview.app.elstc.co/guide/en/elastic-stack-glossary/master/terms.html#m-glos