### PR TITLE
[DOCS] Adds Jupyter notebook link to loss function section of regression conceptual

### DIFF
--- a/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
@@ -114,6 +114,10 @@ create the {dfanalytics-job}. The default is mean squared error (`mse`). If you
 choose `msle` or `huber`, you can also set up a parameter for the loss function. 
 With the parameter, you can further refine the behavior of the chosen functions.
 
+Consult 
+https://github.com/elastic/examples/tree/master/Machine%20Learning/Regression%20Loss%20Functions[the Jupyter notebook on regression loss functions] 
+to learn more.
+
 TIP: The default loss function parameter values work fine for most of the cases. 
 It is highly recommended to use the default values, unless you fully understand 
 the impact of the different loss function parameters.
@@ -158,4 +162,6 @@ data set. For more information about the evaluation metrics, see
 [[dfa-regression-readings]]
 === Further readings
 
-https://github.com/elastic/examples/tree/master/Machine%20Learning/Feature%20Importance[Feature importance for {dfanalytics} (Jupyter notebook)]
+* https://github.com/elastic/examples/tree/master/Machine%20Learning/Feature%20Importance[Feature importance for {dfanalytics} (Jupyter notebook)]
+
+* https://github.com/elastic/examples/tree/master/Machine%20Learning/Regression%20Loss%20Functions[Regression loss functions (Jupyter notebook)]


### PR DESCRIPTION
## Overview

This PR adds a link of a Jupyter notebook about regression loss functions to the loss function and the further reading sections of regression conceptual documentation.

## Preview

[Loss functions for regression analyses](https://stack-docs_1274.docs-preview.app.elstc.co/guide/en/machine-learning/master/dfa-regression.html#dfa-regression-lossfunction)