### PR TITLE
[Docs][ML]Updates ML job group names

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-siem.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-siem.asciidoc
@@ -2,7 +2,7 @@
 [[ootb-ml-jobs-siem]]
 = Security {anomaly-detect} configurations
 ++++
-<titleabbrev>SIEM</titleabbrev>
+<titleabbrev>Security</titleabbrev>
 ++++
 
 These {anomaly-jobs} appear by default in the Anomaly Detection interface of

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-siem.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-siem.asciidoc
@@ -1,15 +1,15 @@
 [role="xpack"]
 [[ootb-ml-jobs-siem]]
-= SIEM {anomaly-detect} configurations
+= Security {anomaly-detect} configurations
 ++++
 <titleabbrev>SIEM</titleabbrev>
 ++++
 
 These {anomaly-jobs} appear by default in the Anomaly Detection interface of
-the {security-guide}/machine-learning.html[SIEM app] in {kib}. They help you 
-automatically detect file system and network anomalies on your hosts. However,
-if you don't use Beats, you need to map your data to the ECS fields that are 
-listed for every job.
+the {security-guide}/machine-learning.html[Elastic Security app] in {kib}. They
+help you automatically detect file system and network anomalies on your hosts.
+However, if you don't use Beats, you need to map your data to the ECS fields
+that are listed for every job.
 
 // tag::siem-jobs[]
 For more details, see the
@@ -18,7 +18,7 @@ https://github.com/elastic/kibana/tree/{branch}/x-pack/plugins/ml/server/models/
 
 [discrete]
 [[security-auditbeat-jobs]]
-== SIEM {auditbeat}
+== Security {auditbeat}
 
 Detect suspicious network activity and unusual processes in {auditbeat} data.
 
@@ -224,7 +224,7 @@ Required ECS fields when not using {beats}:::
 
 [discrete]
 [[security-auditbeat-authentication-jobs]]
-== SIEM {auditbeat} authentication
+== Security {auditbeat} authentication
 
 Detect suspicious authentication events in {auditbeat} data.
 
@@ -370,7 +370,7 @@ Required ECS fields when not using {beats}:::
 
 [discrete]
 [[security-packetbeat-jobs]]
-== SIEM {packetbeat}
+== Security {packetbeat}
 
 Detect suspicious network activity in {packetbeat} data.
 
@@ -544,7 +544,7 @@ Required ECS fields when not using {beats}:::
 
 [discrete]
 [[security-winlogbeat-jobs]]
-== SIEM {winlogbeat}
+== Security {winlogbeat}
 
 Detect unusual processes and network activity in {winlogbeat} data.
 
@@ -812,7 +812,7 @@ Required ECS fields when not using {beats}:::
 
 [discrete]
 [[security-winlogbeat-authentication-jobs]]
-== SIEM {winlogbeat} authentication
+== Security {winlogbeat} authentication
 
 Detect suspicious authentication events in {winlogbeat} data.
 


### PR DESCRIPTION
Changes SIEM ML job group names to Security, and updates the name of the app.

[Preview](https://stack-docs_1317.docs-preview.app.elstc.co/guide/en/machine-learning/master/ootb-ml-jobs-siem.html)