### PR TITLE
[DOCS] Changes level offset for anomaly detection pages

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/anomaly-examples.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/anomaly-examples.asciidoc
@@ -1,7 +1,7 @@
 [role="xpack"]
 [testenv="platinum"]
 [[anomaly-examples]]
-== {anomaly-detect-cap} examples
+= {anomaly-detect-cap} examples
 ++++
 <titleabbrev>Examples</titleabbrev>
 ++++
@@ -15,13 +15,13 @@ The scenarios in this section describe some best practices for generating useful
 * <<ml-configuring-aggregation>>
 * <<ml-configuring-categories>>
 * <<ml-configuring-detector-custom-rules>>
-* <<ml-configuring-pop>>
+* <<ml-configuring-populations>>
 * <<ml-configuring-transform>>
 * <<ml-delayed-data-detection>>
 
 [discrete]
 [[anomaly-examples-blog-posts]]
-=== {anomaly-detect-cap} examples in blog posts
+== {anomaly-detect-cap} examples in blog posts
 
 The blog posts listed below show how to get the most out of Elastic {ml} 
 {anomaly-detect}.

--- a/docs/en/stack/ml/anomaly-detection/create-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/create-jobs.asciidoc
@@ -1,6 +1,6 @@
 [role="xpack"]
 [[create-jobs]]
-== Create {anomaly-jobs}
+= Create {anomaly-jobs}
 
 {anomaly-jobs-cap} contain the configuration information and metadata
 necessary to perform an analytics task.
@@ -21,7 +21,7 @@ A _multi-metric job_ can contain more than one detector, which is more efficient
 than running multiple jobs against the same data.
 
 A _population job_ detects activity that is unusual compared to the behavior of
-the population. For more information, see <<ml-configuring-pop>>.
+the population. For more information, see <<ml-configuring-populations>>.
 
 A _categorization job_ groups log messages into categories and uses
 <<ml-count-functions,count>> or <<ml-rare-functions,rare>> functions to detect
@@ -73,7 +73,7 @@ These wizards create {anomaly-jobs}, dashboards, searches, and visualizations
 that are customized to help you analyze your {auditbeat}, {filebeat}, and
 {metricbeat} data.
 
-[NOTE] 
+[NOTE]
 ===============================
 If your data is located outside of {es}, you cannot use {kib} to create
 your jobs and you cannot use {dfeeds} to retrieve your data in real time.

--- a/docs/en/stack/ml/anomaly-detection/index.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/index.asciidoc
@@ -1,69 +1,83 @@
 include::xpack-ml.asciidoc[]
 
-include::ml-overview.asciidoc[]
+include::ml-overview.asciidoc[leveloffset=+1]
 
-include::ml-concepts.asciidoc[]
+include::ml-concepts.asciidoc[leveloffset=+1]
 
-include::ml-jobs.asciidoc[leveloffset=+1]
+include::ml-jobs.asciidoc[leveloffset=+2]
 
-include::ml-datafeeds.asciidoc[leveloffset=+1]
+include::ml-datafeeds.asciidoc[leveloffset=+2]
 
-include::ml-buckets.asciidoc[leveloffset=+1]
+include::ml-buckets.asciidoc[leveloffset=+2]
 
-include::ml-influencers.asciidoc[leveloffset=+1]
+include::ml-influencers.asciidoc[leveloffset=+2]
 
-include::ml-calendars.asciidoc[leveloffset=+1]
+include::ml-calendars.asciidoc[leveloffset=+2]
 
-include::ml-rules.asciidoc[leveloffset=+1]
+include::ml-rules.asciidoc[leveloffset=+2]
 
-include::ml-model-snapshots.asciidoc[leveloffset=+1]
+include::ml-model-snapshots.asciidoc[leveloffset=+2]
 
-include::ml-configuration.asciidoc[]
+include::ml-configuration.asciidoc[leveloffset=+1]
 
-include::create-jobs.asciidoc[leveloffset=+1]
+include::create-jobs.asciidoc[leveloffset=+2]
 
-include::job-tips.asciidoc[leveloffset=+2]
+include::job-tips.asciidoc[leveloffset=+3]
 
-include::stopping-ml.asciidoc[leveloffset=+1]
+include::stopping-ml.asciidoc[leveloffset=+2]
 
-include::ml-api-quickref.asciidoc[]
+include::ml-api-quickref.asciidoc[leveloffset=+1]
 
-include::ootb-ml-jobs.asciidoc[]
+include::ootb-ml-jobs.asciidoc[leveloffset=+1]
 
-include::ootb-ml-jobs-apache.asciidoc[leveloffset=+1]
+include::ootb-ml-jobs-apache.asciidoc[leveloffset=+2]
 
-include::ootb-ml-jobs-apm.asciidoc[leveloffset=+1]
+include::ootb-ml-jobs-apm.asciidoc[leveloffset=+2]
 
-include::ootb-ml-jobs-auditbeat.asciidoc[leveloffset=+1]
+include::ootb-ml-jobs-auditbeat.asciidoc[leveloffset=+2]
 
-include::ootb-ml-jobs-logs-ui.asciidoc[leveloffset=+1]
+include::ootb-ml-jobs-logs-ui.asciidoc[leveloffset=+2]
 
-include::ootb-ml-jobs-metricbeat.asciidoc[leveloffset=+1]
+include::ootb-ml-jobs-metricbeat.asciidoc[leveloffset=+2]
 
-include::ootb-ml-jobs-nginx.asciidoc[leveloffset=+1]
+include::ootb-ml-jobs-nginx.asciidoc[leveloffset=+2]
 
-include::ootb-ml-jobs-siem.asciidoc[leveloffset=+1]
+include::ootb-ml-jobs-siem.asciidoc[leveloffset=+2]
 
-include::ootb-ml-jobs-uptime.asciidoc[leveloffset=+1]
+include::ootb-ml-jobs-uptime.asciidoc[leveloffset=+2]
 
-include::{es-repo-dir}/ml/anomaly-detection/functions.asciidoc[]
+include::{es-repo-dir}/ml/anomaly-detection/functions/ml-functions.asciidoc[leveloffset=+1]
 
-include::anomaly-examples.asciidoc[]
+include::{es-repo-dir}/ml/anomaly-detection/functions/ml-count-functions.asciidoc[leveloffset=+2]
 
-include::{es-repo-dir}/ml/anomaly-detection/customurl.asciidoc[]
+include::{es-repo-dir}/ml/anomaly-detection/functions/ml-geo-functions.asciidoc[leveloffset=+2]
 
-include::{es-repo-dir}/ml/anomaly-detection/aggregations.asciidoc[]
+include::{es-repo-dir}/ml/anomaly-detection/functions/ml-info-functions.asciidoc[leveloffset=+2]
 
-include::{es-repo-dir}/ml/anomaly-detection/detector-custom-rules.asciidoc[]
+include::{es-repo-dir}/ml/anomaly-detection/functions/ml-metric-functions.asciidoc[leveloffset=+2]
 
-include::{es-repo-dir}/ml/anomaly-detection/categories.asciidoc[]
+include::{es-repo-dir}/ml/anomaly-detection/functions/ml-rare-functions.asciidoc[leveloffset=+2]
 
-include::{es-repo-dir}/ml/anomaly-detection/populations.asciidoc[]
+include::{es-repo-dir}/ml/anomaly-detection/functions/ml-sum-functions.asciidoc[leveloffset=+2]
 
-include::{es-repo-dir}/ml/anomaly-detection/transforms.asciidoc[]
+include::{es-repo-dir}/ml/anomaly-detection/functions/ml-time-functions.asciidoc[leveloffset=+2]
 
-include::{es-repo-dir}/ml/anomaly-detection/delayed-data-detection.asciidoc[]
+include::anomaly-examples.asciidoc[leveloffset=+1]
 
-include::ml-limitations.asciidoc[]
+include::{es-repo-dir}/ml/anomaly-detection/ml-configuring-url.asciidoc[leveloffset=+2]
 
-//include::ml-troubleshooting.asciidoc[]
+include::{es-repo-dir}/ml/anomaly-detection/ml-configuring-aggregations.asciidoc[leveloffset=+2]
+
+include::{es-repo-dir}/ml/anomaly-detection/ml-configuring-detector-custom-rules.asciidoc[leveloffset=+2]
+
+include::{es-repo-dir}/ml/anomaly-detection/ml-configuring-categories.asciidoc[leveloffset=+2]
+
+include::{es-repo-dir}/ml/anomaly-detection/ml-configuring-populations.asciidoc[leveloffset=+2]
+
+include::{es-repo-dir}/ml/anomaly-detection/ml-configuring-transform.asciidoc[leveloffset=+2]
+
+include::{es-repo-dir}/ml/anomaly-detection/ml-delayed-data-detection.asciidoc[leveloffset=+2]
+
+include::ml-limitations.asciidoc[leveloffset=+1]
+
+//include::ml-troubleshooting.asciidoc[leveloffset=+1]

--- a/docs/en/stack/ml/anomaly-detection/index.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/index.asciidoc
@@ -45,7 +45,7 @@ include::ootb-ml-jobs-nginx.asciidoc[leveloffset=+2]
 include::ootb-ml-jobs-siem.asciidoc[leveloffset=+2]
 
 include::ootb-ml-jobs-uptime.asciidoc[leveloffset=+2]
-
+////
 include::{es-repo-dir}/ml/anomaly-detection/functions/ml-functions.asciidoc[leveloffset=+1]
 
 include::{es-repo-dir}/ml/anomaly-detection/functions/ml-count-functions.asciidoc[leveloffset=+2]
@@ -61,9 +61,9 @@ include::{es-repo-dir}/ml/anomaly-detection/functions/ml-rare-functions.asciidoc
 include::{es-repo-dir}/ml/anomaly-detection/functions/ml-sum-functions.asciidoc[leveloffset=+2]
 
 include::{es-repo-dir}/ml/anomaly-detection/functions/ml-time-functions.asciidoc[leveloffset=+2]
-
+////
 include::anomaly-examples.asciidoc[leveloffset=+1]
-
+////
 include::{es-repo-dir}/ml/anomaly-detection/ml-configuring-url.asciidoc[leveloffset=+2]
 
 include::{es-repo-dir}/ml/anomaly-detection/ml-configuring-aggregations.asciidoc[leveloffset=+2]
@@ -77,7 +77,7 @@ include::{es-repo-dir}/ml/anomaly-detection/ml-configuring-populations.asciidoc[
 include::{es-repo-dir}/ml/anomaly-detection/ml-configuring-transform.asciidoc[leveloffset=+2]
 
 include::{es-repo-dir}/ml/anomaly-detection/ml-delayed-data-detection.asciidoc[leveloffset=+2]
-
+////
 include::ml-limitations.asciidoc[leveloffset=+1]
 
 //include::ml-troubleshooting.asciidoc[leveloffset=+1]

--- a/docs/en/stack/ml/anomaly-detection/job-tips.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/job-tips.asciidoc
@@ -1,6 +1,6 @@
 [role="xpack"]
 [[job-tips]]
-== Machine learning job tips
+= Machine learning job tips
 ++++
 <titleabbrev>Job tips</titleabbrev>
 ++++
@@ -12,7 +12,7 @@ results.
 
 [discrete]
 [[bucket-span]]
-=== Bucket span
+== Bucket span
 
 The bucket span is the time interval that {ml} analytics use to summarize and
 model data for your job. When you create an {anomaly-job} in {kib}, you can
@@ -27,7 +27,7 @@ information about choosing an appropriate bucket span, see <<ml-buckets>>.
 
 [discrete]
 [[cardinality]]
-=== Cardinality
+== Cardinality
 
 If there are logical groupings of related entities in your data, {ml} analytics
 can make data models and generate results that take these groupings into
@@ -41,11 +41,11 @@ job uses more memory resources. In particular, if the cardinality of the
 
 Likewise if you are performing population analysis and the cardinality of the
 `over_field_name` is below 10, you are advised that this might not be a suitable
-field to use. For more information, see <<ml-configuring-pop>>.
+field to use. For more information, see <<ml-configuring-populations>>.
 
 [discrete]
 [[detectors]]
-=== Detectors
+== Detectors
 
 Each {anomaly-job} must have one or more _detectors_. A detector applies an
 analytical function to specific fields in your data. If your job does not
@@ -58,14 +58,14 @@ duplicates if they have the same `function`, `field_name`, `by_field_name`,
 
 [discrete]
 [[influencers]]
-=== Influencers
+== Influencers
 
 See <<ml-influencers>>.
 
 
 [discrete]
 [[model-memory-limits]]
-=== Model memory limits
+== Model memory limits
 
 For each {anomaly-job}, you can optionally specify a `model_memory_limit`, which
 is the approximate maximum amount of memory resources that are required for
@@ -108,7 +108,7 @@ increase the size of the {ml} nodes in your cluster.
 
 [discrete]
 [[dedicated-indices]]
-=== Dedicated indices
+== Dedicated indices
 
 For each {anomaly-job}, you can optionally specify a dedicated index to store 
 the {anomaly-detect} results. As {anomaly-jobs} may produce a large amount 

--- a/docs/en/stack/ml/anomaly-detection/ml-api-quickref.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-api-quickref.asciidoc
@@ -1,6 +1,6 @@
 [role="xpack"]
 [[ml-api-quickref]]
-== API quick reference
+= API quick reference
 
 All {ml} {anomaly-detect} endpoints have the following base:
 

--- a/docs/en/stack/ml/anomaly-detection/ml-buckets.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-buckets.asciidoc
@@ -1,6 +1,6 @@
 [role="xpack"]
 [[ml-buckets]]
-== Buckets
+= Buckets
 
 The {ml-features} use the concept of a _bucket_ to divide the time series into
 batches for processing.
@@ -20,7 +20,7 @@ The bucket span has a significant impact on the analysis. When you’re trying t
 
 [discrete]
 [[ml-bucket-results]]
-=== Bucket results
+== Bucket results
 
 When you view your {ml} results, each bucket has an anomaly score. This score is
 a statistically aggregated and normalized view of the combined anomalousness of

--- a/docs/en/stack/ml/anomaly-detection/ml-calendars.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-calendars.asciidoc
@@ -1,6 +1,6 @@
 [role="xpack"]
 [[ml-calendars]]
-== Calendars and scheduled events
+= Calendars and scheduled events
 
 Sometimes there are periods when you expect unusual activity to take place,
 such as bank holidays, "Black Friday", or planned system outages. If you

--- a/docs/en/stack/ml/anomaly-detection/ml-concepts.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-concepts.asciidoc
@@ -1,6 +1,6 @@
 [role="xpack"]
 [[ml-concepts]]
-== Concepts
+= Concepts
 
 This section explains the fundamental concepts of the Elastic {ml} 
 {anomaly-detect} feature.

--- a/docs/en/stack/ml/anomaly-detection/ml-configuration.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-configuration.asciidoc
@@ -1,6 +1,6 @@
 [role="xpack"]
 [[ml-configuration]]
-== Configure {anomaly-detect}
+= Configure {anomaly-detect}
 
 If you want to use {ml-features}, there must be at least one {ml} node in
 your cluster and all master-eligible nodes must have {ml} enabled. By default,

--- a/docs/en/stack/ml/anomaly-detection/ml-datafeeds.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-datafeeds.asciidoc
@@ -1,6 +1,6 @@
 [role="xpack"]
 [[ml-datafeeds]]
-== {dfeeds-cap}
+= {dfeeds-cap}
 
 {anomaly-jobs-cap} can analyze data that is stored in {es} or data that is
 sent from some other source via an API. _{dfeeds-cap}_ retrieve data from {es}

--- a/docs/en/stack/ml/anomaly-detection/ml-influencers.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-influencers.asciidoc
@@ -1,6 +1,6 @@
 [role="xpack"]
 [[ml-influencers]]
-== Influencers
+= Influencers
 
 When anomalous events occur, we want to know why. To determine the cause,
 however, you often need a broader knowledge of the domain. If you have
@@ -40,7 +40,7 @@ can be overwhelming and there is a small overhead to the analysis.
 
 [discrete]
 [[ml-influencer-results]]
-=== Influencer results
+== Influencer results
 
 The influencer results show which entities were anomalous and when. One
 influencer result is written per bucket for each influencer that affects the

--- a/docs/en/stack/ml/anomaly-detection/ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-jobs.asciidoc
@@ -1,6 +1,6 @@
 [role="xpack"]
 [[ml-jobs]]
-== {anomaly-jobs-cap}
+= {anomaly-jobs-cap}
 ++++
 <titleabbrev>Jobs</titleabbrev>
 ++++

--- a/docs/en/stack/ml/anomaly-detection/ml-limitations.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-limitations.asciidoc
@@ -1,6 +1,6 @@
 [role="xpack"]
 [[ml-limitations]]
-== {ml-cap} {anomaly-detect} limitations
+= {ml-cap} {anomaly-detect} limitations
 [subs="attributes"]
 ++++
 <titleabbrev>Limitations</titleabbrev>
@@ -11,7 +11,7 @@ the Elastic {ml-features}:
 
 [float]
 [[ml-limitations-sse]]
-=== CPUs must support SSE4.2
+== CPUs must support SSE4.2
 
 {ml-cap} uses Streaming SIMD Extensions (SSE) 4.2 instructions, so it works only
 on machines whose CPUs https://en.wikipedia.org/wiki/SSE4#Supporting_CPUs[support]
@@ -20,7 +20,7 @@ SSE4.2. If you run {es} on older hardware you must disable {ml} by setting
 {ref}/ml-settings.html[{ml-cap} settings in {es}].
 
 [float]
-=== Categorization uses English dictionary words
+== Categorization uses English dictionary words
 //See x-pack-elasticsearch/#3021
 Categorization identifies static parts of unstructured logs and groups similar
 messages together. The default categorization tokenizer assumes English language
@@ -34,7 +34,7 @@ in other languages. The ability to customize the dictionary will be added in a
 future release.
 
 [float]
-=== Pop-ups must be enabled in browsers
+== Pop-ups must be enabled in browsers
 //See x-pack-elasticsearch/#844
 
 The {ml-features} in {kib} use pop-ups. You must configure your
@@ -42,7 +42,7 @@ web browser so that it does not block pop-up windows or create an
 exception for your {kib} URL.
 
 [float]
-=== Anomaly Explorer omissions and limitations
+== Anomaly Explorer omissions and limitations
 //See x-pack-elasticsearch/#844 and x-pack-kibana/#1461
 
 In {kib}, Anomaly Explorer charts are not displayed for anomalies
@@ -60,7 +60,7 @@ represented as a single dot. If there are only two data points, they are joined
 by a line.
 
 [float]
-=== Jobs close on the {dfeed} end date
+== Jobs close on the {dfeed} end date
 //See x-pack-elasticsearch/#1037
 
 If you start a {dfeed} and specify an end date, it will close the job when
@@ -71,7 +71,7 @@ remains open when you stop the {dfeed}. This behavior avoids the overhead
 of closing and re-opening large jobs when there are pauses in the {dfeed}.
 
 [float]
-=== Jobs created in {kib} must use {dfeeds}
+== Jobs created in {kib} must use {dfeeds}
 
 If you create jobs in {kib}, you must use {dfeeds}. If the data that you want to
 analyze is not stored in {es}, you cannot use {dfeeds} and therefore you cannot
@@ -80,7 +80,7 @@ and to send batches of data directly to the jobs. For more information, see
 <<ml-datafeeds>> and <<ml-api-quickref>>.
 
 [float]
-=== Post data API requires JSON format
+== Post data API requires JSON format
 
 The post data API enables you to send data to a job for analysis. The data that
 you send to the job must use the JSON format.
@@ -90,7 +90,7 @@ For more information about this API, see
 
 
 [float]
-=== Misleading high missing field counts
+== Misleading high missing field counts
 //See x-pack-elasticsearch/#684
 
 One of the counts associated with a {ml} job is `missing_field_count`,
@@ -107,7 +107,7 @@ see the {ref}/ml-get-job-stats.html[get {anomaly-job} statistics API].
 
 
 [float]
-=== Terms aggregation size affects data analysis
+== Terms aggregation size affects data analysis
 //See x-pack-elasticsearch/#601
 
 By default, the `terms` aggregation returns the buckets for the top ten terms.
@@ -118,7 +118,7 @@ that the `size` is configured correctly. Otherwise, some data might not be
 analyzed.
 
 [float]
-=== Fields named "by", "count", or "over" cannot be used to split data
+== Fields named "by", "count", or "over" cannot be used to split data
 //See x-pack-elasticsearch/#858
 
 You cannot use the following field names in the `by_field_name` or
@@ -127,7 +127,7 @@ also applies to those properties when you create advanced jobs in {kib}.
 
 
 [float]
-=== Jobs created in {kib} use model plot config and pre-aggregated data
+== Jobs created in {kib} use model plot config and pre-aggregated data
 //See x-pack-elasticsearch/#844
 
 If you create single or multi-metric jobs in {kib}, it might enable some
@@ -159,7 +159,7 @@ poorer precision worthwhile. If you want to view or change the aggregations
 that are used in your job, refer to the `aggregations` property in your {dfeed}.
 
 [float]
-=== Security integration
+== Security integration
 
 When the {es} {security-features} are enabled, a {dfeed} stores the roles of the
 user who created or updated the {dfeed} **at that time**. This means that if those
@@ -170,14 +170,14 @@ permissions that were associated with the original roles. For more information,
 see <<ml-datafeeds>>.
 
 [float]
-=== Jobs must be stopped before upgrades
+== Jobs must be stopped before upgrades
 
 You must stop any {ml} jobs that are running before you start the upgrade
 process. For more information, see <<stopping-ml>> and
 {stack-ref}/upgrading-elastic-stack.html[Upgrading the Elastic Stack].
 
 [float]
-=== Rollup indices and index patterns are not supported
+== Rollup indices and index patterns are not supported
 
 Rollup indices and index patterns cannot be used in machine learning jobs or 
 {dfeeds}. This limitation applies irrespective of whether you create the jobs in 
@@ -188,7 +188,7 @@ See {ref}/xpack-rollup.html[Rolling up historical data].
 
 [float]
 [[ml-space-limitations]]
-=== Machine learning objects do not belong to {kib} spaces
+== Machine learning objects do not belong to {kib} spaces
 
 If you create {kibana-ref}/xpack-spaces.html[spaces] in {kib}, you see only the  
 saved objects that belong to that space. This limited scope does not apply to 
@@ -216,7 +216,7 @@ the dashboards or visualizations might fail.
 
 [float]
 [[ml-result-size-limitations]]
-=== Job and {dfeed} APIs have a maximum search size
+== Job and {dfeed} APIs have a maximum search size
 //https://github.com/elastic/elasticsearch/issues/34864
 
 In 6.6 and later releases, the {ref}/ml-get-job.html[get jobs API] and the
@@ -227,7 +227,7 @@ jobs. Likewise, the {ref}/ml-get-datafeed.html[get {dfeeds} API] and the
 
 [float]
 [[ml-limitations-nanos]]
-=== Date nanoseconds data types are not supported
+== Date nanoseconds data types are not supported
 // https://github.com/elastic/elasticsearch/issues/49889
 
 When you create an {anomaly-job}, you cannot use a field with the
@@ -237,7 +237,7 @@ create jobs in {kib} or by using APIs.
 
 [discrete]
 [[ml-forecast-limitations]]
-=== Forecast limitations
+== Forecast limitations
 
 There are some limitations that affect your ability to create a forecast:
 
@@ -268,7 +268,7 @@ of the data analysis are less accurate.
 
 [float]
 [[ml-frozen-limitations]]
-=== Frozen indices are not supported
+== Frozen indices are not supported
 
 {ref}/frozen-indices.html[Frozen indices] cannot be used in {anomaly-jobs} or 
 {dfeeds}. This limitation applies irrespective of whether you create the jobs in 
@@ -279,7 +279,7 @@ in {dfeeds} or jobs. See
 
 [discrete]
 [[ml-scheduling-priority]]
-=== CPU scheduling improvements apply to Linux and MacOS only
+== CPU scheduling improvements apply to Linux and MacOS only
 
 When there are many {ml} jobs running at the same time and there are insufficient
 CPU resources, the JVM performance must be prioritized so search and indexing

--- a/docs/en/stack/ml/anomaly-detection/ml-model-snapshots.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-model-snapshots.asciidoc
@@ -1,6 +1,6 @@
 [role="xpack"]
 [[ml-model-snapshots]]
-== Model snapshots
+= Model snapshots
 
 As described in <<ml-analyzing>>, {stack} {ml-features} can calculate baselines
 of normal behavior then extrapolate anomalous events. These baselines are

--- a/docs/en/stack/ml/anomaly-detection/ml-overview.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-overview.asciidoc
@@ -1,10 +1,10 @@
 [role="xpack"]
 [[ml-overview]]
-== Overview
+= Overview
 
 [discrete]
 [[ml-analyzing]]
-=== Analyzing the past and present
+== Analyzing the past and present
 
 The {ml-features} automate the analysis of time series data by creating
 accurate baselines of normal behavior in the data and identifying anomalous
@@ -35,7 +35,7 @@ image::images/overview-smv.jpg["Example screenshot from the Machine Learning Sin
 
 [discrete]
 [[ml-forecasting]]
-=== Forecasting the future
+== Forecasting the future
 
 After the {ml-features} create baselines of normal behavior for your data,
 you can use that information to extrapolate future behavior.
@@ -75,7 +75,7 @@ different expiration period by using the `expires_in` parameter in the
 
 [discrete]
 [[anomaly-algorithms]]
-=== {anomaly-detect-cap} algorithms
+== {anomaly-detect-cap} algorithms
 
 The {anomaly-detect} {ml-features} use a bespoke amalgamation of different
 techniques such as clustering, various types of time series decomposition,

--- a/docs/en/stack/ml/anomaly-detection/ml-rules.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-rules.asciidoc
@@ -1,6 +1,6 @@
 [role="xpack"]
 [[ml-rules]]
-== Custom rules
+= Custom rules
 
 By default, as described in <<ml-analyzing>>, anomaly detection is unsupervised 
 and the {ml} models have no awareness of the domain of your data. As a result, 

--- a/docs/en/stack/ml/anomaly-detection/ml-troubleshooting.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-troubleshooting.asciidoc
@@ -1,6 +1,6 @@
 [role="xpack"]
 [[ml-troubleshooting]]
-== Troubleshooting {ml} {anomaly-detect}
+= Troubleshooting {ml} {anomaly-detect}
 ++++
 <titleabbrev>Troubleshooting</titleabbrev>
 ++++
@@ -17,7 +17,7 @@ include::{stack-repo-dir}/help.asciidoc[tag=get-help]
 
 [discrete]
 [[ml-rollingupgrade]]
-=== Machine learning features unavailable after rolling upgrade
+== Machine learning features unavailable after rolling upgrade
 
 This problem occurs after you upgrade all of the nodes in your cluster to
 {version} by using rolling upgrades. When you try to use {ml-features} for
@@ -42,7 +42,7 @@ For more information, see {ref}/rolling-upgrades.html[Rolling upgrades].
 
 [discrete]
 [[ml-mappingclash]]
-=== Job creation failure due to mapping clash
+== Job creation failure due to mapping clash
 
 This problem occurs when you try to create an {anomaly-job}.
 
@@ -68,7 +68,7 @@ index name in the `results_index_name` property.
 
 [discrete]
 [[ml-jobnames]]
-=== {kib} cannot display jobs with invalid characters in their name
+== {kib} cannot display jobs with invalid characters in their name
 
 This problem occurs when you create an {anomaly-job} by using the
 {ref}/ml-put-job.html[Create {anomaly-jobs} API] then try to view that job in
@@ -93,7 +93,7 @@ identifiers, see
 
 [discrete]
 [[ml-upgradedf]]
-=== Upgraded nodes fail to start due to {dfeed} issues
+== Upgraded nodes fail to start due to {dfeed} issues
 
 This problem occurs when you have a {dfeed} that contains search or query
 domain specific language (DSL) that was discontinued. For example, if you

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-apache.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-apache.asciidoc
@@ -1,6 +1,6 @@
 [role="xpack"]
 [[ootb-ml-jobs-apache]]
-== Apache {anomaly-detect} configurations
+= Apache {anomaly-detect} configurations
 ++++
 <titleabbrev>Apache</titleabbrev>
 ++++

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-apm.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-apm.asciidoc
@@ -1,6 +1,6 @@
 [role="xpack"]
 [[ootb-ml-jobs-apm]]
-== APM {anomaly-detect} configurations
+= APM {anomaly-detect} configurations
 ++++
 <titleabbrev>APM</titleabbrev>
 ++++
@@ -12,7 +12,7 @@ https://github.com/elastic/kibana/tree/{branch}/x-pack/plugins/ml/server/models/
 
 // tag::apm-jobs[]
 [[apm-nodejs-jobs]]
-=== NodeJS
+== NodeJS
 // tag::apm-nodejs-jobs[]
 Detect abnormal traces, anomalous spans, and identify periods of decreased
 throughput.
@@ -42,7 +42,7 @@ than normal (using the <<ml-count,`low_count` function>>).
 
 
 [[apm-rum-javascript-jobs]]
-=== RUM Javascript
+== RUM Javascript
 // tag::apm-rum-javascript-jobs[]
 Detect problematic spans and identify user agents that are potentially causing
 issues.
@@ -83,7 +83,7 @@ This job is useful in identifying bots.
 // end::apm-rum-javascript-jobs[]
 
 [[apm-transaction-jobs]]
-=== Transactions
+== Transactions
 // tag::apm-transaction-jobs[]
 Detect anomalies in transactions from your APM services.
 

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-auditbeat.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-auditbeat.asciidoc
@@ -1,6 +1,6 @@
 [role="xpack"]
 [[ootb-ml-jobs-auditbeat]]
-== {auditbeat} {anomaly-detect} configurations
+= {auditbeat} {anomaly-detect} configurations
 ++++
 <titleabbrev>{auditbeat}</titleabbrev>
 ++++

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-logs-ui.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-logs-ui.asciidoc
@@ -1,6 +1,6 @@
 [role="xpack"]
 [[ootb-ml-jobs-logs-ui]]
-== Logs {anomaly-detect} configurations
+= Logs {anomaly-detect} configurations
 ++++
 <titleabbrev>Logs</titleabbrev>
 ++++

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-metricbeat.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-metricbeat.asciidoc
@@ -1,6 +1,6 @@
 [role="xpack"]
 [[ootb-ml-jobs-metricbeat]]
-== {metricbeat} {anomaly-detect} configurations
+= {metricbeat} {anomaly-detect} configurations
 ++++
 <titleabbrev>{metricbeat}</titleabbrev>
 ++++

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-nginx.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-nginx.asciidoc
@@ -1,6 +1,6 @@
 [role="xpack"]
 [[ootb-ml-jobs-nginx]]
-== Nginx {anomaly-detect} configurations
+= Nginx {anomaly-detect} configurations
 ++++
 <titleabbrev>Nginx</titleabbrev>
 ++++

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-siem.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-siem.asciidoc
@@ -1,6 +1,6 @@
 [role="xpack"]
 [[ootb-ml-jobs-siem]]
-== SIEM {anomaly-detect} configurations
+= SIEM {anomaly-detect} configurations
 ++++
 <titleabbrev>SIEM</titleabbrev>
 ++++
@@ -18,7 +18,7 @@ https://github.com/elastic/kibana/tree/{branch}/x-pack/plugins/ml/server/models/
 
 [discrete]
 [[security-auditbeat-jobs]]
-=== SIEM {auditbeat}
+== SIEM {auditbeat}
 
 Detect suspicious network activity and unusual processes in {auditbeat} data.
 
@@ -224,7 +224,7 @@ Required ECS fields when not using {beats}:::
 
 [discrete]
 [[security-auditbeat-authentication-jobs]]
-=== SIEM {auditbeat} authentication
+== SIEM {auditbeat} authentication
 
 Detect suspicious authentication events in {auditbeat} data.
 
@@ -257,7 +257,7 @@ Required ECS fields when not using {beats}:::
 
 [discrete]
 [[security-packetbeat-jobs]]
-=== SIEM {packetbeat}
+== SIEM {packetbeat}
 
 Detect suspicious network activity in {packetbeat} data.
 
@@ -431,7 +431,7 @@ Required ECS fields when not using {beats}:::
 
 [discrete]
 [[security-winlogbeat-jobs]]
-=== SIEM {winlogbeat}
+== SIEM {winlogbeat}
 
 Detect unusual processes and network activity in {winlogbeat} data.
 
@@ -699,7 +699,7 @@ Required ECS fields when not using {beats}:::
 
 [discrete]
 [[security-winlogbeat-authentication-jobs]]
-=== SIEM {winlogbeat} authentication
+== SIEM {winlogbeat} authentication
 
 Detect suspicious authentication events in {winlogbeat} data.
 

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-uptime.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-uptime.asciidoc
@@ -1,6 +1,6 @@
 [role="xpack"]
 [[ootb-ml-jobs-uptime]]
-== Uptime {anomaly-detect} configurations
+= Uptime {anomaly-detect} configurations
 ++++
 <titleabbrev>Uptime</titleabbrev>
 ++++

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -1,6 +1,6 @@
 [role="xpack"]
 [[ootb-ml-jobs]]
-== Supplied {anomaly-detect} configurations
+= Supplied {anomaly-detect} configurations
 
 {anomaly-jobs-cap} contain the configuration information and metadata necessary 
 to perform an analytics task. {kib} can recognize certain types of data and 

--- a/docs/en/stack/ml/anomaly-detection/stopping-ml.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/stopping-ml.asciidoc
@@ -1,6 +1,6 @@
 [role="xpack"]
 [[stopping-ml]]
-== Stop {ml} {anomaly-detect}
+= Stop {ml} {anomaly-detect}
 
 An orderly shutdown ensures that:
 
@@ -16,7 +16,7 @@ subsequently re-open them.
 
 [discrete]
 [[stopping-ml-datafeeds]]
-=== Stopping {dfeeds}
+== Stopping {dfeeds}
 
 When you stop a {dfeed}, it ceases to retrieve data from {es}. You can stop a
 {dfeed} by using {kib} or the
@@ -38,7 +38,7 @@ A {dfeed} can be started and stopped multiple times throughout its lifecycle.
 
 [discrete]
 [[stopping-all-ml-datafeeds]]
-=== Stopping all {dfeeds}
+== Stopping all {dfeeds}
 
 If you are upgrading your cluster, you can use the following request to stop all
 {dfeeds}:
@@ -51,7 +51,7 @@ POST _ml/datafeeds/_all/_stop
 
 [discrete]
 [[closing-ml-jobs]]
-=== Closing {anomaly-jobs}
+== Closing {anomaly-jobs}
 
 When you close an {anomaly-job}, it cannot receive data or perform analysis
 operations. If a job is associated with a {dfeed}, you must stop the {dfeed}
@@ -76,7 +76,7 @@ lifecycle.
 
 [discrete]
 [[closing-all-ml-datafeeds]]
-=== Closing all {anomaly-jobs}
+== Closing all {anomaly-jobs}
 
 If you are upgrading your cluster, you can use the following request to close
 all open {anomaly-jobs} on the cluster:

--- a/docs/en/stack/ml/anomaly-detection/xpack-ml.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/xpack-ml.asciidoc
@@ -20,6 +20,4 @@ privileges that are required to use {anomaly-detect}.
 * <<anomaly-examples>>
 * <<ml-limitations>>
 //* <<ml-troubleshooting>>
-
-
 --

--- a/docs/en/stack/ml/get-started/ml-gs-results.asciidoc
+++ b/docs/en/stack/ml/get-started/ml-gs-results.asciidoc
@@ -202,4 +202,4 @@ anomalous event found for `Abd Burton`:
 [role="screenshot"]
 image::images/ml-gs-job4-explorer.png["Anomaly charts for the high_sum_total_sales job"]
 
-For more information, see <<ml-configuring-pop>>.
+For more information, see <<ml-configuring-populations>>.

--- a/docs/en/stack/ml/redirects.asciidoc
+++ b/docs/en/stack/ml/redirects.asciidoc
@@ -15,18 +15,8 @@ This page has moved. See <<ml-datafeeds>>.
 
 TBD
 
-[role="exclude",id="ml-nonzero-count"]
-=== Non-zero count
-
-TBD
-
 [role="exclude",id="ml-metric-mean"]
 === Metric mean
-
-TBD
-
-[role="exclude",id="ml-rare"]
-=== Rare functions
 
 TBD
 
@@ -85,6 +75,11 @@ TBD
 
 TBD
 
+[role="exclude",id="ml-nonzero-count"]
+==== Non-zero count
+
+TBD
+
 [role="exclude",id="ml-count"]
 === Count, high_count, low_count
 
@@ -100,6 +95,11 @@ TBD
 
 TBD
 
+[role="exclude",id="ml-info-content"]
+==== Info content functions
+
+TBD
+
 [role="exclude",id="ml-metric-functions"]
 === Metric functions
 
@@ -107,6 +107,11 @@ TBD
 
 [role="exclude",id="ml-rare-functions"]
 === Rare functions
+
+TBD
+
+[role="exclude",id="ml-rare"]
+==== Rare functions
 
 TBD
 

--- a/docs/en/stack/ml/redirects.asciidoc
+++ b/docs/en/stack/ml/redirects.asciidoc
@@ -7,3 +7,115 @@ The following pages have moved or been deleted.
 === Datafeeds
 
 This page has moved. See <<ml-datafeeds>>.
+
+// TEMPORARY
+
+[role="exclude",id="ml-functions"]
+=== Functions
+
+TBD
+
+[role="exclude",id="ml-nonzero-count"]
+=== Non-zero count
+
+TBD
+
+[role="exclude",id="ml-metric-mean"]
+=== Metric mean
+
+TBD
+
+[role="exclude",id="ml-rare"]
+=== Rare functions
+
+TBD
+
+[role="exclude",id="ml-metric-max"]
+=== Metric max functions
+
+TBD
+
+[role="exclude",id="ml-configuring-populations"]
+=== Performing population analysis
+
+TBD
+
+[role="exclude",id="ml-configuring-aggregation"]
+=== Aggregating data for faster performance
+
+TBD
+
+[role="exclude",id="ml-distinct-count"]
+=== Distinct count
+
+TBD
+
+[role="exclude",id="ml-configuring-categories"]
+=== Detecting anomalous categories of data
+
+TBD
+
+[role="exclude",id="ml-configuring-detector-custom-rules"]
+=== Customizing detectors with custom rules
+
+TBD
+
+[role="exclude",id="ml-configuring-pop"]
+=== Performing population analysis
+
+TBD
+
+[role="exclude",id="ml-configuring-transform"]
+=== Transforming data with script fields
+
+TBD
+
+[role="exclude",id="ml-configuring-url"]
+=== Adding custom URLs to machine learning results
+
+TBD
+
+[role="exclude",id="ml-delayed-data-detection"]
+=== Handling delayed data
+
+TBD
+
+[role="exclude",id="ml-count-functions"]
+=== Count functions
+
+TBD
+
+[role="exclude",id="ml-count"]
+=== Count, high_count, low_count
+
+TBD
+
+[role="exclude",id="ml-geo-functions"]
+=== Geographic functions
+
+TBD
+
+[role="exclude",id="ml-info-functions"]
+=== Information Content Functions
+
+TBD
+
+[role="exclude",id="ml-metric-functions"]
+=== Metric functions
+
+TBD
+
+[role="exclude",id="ml-rare-functions"]
+=== Rare functions
+
+TBD
+
+[role="exclude",id="ml-sum-functions"]
+=== Sum functions
+
+TBD
+
+[role="exclude",id="ml-time-functions"]
+=== Time functions
+
+TBD


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/59911

This PR improves the consistency of machine learning anomaly detection pages such that all of the source files begin with the same section title level (=).  It also temporarily omits the files included from the elasticsearch repo, so that they can be renamed in the elasticsearch PR.