### PR TITLE
[DOCS] Sorts APM ML modules

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-apm.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-apm.asciidoc
@@ -11,10 +11,15 @@ definitions in the `apm_*` folders in
 https://github.com/elastic/kibana/tree/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules[GitHub].
 
 // tag::apm-jobs[]
-abnormal_span_durations_jsbase::
+[[apm-nodejs-jobs]]
+=== NodeJS
+// tag::apm-nodejs-jobs[]
+Detect abnormal traces, anomalous spans, and identify periods of decreased
+throughput.
+
 abnormal_span_durations_nodejs::
 
-* For data from {apm-rum-agents} or {apm-node-agents} (where `agent.name` is `js-base` or `nodejs`).
+* For data from {apm-node-agents} (where `agent.name` is `nodejs`).
 * Models the duration of spans (`partition_field_name` is `span.type`).
 * Detects for spans that are taking longer than usual to process (using the 
   <<ml-metric-mean,`high_mean` function>>).
@@ -26,33 +31,61 @@ abnormal_trace_durations_nodejs::
 * Detects trace transactions that are processing slower than usual (using the 
   <<ml-metric-mean,`high_mean` function>>).
 
-anomalous_error_rate_for_user_agents_jsbase::
-
-* For data from {apm-rum-agents} (where `agent.name` is `js-base`).
-* Models the error rate of user agents (`partition_field_name` is 
-  `user_agent.name`).
-* Detects user agents that are encountering errors at an above normal rate 
-  (using the <<ml-nonzero-count,`high_non_zero_count` function>>).
-  
-This job can help detect browser compatibility issues.
-
-decreased_throughput_jsbase::
 decreased_throughput_nodejs::
 
-* For data from {apm-rum-agents} or {apm-node-agents} (where `agent.name` is `js-base` or `nodejs`).
+* For data from {apm-node-agents} (where `agent.name` is `nodejs`).
 * Models the transaction rate of the application.
 * Detects periods during which the application is processing fewer requests 
 than normal (using the <<ml-count,`low_count` function>>).
 
-high_count_by_user_agent_jsbase::
+// end::apm-nodejs-jobs[]
+
+
+[[apm-rum-javascript-jobs]]
+=== RUM Javascript
+// tag::apm-rum-javascript-jobs[]
+Detect problematic spans and identify user agents that are potentially causing
+issues.
+
+abnormal_span_durations_jsbase::
 
 * For data from {apm-rum-agents} (where `agent.name` is `js-base`).
-* Models the request rate of user agents (`partition_field_name` is 
-  `user_agent.name`).
-* Detects user agents that are making requests at a suspiciously high rate 
-  (using the <<ml-nonzero-count,`high_non_zero_count` function>>).
+* Models the duration of spans (`partition_field_name` is `span.type`).
+* Detects for spans that are taking longer than usual to process (using the 
+<<ml-metric-mean,`high_mean` function>>).
+  
+anomalous_error_rate_for_user_agents_jsbase::
+This job can help detect browser compatibility issues.
++
+* For data from {apm-rum-agents} (where `agent.name` is `js-base`).
+* Models the error rate of user agents (`partition_field_name` is 
+`user_agent.name`).
+* Detects user agents that are encountering errors at an above normal rate 
+(using the <<ml-nonzero-count,`high_non_zero_count` function>>).
 
+decreased_throughput_jsbase::
+
+* For data from {apm-rum-agents} or {apm-node-agents} (where `agent.name` is
+`js-base`).
+* Models the transaction rate of the application.
+* Detects periods during which the application is processing fewer requests than
+normal (using the <<ml-count,`low_count` function>>).
+
+high_count_by_user_agent_jsbase::
 This job is useful in identifying bots.
++
+* For data from {apm-rum-agents} (where `agent.name` is `js-base`).
+* Models the request rate of user agents (`partition_field_name` is 
+`user_agent.name`).
+* Detects user agents that are making requests at a suspiciously high rate 
+(using the <<ml-nonzero-count,`high_non_zero_count` function>>).
+
+// end::apm-rum-javascript-jobs[]
+
+[[apm-transaction-jobs]]
+=== Transactions
+// tag::apm-transaction-jobs[]
+Detect anomalies in transactions from your APM services.
 
 high_mean_response_time::
 
@@ -62,4 +95,5 @@ high_mean_response_time::
 * Detects anomalies in high mean of transaction duration (using the 
   <<ml-metric-mean,`high_mean` function>>).
 
+// end::apm-transaction-jobs[]
 // end::apm-jobs[]


### PR DESCRIPTION
Related to #1270 (review)

This PR groups the machine learning jobs by module rather than sorting them alphabetically in https://www.elastic.co/guide/en/machine-learning/master/ootb-ml-jobs-apm.html

### Preview

https://stack-docs_1276.docs-preview.app.elstc.co/guide/en/machine-learning/master/ootb-ml-jobs-apm.html