### PR TITLE
[DOCS] Rename binary_soft_classification evaluation

### DIFF
--- a/docs/en/stack/ml/df-analytics/ml-dfa-overview.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-overview.asciidoc
@@ -31,7 +31,7 @@ table below.
 |===
 | {dfanalytics-cap} type    | Learning type | Evaluation type
 
-| {oldetection}             | unsupervised  | {binarysc}
+| {oldetection}             | unsupervised  | {oldetection}
 | {regression}              | supervised    | {regression}
 | {classification}          | supervised    | {classification}
 |===

--- a/docs/en/stack/ml/df-analytics/ml-dfanalytics-evaluate.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfanalytics-evaluate.asciidoc
@@ -14,8 +14,7 @@ understand error distributions and identifies the points where the {dfanalytics}
 model performs well or less trustworthily.
 
 The {evaluatedf-api} is designed for providing a general evaluation mechanism 
-for the different kinds of {dfanalytics}. For example, you can evaluate the 
-results of an {oldetection} analysis by using {binarysc}.
+for the different kinds of {dfanalytics}.
 
 To evaluate the {dfanalytics} with this API, you need to annotate your index 
 that contains the results of the analysis with a field that marks each 
@@ -24,12 +23,12 @@ the field must indicate whether the given data point really is an outlier or
 not. The {evaluatedf-api} evaluates the performance of the {dfanalytics} against 
 this manually provided ground truth.
 
-[[ml-dfanalytics-binary-soft-classification]]
-== {binarysc-cap} evaluation
+[[ml-dfanalytics-outlier-detection]]
+== {oldetection-cap} evaluation
 
 This evaluation type is suitable for analyses which calculate a probability that 
-each data point in a data set is a member of a class or not. The {binarysc} 
-evaluation type offers the following metrics to evaluate the model performance:
+each data point in a data set is a member of a class or not. It offers the
+following metrics to evaluate the model performance:
 
 * confusion matrix
 * precision


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch/issues/59947

This PR renames the binary_soft_classification evaluation type to outlier_detection in order to avoid confusion.

### Preview

* https://stack-docs_1300.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-dfanalytics-evaluate.html
* https://stack-docs_1300.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-dfa-overview.html
