### PR TITLE
Change highlights path

### DIFF
--- a/docs/en/install-upgrade/highlights.asciidoc
+++ b/docs/en/install-upgrade/highlights.asciidoc
@@ -25,17 +25,16 @@ include::{apm-repo-dir}/apm-release-notes.asciidoc[tag=notable-v8-highlights]
 
 
 [[beats-highlights]]
-=== Beats highlights
+=== {beats} highlights
 ++++
 <titleabbrev>Beats</titleabbrev>
 ++++
 
 coming[8.0.0]
 
-This list summarizes the most important enhancements in Beats.
-For the complete list, go to {beats-ref}/release-highlights.html[Beats release highlights].
+This list summarizes the most important enhancements in {beats} {minor-version}.
 
-include::{beats-repo-dir}/release-notes/highlights/highlights-8.0.0.asciidoc[tag=notable-highlights]
+//include::{beats-repo-dir}/release-notes/whats-new.asciidoc[tag=notable-highlights]
 
 [[elasticsearch-highlights]]
 === {es} highlights


### PR DESCRIPTION
Changing the link in the release highlights to support a parallel change I'm making in Beats (to align with Kibana practice of providing a "What's new" topic instead of "Release highlights."

Related PR: https://github.com/elastic/beats/pull/20255
