### PR TITLE
[DOCS] Add model memory tip for ML modules

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/anomaly-detection-scale.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/anomaly-detection-scale.asciidoc
@@ -165,7 +165,7 @@ is based on the analysis configuration details for the job and cardinality
 estimates, which are derived by running aggregations on the source indices as
 they exist at that specific point in time. 
 
-If you change the resources available on your {ml} nodes or the make significant 
+If you change the resources available on your {ml} nodes or make significant 
 changes to the characteristics or cardinality of your data, the model memory 
 requirements might also change. You can update the model memory limit for a job 
 while it is closed. If you want to decrease the limit below the current model 

--- a/docs/en/stack/ml/anomaly-detection/anomaly-detection-scale.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/anomaly-detection-scale.asciidoc
@@ -180,8 +180,8 @@ each job. If you reach the hard limit and are concerned about the missing data,
 ensure that you have adequate resources then clone and re-run the job with a 
 larger model memory limit. For more information about retrieving the memory 
 status, see the
-{ref}ml-get-job-stats.html[get {anomaly-jobs} stats API] or the
-{ref}ml-get-snapshot.html[get model snapshots API].
+{ref}/ml-get-job-stats.html[get {anomaly-jobs} stats API] or the
+{ref}/ml-get-snapshot.html[get model snapshots API].
 
 [discrete]
 [[pre-aggregate-data]]

--- a/docs/en/stack/ml/anomaly-detection/anomaly-detection-scale.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/anomaly-detection-scale.asciidoc
@@ -162,14 +162,21 @@ The `model_memory_limit` job configuration option sets the approximate maximum
 amount of memory resources required for analytical processing. When you create
 an {anomaly-job} in {kib}, it provides an estimate for this limit. The estimate 
 is based on the analysis configuration details for the job and cardinality 
-estimates for the fields it references. You can also obtain this information
-from the
-{ref}/ml-estimate-model-memory.html[estimate {anomaly-jobs} model memory API].  
+estimates, which are derived by running aggregations on the source indices as
+they exist at that specific point in time. 
 
-If you change the resources available on your {ml} nodes or the characteristics 
-of your data, the memory requirements might also change. You can increase the 
-model memory limit for an existing job while it is closed. To decrease the limit, 
-you must clone and re-run the job.
+If you change the resources available on your {ml} nodes or the make significant 
+changes to the characteristics or cardinality of your data, the model memory 
+requirements might also change. You can update the model memory limit for a job 
+while it is closed. If you want to decrease the limit below the current model 
+memory usage, however, you must clone and re-run the job.
+
+TIP: You can view the current model size statistics with the
+{ref}/ml-get-job-stats.html[get {anomaly-job} stats] and
+{ref}/ml-get-snapshot.html[get model snapshots] APIs. You can also obtain a
+model memory limit estimate at any time by running the
+{ref}/ml-estimate-model-memory.html[estimate {anomaly-jobs} model memory API].  
+However, you must provide your own cardinality estimates.
 
 As a job approaches its model memory limit, the memory status is `soft_limit`
 and older models are more aggressively pruned to free up space. If you have
@@ -178,10 +185,7 @@ limit, the memory status is `hard_limit` and the job no longer models new
 entities. It is therefore important to have appropriate memory model limits for 
 each job. If you reach the hard limit and are concerned about the missing data,
 ensure that you have adequate resources then clone and re-run the job with a 
-larger model memory limit. For more information about retrieving the memory 
-status, see the
-{ref}/ml-get-job-stats.html[get {anomaly-jobs} stats API] or the
-{ref}/ml-get-snapshot.html[get model snapshots API].
+larger model memory limit.
 
 [discrete]
 [[pre-aggregate-data]]

--- a/docs/en/stack/ml/anomaly-detection/anomaly-detection-scale.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/anomaly-detection-scale.asciidoc
@@ -159,18 +159,29 @@ start the {dfeed} for the change to be applied.
 == 7. Set the model memory limit
 
 The `model_memory_limit` job configuration option sets the approximate maximum 
-amount of memory resources required for analytical processing. If this variable 
-is set too low for the job and the limit is approached, data pruning becomes 
-more aggressive. Upon exceeding this limit, new entities are not modeled.
+amount of memory resources required for analytical processing. When you create
+an {anomaly-job} in {kib}, it provides an estimate for this limit. The estimate 
+is based on the analysis configuration details for the job and cardinality 
+estimates for the fields it references. You can also obtain this information
+from the
+{ref}/ml-estimate-model-memory.html[estimate {anomaly-jobs} model memory API].  
 
-Use model memory estimation to have a better picture of the memory needs of the 
-model. Model memory estimation happens automatically when you create the job in 
-{kib} or you can call the 
-{ref}/ml-estimate-model-memory.html[Estimate {anomaly-jobs} model memory API] 
-manually. The estimation is based on the analysis configuration details for the 
-job and cardinality estimates for the fields it references. You can update the 
-memory settings of an existing job, but the job must be closed.
+If you change the resources available on your {ml} nodes or the characteristics 
+of your data, the memory requirements might also change. You can increase the 
+model memory limit for an existing job while it is closed. To decrease the limit, 
+you must clone and re-run the job.
 
+As a job approaches its model memory limit, the memory status is `soft_limit`
+and older models are more aggressively pruned to free up space. If you have
+categorization jobs, no further examples are stored. When a job exceeds its 
+limit, the memory status is `hard_limit` and the job no longer models new 
+entities. It is therefore important to have appropriate memory model limits for 
+each job. If you reach the hard limit and are concerned about the missing data,
+ensure that you have adequate resources then clone and re-run the job with a 
+larger model memory limit. For more information about retrieving the memory 
+status, see the
+{ref}ml-get-job-stats.html[get {anomaly-jobs} stats API] or the
+{ref}ml-get-snapshot.html[get model snapshots API].
 
 [discrete]
 [[pre-aggregate-data]]

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -32,11 +32,8 @@ the descriptions of the individual configurations.
 [[ootb-ml-model-memory]]
 == Model memory considerations
 
-By default, these jobs have
-{ref}/ml-put-job.html#put-analysislimits[model_memory_limit] values that are
-deemed appropriate for typical user environments. If the characteristics of your
-data cause these jobs to reach `soft_limit` or
-`hard_limit` {ref}/ml-get-job-stats.html#modelsizestats[memory_status] values,
-you can clone the job and increase the model memory limit. Before you clone the
-job, you might also need to update the
-{ref}/ml-settings.html[xpack.ml.max_model_memory_limit] setting.
+By default, these jobs have `model_memory_limit` values that are deemed 
+appropriate for typical user environments and data characteristics. If your
+environment or your data is atypical and your jobs reach a memory status value
+of `soft_limit` or `hard_limit`, you might need to update the model memory
+limits. For more information, see <<set-model-memory-limit>>.

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -37,6 +37,6 @@ By default, these jobs have
 deemed appropriate for typical user environments. If the characteristics of your
 data cause these jobs to reach `soft_limit` or
 `hard_limit` {ref}/ml-get-job-stats.html#modelsizestats[memory_status] values,
-you can clone the job and increase the model memory limit. You might also need
-to update the {ref}/ml-settings.html[xpack.ml.max_model_memory_limit] setting
-before you clone the job.
+you can clone the job and increase the model memory limit. Before you clone the
+job, you might also need to update the
+{ref}/ml-settings.html[xpack.ml.max_model_memory_limit] setting.

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -27,3 +27,16 @@ be created via the related solution UI in {kib}.
 NOTE: The configurations are only available if data exists that matches the 
 queries specified in the manifest files. These recognizer queries are linked in 
 the descriptions of the individual configurations.
+
+[discrete]
+[[ootb-ml-model-memory]]
+== Model memory considerations
+
+By default, these jobs have
+{ref}/ml-put-job.html#put-analysislimits[model_memory_limit] values that are
+deemed appropriate for typical user environments. If the characteristics of your
+data cause these jobs to reach `soft_limit` or
+`hard_limit` {ref}/ml-get-job-stats.html#modelsizestats[memory_status] values,
+you can clone the job and increase the model memory limit. You might also need
+to update the {ref}/ml-settings.html[xpack.ml.max_model_memory_limit] setting
+before you clone the job.

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -36,4 +36,5 @@ By default, these jobs have `model_memory_limit` values that are deemed
 appropriate for typical user environments and data characteristics. If your
 environment or your data is atypical and your jobs reach a memory status value
 of `soft_limit` or `hard_limit`, you might need to update the model memory
-limits. For more information, see <<set-model-memory-limit>>.
+limits. For more information, see
+<<set-model-memory-limit,Working with {anomaly-detect} at scale>>.


### PR DESCRIPTION
This PR adds a tip in https://www.elastic.co/guide/en/machine-learning/master/ootb-ml-jobs.html for dealing with model memory limits.

### Preview

* https://stack-docs_1271.docs-preview.app.elstc.co/guide/en/machine-learning/master/anomaly-detection-scale.html#set-model-memory-limit
* https://stack-docs_1271.docs-preview.app.elstc.co/guide/en/machine-learning/master/ootb-ml-jobs.html