### PR TITLE
[DOCS] Fine-tunes wording in inference phase description

### DIFF
--- a/docs/en/stack/ml/df-analytics/ml-dfa-phases.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-phases.asciidoc
@@ -63,7 +63,7 @@ index, merges them, and indexes them back to the destination index.
 == {infer-cap}
 
 This phase exists only for {regression} and {classification} jobs. In this 
-phase, the job validates the trained model agains the test split of the data 
+phase, the job validates the trained model against the test split of the data 
 set.
 
 

--- a/docs/en/stack/ml/df-analytics/ml-dfa-phases.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-phases.asciidoc
@@ -63,8 +63,8 @@ index, merges them, and indexes them back to the destination index.
 == {infer-cap}
 
 This phase exists only for {regression} and {classification} jobs. In this 
-phase, the job validates the test split of the data set against the trained 
-model. 
+phase, the job validates the trained model agains the test split of the data 
+set.
 
 
 Finally, after all phases are completed, the task is marked as completed and the 

--- a/docs/en/stack/ml/df-analytics/ml-dfa-phases.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-phases.asciidoc
@@ -63,7 +63,8 @@ index, merges them, and indexes them back to the destination index.
 == {infer-cap}
 
 This phase exists only for {regression} and {classification} jobs. In this 
-phase, the job infers the test split of the data set against the trained model. 
+phase, the job validates the test split of the data set against the trained 
+model. 
 
 
 Finally, after all phases are completed, the task is marked as completed and the 


### PR DESCRIPTION
## Overview

This PR changes the verb `infer` to `validate` in the description of the inference phase to differentiate it from the inference process that happens in a pipeline, in an aggregation, or in a continuous transform. Applies to 7.9 and above.

### Preview

[How a data frame analytics job works]()