### PR TITLE
[DOCS] Enables ES highlights and breaking changes in Install Upgrade Guide

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -61,7 +61,7 @@ coming::[7.9.0]
 This list summarizes the most important breaking changes in {es} {version}. For
 the complete list, go to {ref}/breaking-changes.html[{es} breaking changes].
 
-//include::{es-repo-dir}/migration/migrate_7_8.asciidoc[tag=notable-breaking-changes]
+include::{es-repo-dir}/migration/migrate_7_9.asciidoc[tag=notable-breaking-changes]
 
 [[elasticsearch-hadoop-breaking-changes]]
 === {es} Hadoop breaking changes

--- a/docs/en/install-upgrade/highlights.asciidoc
+++ b/docs/en/install-upgrade/highlights.asciidoc
@@ -45,13 +45,11 @@ coming::[7.9.0]
 This list summarizes the most important enhancements in {es} {minor-version}].
 For the complete list, go to {ref}/release-highlights.html[{es} release highlights].
 
-////
 :leveloffset: +1
 
-include::{es-repo-dir}/reference/release-notes/highlights.asciidoc[tag=notable-highlights]
+include::{es-repo-dir}/release-notes/highlights.asciidoc[tag=notable-highlights]
 
 :leveloffset: -1
-////
 
 [[kibana-higlights]]
 === {kib} highlights


### PR DESCRIPTION
Depends on https://github.com/elastic/elasticsearch/pull/60695

This PR uncomments the Elasticsearch 7.9.0 release highlights and breaking changes.

### Preview

https://stack-docs_1326.docs-preview.app.elstc.co/guide/en/elastic-stack/7.9/elasticsearch-highlights.html
https://stack-docs_1326.docs-preview.app.elstc.co/guide/en/elastic-stack/7.9/elasticsearch-breaking-changes.html