### PR TITLE
[7.9] [DOCS] Fixes typo in OOTB metricbeat jobs. (#1345)

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-metricbeat.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-metricbeat.asciidoc
@@ -23,7 +23,7 @@ max_disk_utilization_ecs::
 
 * For {metricbeat} data where `event.dataset` is `system.cpu` and 
   `system.filesystem`.
-* Models disc utilization (`partition_field_name` is `host.name`).
+* Models disk utilization (`partition_field_name` is `host.name`).
 * Detects unusual increases in disk utilization (using the 
   <<ml-metric-max,`max` function>>).
 


### PR DESCRIPTION
Backports the following commits to 7.9:
 - [DOCS] Fixes typo in OOTB metricbeat jobs. (#1345)