### PR TITLE
[DOCS] Fix apm-server-ref links

### DIFF
--- a/docs/en/getting-started/get-started-docker.asciidoc
+++ b/docs/en/getting-started/get-started-docker.asciidoc
@@ -253,7 +253,7 @@ Similarly, to load {kib} settings from a file, you overwrite `/usr/share/kibana/
 See the product-specific documentation for information about running a specific Elastic product in Docker:
 
 * {ref}/docker.html[Install {es} with Docker]
-* {apm-server-ref-70}/running-on-docker.html[Running APM Server on Docker]
+* {apm-server-ref}/running-on-docker.html[Running APM Server on Docker]
 * {auditbeat-ref}/running-on-docker.html[Running {auditbeat} on Docker]
 * {filebeat-ref}/running-on-docker.html[Running {filebeat} on Docker]
 * {heartbeat-ref}/running-on-docker.html[Running {heartbeat} on Docker]

--- a/docs/en/install-upgrade/upgrading-stack.asciidoc
+++ b/docs/en/install-upgrade/upgrading-stack.asciidoc
@@ -66,7 +66,7 @@ on the cluster during the upgrade process. For more information, see
 .. Kibana: {kibana-ref}/upgrade.html[upgrade instructions]
 .. Logstash: {logstash-ref}/upgrading-logstash.html[upgrade instructions]
 .. Beats: {beats-ref}/upgrading.html[upgrade instructions]
-.. APM Server: {apm-server-ref-70}/upgrading.html[upgrade instructions]
+.. APM Server: {apm-server-ref}/upgrading.html[upgrade instructions]
 
 NOTE: Logstash 6.8 and Beats 6.8 are compatible with all 7.x versions of
 {es}. This provides flexibility in when you schedule the upgrades


### PR DESCRIPTION
> refer to: https://github.com/elastic/stack-docs/pull/1285

More links of apm-server-ref