### PR TITLE
[DOCS] Adds Deploying the model section to regression and classification conceptual

### DIFF
--- a/docs/en/stack/ml/df-analytics/dfa-classification.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-classification.asciidoc
@@ -86,7 +86,7 @@ The model that you created is stored as {es} documents in internal indices. In
 other words, the characteristics of your trained model are saved and ready to be 
 deployed and used as functions. The <<ml-inference,{infer}>> feature enables you 
 to use your model in a preprocessor of an ingest pipeline or in a pipeline 
-aggregation of a search query to get a prediction on your data.
+aggregation of a search query to make predictions about your data.
 
 
 [[dfa-classification-performance]]

--- a/docs/en/stack/ml/df-analytics/dfa-classification.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-classification.asciidoc
@@ -27,6 +27,7 @@ can optionally include or exclude fields from the analysis. For more information
 about field selection, see the
 {ref}/explain-dfanalytics.html[explain data frame analytics API].
 
+
 [[dfa-classification-supervised]]
 === Training the {classification} model
 
@@ -63,6 +64,7 @@ that is approximately balanced. That is to say, ideally your data set should
 have a similar number of data points for each class.
 ////
 
+
 [[dfa-classification-algorithm]]
 ==== {classification-cap} algorithms
 
@@ -75,6 +77,17 @@ and every decision tree learns from the mistakes of the previous one. Every tree
 is an iteration of the last one, hence it improves the decision made by the 
 previous tree.
 //end::classification-algorithms[]
+
+
+[[dfa-classification-deploy]]
+=== Deploying the model
+
+The model that you created is stored as {es} documents in internal indices. In 
+other words, the characteristics of your trained model are saved and ready to be 
+deployed and used as functions. The <<ml-inference,{infer}>> feature enables you 
+to use your model in a preprocessor of an ingest pipeline or in a pipeline 
+aggregation of a search query to get a prediction on your data.
+
 
 [[dfa-classification-performance]]
 === {classification-cap} performance

--- a/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
@@ -72,6 +72,7 @@ predictions are combined.
 {regression-cap} works as a batch analysis. If new data comes into your index, 
 you must restart the {dfanalytics-job}.
 
+
 [[dfa-regression-algorithm]]
 ==== {regression-cap} algorithms
 
@@ -117,6 +118,16 @@ With the parameter, you can further refine the behavior of the chosen functions.
 TIP: The default loss function parameter values work fine for most of the cases. 
 It is highly recommended to use the default values, unless you fully understand 
 the impact of the different loss function parameters.
+
+
+[[dfa-regression-deploy]]
+=== Deploying the model
+
+The model that you created is stored as {es} documents in internal indices. In 
+other words, the characteristics of your trained model are saved and ready to be 
+deployed and used as functions. The <<ml-inference,{infer}>> feature enables you 
+to use your model in a preprocessor of an ingest pipeline or in a pipeline 
+aggregation of a search query to get a prediction on your data.
 
 
 [[dfa-regression-feature-importance]]

--- a/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
@@ -127,7 +127,7 @@ The model that you created is stored as {es} documents in internal indices. In
 other words, the characteristics of your trained model are saved and ready to be 
 deployed and used as functions. The <<ml-inference,{infer}>> feature enables you 
 to use your model in a preprocessor of an ingest pipeline or in a pipeline 
-aggregation of a search query to get a prediction on your data.
+aggregation of a search query to make predictions about your data.
 
 
 [[dfa-regression-feature-importance]]


### PR DESCRIPTION
## Overview

This PR expands the conceptual documentation of regression and classification with a section about possible further steps after training the model and adds a link that points to the inference conceptual piece.

### Preview

[Regression – Deploying the model](https://stack-docs_1273.docs-preview.app.elstc.co/guide/en/machine-learning/master/dfa-regression.html#dfa-regression-deploy)
[Classification – Deploying the model](https://stack-docs_1273.docs-preview.app.elstc.co/guide/en/machine-learning/master/dfa-classification.html#dfa-classification-deploy)