### PR TITLE
[DOCS] Fix more apm-server-ref-links

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -31,7 +31,7 @@ Upgrade Assistant provides information about which {dfeeds} need to be updated.
 coming::[7.9.0]
 
 This list summarizes the most important breaking changes in APM. 
-For the complete list, go to {apm-server-ref-70}/breaking-changes.html[APM Server 7.0 breaking changes].
+For the complete list, go to {apm-server-ref}/breaking-changes.html[APM Server breaking changes].
 
 //include::{apm-repo-dir}/apm-breaking-changes.asciidoc[tag=notable-v7-breaking-changes]
 

--- a/docs/en/install-upgrade/overview.asciidoc
+++ b/docs/en/install-upgrade/overview.asciidoc
@@ -7,7 +7,7 @@ to simplify the installation and upgrade process. The full stack
 consists of:
 
 * {beats-ref}/index.html[Beats {branch}]
-* {apm-server-ref-70}/index.html[APM Server {branch}]
+* {apm-server-ref}/index.html[APM Server {branch}]
 * {ref}/index.html[Elasticsearch {branch}]
 * {hadoop-ref}/index.html[Elasticsearch Hadoop {branch}]
 * {kibana-ref}/index.html[Kibana {branch}]


### PR DESCRIPTION
Related to https://github.com/elastic/stack-docs/pull/1285 and https://github.com/elastic/stack-docs/pull/1286.

This PR fixes more occurrences of the "apm-server-ref-70" attribute.

## Preview 

https://stack-docs_1287.docs-preview.app.elstc.co/diff