### PR TITLE
[DOCS] Updates to APM ML module for service maps

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-apm.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-apm.asciidoc
@@ -87,11 +87,10 @@ This job is useful in identifying bots.
 // tag::apm-transaction-jobs[]
 Detect anomalies in transactions from your APM services.
 
-high_mean_response_time::
+high_mean_transaction_duration::
 
-* For transaction data where `processor.event` is `transaction` and 
-`transaction.type` is `request`.
-* Models response time duration of transactions.
+* For transaction data where `processor.event` is `transaction`.
+* Models duration of transactions by transaction type for APM services.
 * Detects anomalies in high mean of transaction duration (using the 
   <<ml-metric-mean,`high_mean` function>>).
 


### PR DESCRIPTION
Related to https://github.com/elastic/kibana/pull/70361

This PR updates the list of supplied ML modules for APM to replace the high_mean_response_time job with the high_mean_transaction_duration job.

### Preview

https://stack-docs_1272.docs-preview.app.elstc.co/guide/en/machine-learning/master/ootb-ml-jobs-apm.html