### PR TITLE
[7.x] Activate include for Beats highlights (#1311)

### DIFF
--- a/docs/en/install-upgrade/highlights.asciidoc
+++ b/docs/en/install-upgrade/highlights.asciidoc
@@ -33,7 +33,7 @@ coming::[7.9.0]
 
 This list summarizes the most important enhancements in {beats} {minor-version}.
 
-//include::{beats-repo-dir}/release-notes/whats-new.asciidoc[tag=notable-highlights]
+include::{beats-repo-dir}/release-notes/whats-new.asciidoc[tag=notable-highlights]
 
 [[elasticsearch-highlights]]
 === {es} highlights


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Activate include for Beats highlights (#1311)