### PR TITLE
[7.9] Add APM release highlights / breaking changes

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -2,7 +2,7 @@
 == Breaking changes
 
 Before you upgrade, you must review the breaking changes for each product you
-use and make the necessary changes so your code is compatible with {version}. 
+use and make the necessary changes so your code is compatible with {version}.
 
 ** <<apm-breaking-changes,APM {version} breaking changes>>
 ** <<beats-breaking-changes,Beats {version} breaking changes>>
@@ -30,10 +30,10 @@ Upgrade Assistant provides information about which {dfeeds} need to be updated.
 
 coming::[7.9.0]
 
-This list summarizes the most important breaking changes in APM. 
+This list summarizes the most important breaking changes in APM.
 For the complete list, go to {apm-server-ref}/breaking-changes.html[APM Server breaking changes].
 
-//include::{apm-repo-dir}/apm-breaking-changes.asciidoc[tag=notable-v7-breaking-changes]
+//include::{apm-repo-dir}/apm-breaking-changes.asciidoc[tag=notable-v79-breaking-changes]
 
 [[beats-breaking-changes]]
 === Beats breaking changes
@@ -106,4 +106,3 @@ the complete list, go to
 {logstash-ref}/breaking-changes.html[Logstash breaking changes].
 
 include::{ls-repo-dir}/static/breaking-changes.asciidoc[tag=notable-breaking-changes]
-

--- a/docs/en/install-upgrade/highlights.asciidoc
+++ b/docs/en/install-upgrade/highlights.asciidoc
@@ -1,5 +1,5 @@
 [[elastic-stack-highlights]]
-== Highlights 
+== Highlights
 
 Each release brings new features and product improvements. This section
 highlights notable new features and enhancements in {minor-version}].
@@ -9,7 +9,6 @@ highlights notable new features and enhancements in {minor-version}].
 ** <<elasticsearch-highlights,{es}>>
 ** <<kibana-higlights,{kib}>>
 
-////
 [[apm-highlights]]
 === APM highlights
 ++++
@@ -20,8 +19,7 @@ This list summarizes the most important enhancements in APM.
 For the complete list, go to
 {apm-overview-ref-v}/apm-release-notes.html[APM release highlights].
 
-include::{apm-repo-dir}/apm-release-notes.asciidoc[tag=notable-v7-highlights]
-////
+include::{apm-repo-dir}/apm-release-notes.asciidoc[tag=notable-v79-highlights]
 
 [[beats-highlights]]
 === {beats} highlights


### PR DESCRIPTION
Blocked by https://github.com/elastic/apm-server/pull/4033.