### PR TITLE
[DOCS] Adds further reading section to Influencers

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/ml-influencers.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-influencers.asciidoc
@@ -82,3 +82,8 @@ are generated for each type of result. The anomaly timeline in {kib} uses the
 bucket-level anomaly scores. If you view swim lanes by influencer, it uses the
 influencer-level anomaly scores, as does the list of top influencers. The list
 of anomalies uses the record-level anomaly scores.
+
+[[further-reading]]
+== Further reading
+
+https://www.elastic.co/blog/interpretability-in-ml-identifying-anomalies-influencers-root-causes[Interpretability in ML: Identifying anomalies, influencers, and root causes]

--- a/docs/en/stack/ml/df-analytics/ml-feature-importance.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-feature-importance.asciidoc
@@ -30,6 +30,6 @@ NOTE: The number of {feat-imp} values for each document might be less than the
 features that had a positive or negative effect on the prediction.
 
 [[ml-feature-importance-readings]]
-== Further readings
+== Further reading
 
 https://www.elastic.co/blog/feature-importance-for-data-frame-analytics-with-elastic-machine-learning[{feat-imp-cap} for {dfanalytics} with Elastic {ml}]

--- a/docs/en/stack/ml/df-analytics/ml-lang-ident.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-lang-ident.asciidoc
@@ -186,6 +186,6 @@ The request returns the following response:
 <2> The ISO identifier of the language with the highest probability.
 
 [[ml-lang-ident-readings]]
-== Further readings
+== Further reading
 
 https://www.elastic.co/blog/multilingual-search-using-language-identification-in-elasticsearch[Multilingual search using language identification in Elasticsearch]


### PR DESCRIPTION
## Overview

This PR adds a `Further reading` section to the Influencers chapter in the AD docs and adds a link of a related blog post.

 ### Preview

[Influencers](https://stack-docs_1339.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-influencers.html)