### PR TITLE
[DOCS] Removes ML content from index.asciidoc files

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/index.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/index.asciidoc
@@ -1,27 +1,4 @@
-[role="xpack"]
-[[xpack-ml]]
-= {anomaly-detect-cap}
-
-[partintro]
---
-Use {anomaly-detect} to analyze time series data by creating accurate baselines 
-of normal behavior and identifying anomalous patterns in your dataset. Data is 
-pulled from {es} for analysis and anomaly results are displayed in {kib} 
-dashboards.
-
-* <<ml-overview>>
-* <<ml-concepts>>
-* <<ml-configuration>>
-//* <<ml-getting-started>>
-* <<ml-api-quickref>>
-* <<ootb-ml-jobs>>
-* <<ml-functions>>
-* <<anomaly-examples>>
-* <<ml-limitations>>
-//* <<ml-troubleshooting>>
-
-
---
+include::xpack-ml.asciidoc[]
 
 include::ml-overview.asciidoc[]
 

--- a/docs/en/stack/ml/anomaly-detection/xpack-ml.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/xpack-ml.asciidoc
@@ -1,0 +1,24 @@
+[role="xpack"]
+[[xpack-ml]]
+= {anomaly-detect-cap}
+
+[partintro]
+--
+Use {anomaly-detect} to analyze time series data by creating accurate baselines 
+of normal behavior and identifying anomalous patterns in your dataset. Data is 
+pulled from {es} for analysis and anomaly results are displayed in {kib} 
+dashboards.
+
+* <<ml-overview>>
+* <<ml-concepts>>
+* <<ml-configuration>>
+//* <<ml-getting-started>>
+* <<ml-api-quickref>>
+* <<ootb-ml-jobs>>
+* <<ml-functions>>
+* <<anomaly-examples>>
+* <<ml-limitations>>
+//* <<ml-troubleshooting>>
+
+
+--

--- a/docs/en/stack/ml/df-analytics/index.asciidoc
+++ b/docs/en/stack/ml/df-analytics/index.asciidoc
@@ -1,28 +1,4 @@
-[role="xpack"]
-[[ml-dfanalytics]]
-= {dfanalytics-cap}
-:stem:
-
-
-[partintro]	
---
-IMPORTANT: Using {dfanalytics} requires source data to be structured as a two 
-dimensional "tabular" data structure, in other words a {dataframe}. 
-{ref}/transforms.html[{transforms-cap}] enable you to create 
-{dataframes} which can be used as the source for {dfanalytics}.
-
-experimental[]
-
-{dfanalytics-cap} enable you to perform different analyses of your data and 
-annotate it with the results.
-
-* <<ml-dfa-overview>>
-* <<ml-dfa-concepts>>
-* <<ml-dfanalytics-apis>>
-* <<dfanalytics-examples>>
-* <<ml-dfa-limitations>>
-
---
+include::ml-dfanalytics.asciidoc[]
 
 include::ml-dfa-overview.asciidoc[]
 include::ml-dfa-phases.asciidoc[leveloffset=+1]

--- a/docs/en/stack/ml/df-analytics/ml-dfanalytics.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfanalytics.asciidoc
@@ -1,0 +1,25 @@
+[role="xpack"]
+[[ml-dfanalytics]]
+= {dfanalytics-cap}
+:stem:
+
+
+[partintro]	
+--
+IMPORTANT: Using {dfanalytics} requires source data to be structured as a two 
+dimensional "tabular" data structure, in other words a {dataframe}. 
+{ref}/transforms.html[{transforms-cap}] enable you to create 
+{dataframes} which can be used as the source for {dfanalytics}.
+
+experimental[]
+
+{dfanalytics-cap} enable you to perform different analyses of your data and 
+annotate it with the results.
+
+* <<ml-dfa-overview>>
+* <<ml-dfa-concepts>>
+* <<ml-dfanalytics-apis>>
+* <<dfanalytics-examples>>
+* <<ml-dfa-limitations>>
+
+--


### PR DESCRIPTION
Related to https://github.com/elastic/stack-docs/pull/1240 and https://github.com/elastic/stack-docs/pull/1246

This PR splits the content from the anomaly-detection/index.asciidoc and df-analytics/index.asciidoc into new files with names that match their anchors/URLs. Thus the index.asciidoc files contain only structural information.