### PR TITLE
[DOCS] Changes menu item name to Setup and security in ML book

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/xpack-ml.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/xpack-ml.asciidoc
@@ -7,7 +7,8 @@
 Use {anomaly-detect} to analyze time series data by creating accurate baselines 
 of normal behavior and identifying anomalous patterns in your dataset. Data is 
 pulled from {es} for analysis and anomaly results are displayed in {kib} 
-dashboards.
+dashboards. Consult <<setup>> to learn more about the licence and the security 
+privileges that are required to use {anomaly-detect}.
 
 * <<ml-overview>>
 * <<ml-concepts>>

--- a/docs/en/stack/ml/df-analytics/ml-dfanalytics.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfanalytics.asciidoc
@@ -14,7 +14,8 @@ dimensional "tabular" data structure, in other words a {dataframe}.
 experimental[]
 
 {dfanalytics-cap} enable you to perform different analyses of your data and 
-annotate it with the results.
+annotate it with the results. Consult <<setup>> to learn more about the licence 
+and the security privileges that are required to use {dfanalytics}.
 
 * <<ml-dfa-overview>>
 * <<ml-dfa-concepts>>

--- a/docs/en/stack/ml/setup.asciidoc
+++ b/docs/en/stack/ml/setup.asciidoc
@@ -2,7 +2,7 @@
 [[setup]]
 == Set up {ml-features}
 ++++
-<titleabbrev>Setup</titleabbrev>
+<titleabbrev>Setup and security</titleabbrev>
 ++++
 
 To use the {stack} {ml-features}, you must have the


### PR DESCRIPTION
## Overview

This PR changes one of the main menu items name to `Setup and security` from `Setup`. It also adds a link that points to this page to the first page of the anomaly detection and the data frame analytics sections.

### Preview

[Anomaly detection](https://stack-docs_1283.docs-preview.app.elstc.co/guide/en/machine-learning/master/xpack-ml.html)
[DFA](https://stack-docs_1283.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-dfanalytics.html)