### PR TITLE
[DOCS] Adds inference API links to DFA API quick reference

### DIFF
--- a/docs/en/stack/ml/df-analytics/ml-dfanalytics-apis.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfanalytics-apis.asciidoc
@@ -18,6 +18,15 @@ The evaluation API endpoint has the following base:
 ----
 // NOTCONSOLE
 
+All the {infer} endpoints have the following base:
+
+[source,js]
+----
+/_ml/inference
+----
+// NOTCONSOLE
+
+
 * {ref}/put-dfanalytics.html[Create {dfanalytics-jobs}]
 * {ref}/delete-dfanalytics.html[Delete {dfanalytics-jobs}]
 * {ref}/get-dfanalytics.html[Get {dfanalytics-jobs} info]
@@ -25,4 +34,7 @@ The evaluation API endpoint has the following base:
 * {ref}/start-dfanalytics.html[Start {dfanalytics-jobs}]
 * {ref}/stop-dfanalytics.html[Stop {dfanalytics-jobs}]
 * {ref}/evaluate-dfanalytics.html[Evaluate {dfanalytics}]
-
+* {ref}/put-inference.html[Create {infer} trained model]
+* {ref}/get-inference.html[Get {infer} trained model]
+* {ref}/get-inference-stats.html[Get {infer} trained model statistics]
+* {ref}/delete-inference.html[Delete {infer} trained model]

--- a/docs/en/stack/ml/df-analytics/ml-dfanalytics-apis.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfanalytics-apis.asciidoc
@@ -22,7 +22,7 @@ All the {infer} endpoints have the following base:
 
 [source,js]
 ----
-/_ml/inference
+/_ml/inference/
 ----
 // NOTCONSOLE
 


### PR DESCRIPTION
## Overview

This PR adds Inference API links to the data frame analytics API quick reference page.

### Preview

[DFA API quick reference](https://stack-docs_1323.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-dfanalytics-apis.html)