### PR TITLE
[DOCS] Adds blog links to the DFA examples page

### DIFF
--- a/docs/en/stack/ml/df-analytics/dfanalytics-examples.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfanalytics-examples.asciidoc
@@ -29,3 +29,6 @@ The blog posts listed below show how to get the most out of Elastic {ml}
 * https://www.elastic.co/blog/catching-malware-with-elastic-outlier-detection[Catching malware with Elastic {oldetection}]
 * https://www.elastic.co/blog/benchmarking-outlier-detection-in-elastic-machine-learning[Benchmarking {oldetection} results in Elastic {ml}]
 * https://www.elastic.co/blog/multilingual-search-using-language-identification-in-elasticsearch[Multilingual search using language identification in {es}]
+* https://www.elastic.co/blog/benchmarking-binary-classification-results-in-elastic-machine-learning[Benchmarking binary {classification[] results in Elastic {ml}]
+* https://www.elastic.co/blog/using-elastic-supervised-machine-learning-for-binary-classification[Using Elastic supervised {ml} for binary {classification}]
+* https://www.elastic.co/blog/machine-learning-in-cybersecurity-training-supervised-models-to-detect-dga-activity[{ml-cap} in cybersecurity: Training supervised models to detect DGA activity]

--- a/docs/en/stack/ml/df-analytics/dfanalytics-examples.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfanalytics-examples.asciidoc
@@ -29,6 +29,6 @@ The blog posts listed below show how to get the most out of Elastic {ml}
 * https://www.elastic.co/blog/catching-malware-with-elastic-outlier-detection[Catching malware with Elastic {oldetection}]
 * https://www.elastic.co/blog/benchmarking-outlier-detection-in-elastic-machine-learning[Benchmarking {oldetection} results in Elastic {ml}]
 * https://www.elastic.co/blog/multilingual-search-using-language-identification-in-elasticsearch[Multilingual search using language identification in {es}]
-* https://www.elastic.co/blog/benchmarking-binary-classification-results-in-elastic-machine-learning[Benchmarking binary {classification[] results in Elastic {ml}]
+* https://www.elastic.co/blog/benchmarking-binary-classification-results-in-elastic-machine-learning[Benchmarking binary {classification} results in Elastic {ml}]
 * https://www.elastic.co/blog/using-elastic-supervised-machine-learning-for-binary-classification[Using Elastic supervised {ml} for binary {classification}]
 * https://www.elastic.co/blog/machine-learning-in-cybersecurity-training-supervised-models-to-detect-dga-activity[{ml-cap} in cybersecurity: Training supervised models to detect DGA activity]


### PR DESCRIPTION
## Overview

This PR updates the DFA examples in blog posts section on the DFA examples page with the latest related blog posts.

### Preview

[DFA examples](https://stack-docs_1322.docs-preview.app.elstc.co/guide/en/machine-learning/master/dfanalytics-examples.html)