### PR TITLE
[DOCS] Makes it clear that only significant influencers are reported

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/ml-influencers.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-influencers.asciidoc
@@ -44,11 +44,13 @@ can be overwhelming and there is a small overhead to the analysis.
 
 The influencer results show which entities were anomalous and when. One
 influencer result is written per bucket for each influencer that affects the
-anomalousness of the bucket. The {ml} analytics determine the impact of an
-influencer by performing a series of experiments that remove all data points
-with a specific influencer value and check whether the bucket is still anomalous.
-For jobs with more than one detector, influencer scores provide a powerful view
-of the most anomalous entities.
+anomalousness of the bucket. The {ml} analytics determine the impact of an 
+influencer by performing a series of experiments that remove all data points 
+with a specific influencer value and check whether the bucket is still 
+anomalous. That means that only influencers with statistically significant 
+impact on the anomaly are reported in the results. For jobs with more than one 
+detector, influencer scores provide a powerful view of the most anomalous 
+entities.
 
 For example, the `high_sum_total_sales` {anomaly-job} for the eCommerce orders
 sample data uses `customer_full_name.keyword` and `category.keyword` as


### PR DESCRIPTION
## Overview

This PR amends the docs on influencers to make it clear that they are reported only if they have a statistically significant impact on the anomalousness.

### Preview

[Influencer results](https://stack-docs_1269.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-influencers.html#ml-influencer-results)