### PR TITLE
[DOCS] Removes coming tags from installation upgrade guide

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -28,8 +28,6 @@ Upgrade Assistant provides information about which {dfeeds} need to be updated.
 <titleabbrev>APM</titleabbrev>
 ++++
 
-coming::[7.9.0]
-
 This list summarizes the most important breaking changes in APM.
 For the complete list, go to {apm-server-ref}/breaking-changes.html[APM Server breaking changes].
 
@@ -54,8 +52,6 @@ include::{beats-repo-dir}/release-notes/breaking/breaking-7.9.asciidoc[tag=notab
 <titleabbrev>{es}</titleabbrev>
 ++++
 
-coming::[7.9.0]
-
 This list summarizes the most important breaking changes in {es} {version}. For
 the complete list, go to {ref}/breaking-changes.html[{es} breaking changes].
 
@@ -67,8 +63,6 @@ include::{es-repo-dir}/migration/migrate_7_9.asciidoc[tag=notable-breaking-chang
 ++++
 <titleabbrev>{es} Hadoop</titleabbrev>
 ++++
-
-coming::[7.9.0]
 
 This list summarizes the most important breaking changes in {es} Hadoop {version}.
 For the complete list, go to
@@ -83,8 +77,6 @@ include::{hadoop-repo-dir}/appendix/breaking.adoc[tag=notable-v7-breaking-change
 <titleabbrev>{kib}</titleabbrev>
 ++++
 
-coming::[7.9.0]
-
 This list summarizes the most important breaking changes in {kib} {version}. For
 the complete list, go to {kibana-ref}/breaking-changes.html[{kib} breaking changes].
 
@@ -96,8 +88,6 @@ include::{kib-repo-dir}/migration/migrate_7_9.asciidoc[tag=notable-breaking-chan
 ++++
 <titleabbrev>{ls}</titleabbrev>
 ++++
-
-coming::[7.9.0]
 
 This list summarizes the most important breaking changes in {ls} {version}. For
 the complete list, go to

--- a/docs/en/install-upgrade/highlights.asciidoc
+++ b/docs/en/install-upgrade/highlights.asciidoc
@@ -38,8 +38,6 @@ include::{beats-repo-dir}/release-notes/whats-new.asciidoc[tag=notable-highlight
 <titleabbrev>{es}</titleabbrev>
 ++++
 
-coming::[7.9.0]
-
 This list summarizes the most important enhancements in {es} {minor-version}.
 For the complete list, go to {ref}/release-highlights.html[{es} release highlights].
 
@@ -55,8 +53,6 @@ include::{es-repo-dir}/release-notes/highlights.asciidoc[tag=notable-highlights]
 ++++
 <titleabbrev>{kib}</titleabbrev>
 ++++
-
-coming::[7.9.0]
 
 This list summarizes the most important enhancements in {kib} {minor-version}.
 


### PR DESCRIPTION
This PR removes the coming[7.9.0] tags from the Installation and Upgrade Guide.