### PR TITLE
[DOCS] Adds inference phase to how a DFA job works section

### DIFF
--- a/docs/en/stack/ml/df-analytics/ml-dfa-phases.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-phases.asciidoc
@@ -3,12 +3,13 @@
 = How a {dfanalytics-job} works
 
 A {dfanalytics-job} is essentially a persistent {es} task. During its life 
-cycle, it goes through four main phases:
+cycle, it goes through four or five main phases depending on the analysis type:
 
 * reindexing,
 * loading data,
 * analyzing,
-* writing results.
+* writing results,
+* inference ({regression} and {classification} only).
 
 Let's take a look at the phases one-by-one.
 
@@ -58,6 +59,12 @@ ones that have been loaded in the loading data phase are not. The
 index, merges them, and indexes them back to the destination index. When the 
 process is complete, the task is marked as completed and the {dfanalytics-job} 
 stops. Your data is ready to be evaluated.
+
+[[ml-dfa-phases-inference]]
+== {infer-cap}
+
+
+
 
 Check the <<ml-dfa-concepts>> section if you'd like to know more about the 
 various {dfanalytics} types.

--- a/docs/en/stack/ml/df-analytics/ml-dfa-phases.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-phases.asciidoc
@@ -42,7 +42,8 @@ in which they identify outliers in the data.
 
 {regression-cap} and {classification} jobs have four analysis phases:
 
-. `feature_selection`: Identifies which of the supplied fields are most relevant for predicting the dependent variable. 
+. `feature_selection`: Identifies which of the supplied fields are most relevant 
+  for predicting the dependent variable. 
 . `coarse_parameter_search`: Identifies initial values for undefined 
   hyperparameters.
 . `fine_tuning_parameters`: Identifies final values for undefined 
@@ -57,13 +58,16 @@ Only the additional fields that the analysis calculated are written back, the
 ones that have been loaded in the loading data phase are not. The 
 {dfanalytics-job} matches the results with the data rows in the destination 
 index, merges them, and indexes them back to the destination index. When the 
-process is complete, the task is marked as completed and the {dfanalytics-job} 
-stops. Your data is ready to be evaluated.
+process is complete in case of an {oldetection} job, the task is marked as 
+completed and the {dfanalytics-job} stops. Your data is ready to be evaluated.
 
 [[ml-dfa-phases-inference]]
 == {infer-cap}
 
-
+This phase exists only for {regression} and {classification} jobs. In this 
+phase, the job infers the test split of the data set agains the trained model. 
+When the process is complete, the task is marked as completed and the 
+{dfanalytics-job} stops. Your data is ready to be evaluated.
 
 
 Check the <<ml-dfa-concepts>> section if you'd like to know more about the 

--- a/docs/en/stack/ml/df-analytics/ml-dfa-phases.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-phases.asciidoc
@@ -57,16 +57,16 @@ After the loaded data is analyzed, the analysis process sends back the results.
 Only the additional fields that the analysis calculated are written back, the 
 ones that have been loaded in the loading data phase are not. The 
 {dfanalytics-job} matches the results with the data rows in the destination 
-index, merges them, and indexes them back to the destination index. When the 
-process is complete in case of an {oldetection} job, the task is marked as 
-completed and the {dfanalytics-job} stops. Your data is ready to be evaluated.
+index, merges them, and indexes them back to the destination index.
 
 [[ml-dfa-phases-inference]]
 == {infer-cap}
 
 This phase exists only for {regression} and {classification} jobs. In this 
-phase, the job infers the test split of the data set agains the trained model. 
-When the process is complete, the task is marked as completed and the 
+phase, the job infers the test split of the data set against the trained model. 
+
+
+Finally, after all phases are completed, the task is marked as completed and the 
 {dfanalytics-job} stops. Your data is ready to be evaluated.
 
 


### PR DESCRIPTION
## Overview

This PR adds the `inference` phase and its description to the `How a data frame analytics job works` section. Applies to 7.9 and above.

### Preview

[How a DFA job works – Inference phase](https://stack-docs_1327.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-dfa-phases.html#ml-dfa-phases-inference)