### PR TITLE
[DOCS] Modifies OOTB jobs content

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-apache.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-apache.asciidoc
@@ -17,34 +17,33 @@ low_request_rate_ecs::
 * For HTTP web access logs where `event.dataset` is `apache.access`.
 * Models the event rate of HTTP requests. 
 * Detects unusually low counts of HTTP requests compared to the previous event 
-  rate (using the <<ml-count,`low_count` function>>).
+  rate.
 
 source_ip_request_rate_ecs::
 
 * For HTTP web access logs where `event.dataset` is `apache.access`.
 * Models the event rate of HTTP requests by source IP.
 * Detects source IPs with unusually high request rates in the HTTP access log 
-  compared to the previous rate (using the <<ml-count,`high_count` function>>).
+  compared to the previous rate.
 
 source_ip_url_count_ecs::
 
 * For HTTP web access logs where `event.dataset` is `apache.access`.
 * Models the event rate of HTTP requests by source IP.
 * Detects source IPs with unusually high distinct count of URLs in the HTTP 
-access log (using the <<ml-distinct-count,`high_distinct_count` function>>).
+access log.
 
 status_code_rate_ecs::
 
 * For HTTP web access logs where `event.dataset` is `apache.access`.
-* Models the occurrences of HTTP response status codes (`partition_field_name` 
-  is `http.response.status_code`).
+* Models the occurrences of HTTP response status codes.
 * Detects unusual status code rates in the HTTP access log compared to previous 
-  rates (using the <<ml-count,`count` function>>).
+  rates.
 
 visitor_rate_ecs::
 
 * For HTTP web access logs where `event.dataset` is `apache.access`.
 * Models visitor rates.
-* Detects unusual visitor rates in the HTTP access log ompared to previous 
-  rates (using the <<ml-nonzero-count,`non_zero_count` function>>).
+* Detects unusual visitor rates in the HTTP access log compared to previous 
+  rates.
 // end::apache-jobs[]

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-apm.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-apm.asciidoc
@@ -21,7 +21,7 @@ abnormal_span_durations_nodejs::
 
 * For data from {apm-node-agents} (where `agent.name` is `nodejs`).
 * Models the duration of spans.
-* Detects for spans that are taking longer than usual to process.
+* Detects spans that are taking longer than usual to process.
 
 abnormal_trace_durations_nodejs::
 
@@ -49,7 +49,7 @@ abnormal_span_durations_jsbase::
 
 * For data from {apm-rum-agents} (where `agent.name` is `js-base`).
 * Models the duration of spans.
-* Detects for spans that are taking longer than usual to process.
+* Detects spans that are taking longer than usual to process.
   
 anomalous_error_rate_for_user_agents_jsbase::
 This job can help detect browser compatibility issues.

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-apm.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-apm.asciidoc
@@ -20,23 +20,21 @@ throughput.
 abnormal_span_durations_nodejs::
 
 * For data from {apm-node-agents} (where `agent.name` is `nodejs`).
-* Models the duration of spans (`partition_field_name` is `span.type`).
-* Detects for spans that are taking longer than usual to process (using the 
-  <<ml-metric-mean,`high_mean` function>>).
+* Models the duration of spans.
+* Detects for spans that are taking longer than usual to process.
 
 abnormal_trace_durations_nodejs::
 
 * For data from {apm-node-agents} (where `agent.name` is `nodejs`).
 * Models the duration of trace transactions.
-* Detects trace transactions that are processing slower than usual (using the 
-  <<ml-metric-mean,`high_mean` function>>).
+* Detects trace transactions that are processing slower than usual.
 
 decreased_throughput_nodejs::
 
 * For data from {apm-node-agents} (where `agent.name` is `nodejs`).
 * Models the transaction rate of the application.
 * Detects periods during which the application is processing fewer requests 
-than normal (using the <<ml-count,`low_count` function>>).
+than normal.
 
 // end::apm-nodejs-jobs[]
 
@@ -50,18 +48,15 @@ issues.
 abnormal_span_durations_jsbase::
 
 * For data from {apm-rum-agents} (where `agent.name` is `js-base`).
-* Models the duration of spans (`partition_field_name` is `span.type`).
-* Detects for spans that are taking longer than usual to process (using the 
-<<ml-metric-mean,`high_mean` function>>).
+* Models the duration of spans.
+* Detects for spans that are taking longer than usual to process.
   
 anomalous_error_rate_for_user_agents_jsbase::
 This job can help detect browser compatibility issues.
 +
 * For data from {apm-rum-agents} (where `agent.name` is `js-base`).
-* Models the error rate of user agents (`partition_field_name` is 
-`user_agent.name`).
-* Detects user agents that are encountering errors at an above normal rate 
-(using the <<ml-nonzero-count,`high_non_zero_count` function>>).
+* Models the error rate of user agents.
+* Detects user agents that are encountering errors at an above normal rate.
 
 decreased_throughput_jsbase::
 
@@ -69,16 +64,14 @@ decreased_throughput_jsbase::
 `js-base`).
 * Models the transaction rate of the application.
 * Detects periods during which the application is processing fewer requests than
-normal (using the <<ml-count,`low_count` function>>).
+normal.
 
 high_count_by_user_agent_jsbase::
 This job is useful in identifying bots.
 +
 * For data from {apm-rum-agents} (where `agent.name` is `js-base`).
-* Models the request rate of user agents (`partition_field_name` is 
-`user_agent.name`).
-* Detects user agents that are making requests at a suspiciously high rate 
-(using the <<ml-nonzero-count,`high_non_zero_count` function>>).
+* Models the request rate of user agents.
+* Detects user agents that are making requests at a suspiciously high rate.
 
 // end::apm-rum-javascript-jobs[]
 
@@ -91,8 +84,7 @@ high_mean_transaction_duration::
 
 * For transaction data where `processor.event` is `transaction`.
 * Models duration of transactions by transaction type for APM services.
-* Detects anomalies in high mean of transaction duration (using the 
-  <<ml-metric-mean,`high_mean` function>>).
+* Detects anomalies in high mean of transaction duration.
 
 // end::apm-transaction-jobs[]
 // end::apm-jobs[]

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-auditbeat.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-auditbeat.asciidoc
@@ -16,31 +16,26 @@ docker_high_count_process_events_ecs::
 
 * For Auditbeat data where `event.module` is `auditd` and `container.runtime` is 
 `docker`.
-* Models process execution rates (`partition_field_name` is `container.name`).
-* Detects unusual increases in process execution rates in Docker containers 
-  (using the <<ml-count,`high_count` function>>).
+* Models process execution rates for each `container.name`.
+* Detects unusual increases in process execution rates in Docker containers.
 
 docker_rare_process_activity_ecs::
 
 * For Auditbeat data where `event.module` is `auditd` and `container.runtime` is 
 `docker`.
-* Models occurrences of process execution (`partition_field_name` is 
-  `container.name`).
-* Detects rare process executions in Docker containers (using the 
-  <<ml-rare,`rare` function>>).
+* Models occurrences of process execution for each `container.name`.
+* Detects rare process executions in Docker containers.
 
 hosts_high_count_process_events_ecs::
 
 * For Auditbeat data where `event.module` is `auditd`.
-* Models process execution rates (`partition_field_name` is `host.name`).
-* Detects unusual increases in process execution rates (using the 
-  <<ml-nonzero-count,`high_non_zero_count` function>>).
+* Models process execution rates for each `host.name`.
+* Detects unusual increases in process execution rates.
 
 hosts_rare_process_activity_ecs::
 
 * For Auditbeat data where `event.module` is `auditd`.
-* Models process execution rates (`partition_field_name` is `host.name`).
-* Detects rare process executions on hosts (using the 
-  <<ml-rare,`rare` function>>).
+* Models process execution rates for each `host.name`.
+* Detects rare process executions on hosts.
 
 // end::auditbeat-jobs[]

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-logs-ui.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-logs-ui.asciidoc
@@ -15,7 +15,7 @@ log_entry_categories_count::
 
 * For log entry categories via the Logs UI.
 * Models the occurrences of log events.
-* Detects anomalies in count of log entries by category.
+* Detects anomalies in the count of log entries by category.
 
 log_entry_rate::
 

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-logs-ui.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-logs-ui.asciidoc
@@ -14,16 +14,13 @@ https://github.com/elastic/kibana/tree/{branch}/x-pack/plugins/ml/server/models/
 log_entry_categories_count::
 
 * For log entry categories via the Logs UI.
-* Models the occurrences of log events (`partition_field_name` is 
-  `event.dataset`).
-* Detects anomalies in count of log entries by category (using the 
-  <<ml-count,`count` function>>).
+* Models the occurrences of log events.
+* Detects anomalies in count of log entries by category.
 
 log_entry_rate::
 
 * For log entries via the Logs UI.
-* Models ingestion rates (`partition_field_name` is `event.dataset`). 
-* Detects anomalies in the log entry ingestion rate (using the 
-  <<ml-count,`low_count` function>>).
+* Models ingestion rates. 
+* Detects anomalies in the log entry ingestion rate.
   
 // end::logs-jobs[]

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-metricbeat.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-metricbeat.asciidoc
@@ -15,25 +15,21 @@ high_mean_cpu_iowait_ecs::
 
 * For {metricbeat} data where `event.dataset` is `system.cpu` and 
   `system.filesystem`.
-* Models CPU time spent in iowait (`partition_field_name` is `host.name`).
-* Detects unusual increases in cpu time spent in iowait (using the 
-  <<ml-metric-mean,`high_mean` function>>).
+* Models CPU time spent in iowait for every `host.name`.
+* Detects unusual increases in cpu time spent in iowait.
 
 max_disk_utilization_ecs::
 
 * For {metricbeat} data where `event.dataset` is `system.cpu` and 
   `system.filesystem`.
-* Models disk utilization (`partition_field_name` is `host.name`).
-* Detects unusual increases in disk utilization (using the 
-  <<ml-metric-max,`max` function>>).
+* Models disk utilization for each `host.name`.
+* Detects unusual increases in disk utilization.
 
 metricbeat_outages_ecs::
 
 * For {metricbeat} data where `event.dataset` is `system.cpu` and 
   `system.filesystem`.
-* Models counts of {metricbeat} documents 
-  (`partition_field_name` is `event.dataset`).
-* Detects unusual decreases in {metricbeat} documents (using the 
-  <<ml-count,`low_count` function>>).
+* Models counts of {metricbeat} documents.
+* Detects unusual decreases in {metricbeat} documents.
 
 // end::metricbeat-jobs[]

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-nginx.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-nginx.asciidoc
@@ -17,35 +17,34 @@ low_request_rate_ecs::
 * For HTTP web access logs where `event.dataset` is `nginx.access`.
 * Models the event rate of http requests. 
 * Detects unusually low counts of HTTP requests compared to the previous event 
-  rate (using the <<ml-count,`low_count` function>>).
+  rate.
 
 source_ip_request_rate_ecs::
 
 * For HTTP web access logs where `event.dataset` is `nginx.access`.
 * Models the event rate of HTTP requests by source IP.
 * Detects source IPs with unusually high request rates in the HTTP access log 
-  compared to the previous rate (using the <<ml-count,`high_count` function>>). 
+  compared to the previous rate. 
 
 source_ip_url_count_ecs::
 
 * For HTTP web access logs where `event.dataset` is `nginx.access`.
 * Models the event rate of HTTP requests by source IP.
 * Detects source IPs with unusually high distinct count of URLs in the HTTP 
-  access log (using the <<ml-distinct-count,`high_distinct_count` function>>).
+  access log.
 
 status_code_rate_ecs::
 
 * For HTTP web access logs where `event.dataset` is `nginx.access`.
-* Models the occurrences of HTTP response status codes (`partition_field_name` 
-  is `http.response.status_code`).
+* Models the occurrences of HTTP response status codes.
 * Detects unusual status code rates in the HTTP access log compared to previous 
-  rates (using the <<ml-count,`count` function>>).
+  rates.
 
 visitor_rate_ecs::
 
 * For HTTP web access logs where `event.dataset` is `nginx.access`.
 * Models visitor rates.
 * Detects unusual visitor rates in the HTTP access log compared to previous 
-  rates (using the <<ml-nonzero-count,`non_zero_count` function>>).
+  rates.
 
 // end::nginx-jobs[]

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -1,6 +1,9 @@
 [role="xpack"]
 [[ootb-ml-jobs]]
 = Supplied {anomaly-detect} configurations
+++++
+<titleabbrev>Supplied configurations</titleabbrev>
+++++
 
 {anomaly-jobs-cap} contain the configuration information and metadata necessary 
 to perform an analytics task. {kib} can recognize certain types of data and 


### PR DESCRIPTION
## Overview

This PR makes the following changes on the OOTB AD jobs content:
* removes the links that refer to the used function for each job
* removes the `partition_field_name` value when it is not important to provide
* makes the `partition_field_name` value the part of the sentence when it is important
* adds a `titleabbrev` to the main page.

### Preview

* [Apache](https://stack-docs_1348.docs-preview.app.elstc.co/guide/en/machine-learning/master/ootb-ml-jobs-apache.html)
* [APM](https://stack-docs_1348.docs-preview.app.elstc.co/guide/en/machine-learning/master/ootb-ml-jobs-apm.html)
* [Auditbeat](https://stack-docs_1348.docs-preview.app.elstc.co/guide/en/machine-learning/master/ootb-ml-jobs-auditbeat.html)
* [Logs UI](https://stack-docs_1348.docs-preview.app.elstc.co/guide/en/machine-learning/master/ootb-ml-jobs-logs-ui.html)
* [Metricbeat](https://stack-docs_1348.docs-preview.app.elstc.co/guide/en/machine-learning/master/ootb-ml-jobs-metricbeat.html)
* [Nginx](https://stack-docs_1348.docs-preview.app.elstc.co/guide/en/machine-learning/master/ootb-ml-jobs-nginx.html)
* [OOTB ML jobs](https://stack-docs_1348.docs-preview.app.elstc.co/guide/en/machine-learning/master/ootb-ml-jobs.html)