### PR TITLE
[DOCS] Add link to ML settings from setup

### DIFF
--- a/docs/en/stack/ml/setup.asciidoc
+++ b/docs/en/stack/ml/setup.asciidoc
@@ -29,7 +29,8 @@ To use {ml-features}, there must be at least one {ml} node in your cluster. A
 
 If nodes do not have the {ml} role, they cannot run {ml} jobs. If
 `xpack.ml.enabled` is `true`, however, they can service API requests. For more
-information, see {ref}/modules-node.html#ml-node[Machine learning nodes].
+information, see {ref}/modules-node.html#ml-node[{ml-cap} nodes] and
+{ref}/ml-settings.html[{ml-cap} settings in {es}].
 
 [discrete]
 [[setup-privileges]]


### PR DESCRIPTION
This PR adds a link from https://www.elastic.co/guide/en/machine-learning/current/setup.html to https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-settings.html