### PR TITLE
docs: add Observability terms to glossary

### DIFF
--- a/docs/en/glossary/glossary.asciidoc
+++ b/docs/en/glossary/glossary.asciidoc
@@ -76,8 +76,8 @@ and errors at runtime.
 //Source: Observability
 
 [[glossary-apm-server]] APM Server::
-An open-source application that receives data from <<glossary-apm-agent,APM agents>> and transforms
-it into {es} documents.
+An open-source application that receives data from <<glossary-apm-agent,APM agents>> and sends
+it to {es}.
 //Source: Observability
 
 [[glossary-app]] app::

--- a/docs/en/glossary/glossary.asciidoc
+++ b/docs/en/glossary/glossary.asciidoc
@@ -69,6 +69,17 @@ necessary to perform an analytics task. See
 include::{es-repo-dir}/glossary.asciidoc[tag=api-key-def]
 --
 
+[[glossary-apm-agent]] APM agent::
+An open-source library, written in the same language as your service,
+which <<glossary-instrumentation,instruments>> your code and collects performance data
+and errors at runtime.
+//Source: Observability
+
+[[glossary-apm-server]] APM Server::
+An open-source application that receives data from <<glossary-apm-agent,APM agents>> and transforms
+it into {es} documents.
+//Source: Observability
+
 [[glossary-app]] app::
 +
 --
@@ -297,6 +308,10 @@ deployments it can be separated.
 include::{kib-repo-dir}/glossary.asciidoc[tag=discover-def]
 --
 
+[[glossary-distributed-tracing]] distributed tracing::
+The end-to-end collection of performance data throughout your microservices architecture.
+//Source: Observability
+
 [[glossary-drilldown]] drilldown::
 +
 --
@@ -364,7 +379,7 @@ In supervised {ml} methods such as {regression} and {classification}, feature
 importance indicates the degree to which a specific feature affects a prediction.
 See
 {ml-docs}/dfa-regression.html#dfa-regression-feature-importance[{regression-cap} feature importance]
-and 
+and
 {ml-docs}/dfa-classification.html#dfa-classification-feature-importance[{classification-cap} feature importance].
 //Source: X-Pack
 
@@ -512,12 +527,26 @@ bucket in an {anomaly-job}. For more information, see
 {ml-docs}/ml-influencers.html[Influencers].
 //Source: X-Pack
 
+[[glossary-ingestion]] ingestion::
+The process of collecting and sending data from various data sources to {es}.
+//Source: Observability
+
 [[glossary-input-plugin]] input plugin::
 A {ls} <<glossary-plugin,plugin>> that reads <<glossary-event,event>> data
 from a specific source. Input plugins are the first stage in the {ls}
 event processing <<glossary-pipeline,pipeline>>. Popular input plugins include
 file, syslog, redis, and beats.
 //Source: Logstash
+
+[[glossary-instrumentation]] instrumentation::
+Extending application code to track where your application is spending time.
+Code is considered instrumented when it collects and reports this performance data to APM.
+//Source: Observability
+
+[[glossary-integration]] integration::
+Out-of-the-box configurations for common data sources to simplify the collection,
+parsing, and visualization of logs and metrics. Also known as a <<glossary-module,module>>.
+//Source: Observability
 
 [discrete]
 [[j-glos]]
@@ -550,7 +579,7 @@ include::{kib-repo-dir}/glossary.asciidoc[tag=kql-def]
 [[l-glos]]
 === L
 
-[[glossary-leader-index]] leader index::  
+[[glossary-leader-index]] leader index::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=leader-index-def]
@@ -623,6 +652,16 @@ creating transient fields for use in <<glossary-conditional,conditional>>
 statements.
 //Source: Logstash
 
+[[glossary-module]] module::
+Out-of-the-box configurations for common data sources to simplify the collection,
+parsing, and visualization of logs and metrics. Also known as an <<glossary-integration,integration>>.
+//Source: Observability
+
+[[glossary-monitor]] monitor::
+A network endpoint which is monitored to track the performance and availability of
+applications and services.
+//Source: Observability
+
 [discrete]
 [[n-glos]]
 === N
@@ -636,6 +675,12 @@ include::{es-repo-dir}/glossary.asciidoc[tag=node-def]
 [discrete]
 [[o-glos]]
 === O
+
+[[glossary-observability]] Observability::
+Unifying your logs, metrics, uptime data, and application traces to
+provide granular insights and context into the behavior of services
+running in your environments.
+//Source: Observability
 
 [[glossary-output-plugin]] output plugin::
 A {ls} <<glossary-plugin,plugin>> that writes <<glossary-event,event>> data
@@ -728,6 +773,10 @@ include::{kib-repo-dir}/glossary.asciidoc[tag=query-profiler-def]
 [discrete]
 [[r-glos]]
 === R
+
+[[glossary-real-user-monitoring]] Real user monitoring (RUM)::
+Performance monitoring, metrics, and error tracking of web applications.
+//Source: Observability
 
 [[glossary-recovery]] recovery::
 +
@@ -869,6 +918,12 @@ include::{es-repo-dir}/glossary.asciidoc[tag=source-field-def]
 include::{kib-repo-dir}/glossary.asciidoc[tag=space-def]
 --
 
+[[glossary-span]] span::
+Information about the execution of a specific code path.
+{apm-overview-ref-v}/spans.html[Spans] measure from the start to the end of an activity
+and can have a parent/child relationship with other spans.
+//Source: Observability
+
 [[glossary-split]] split::
 +
 --
@@ -919,6 +974,17 @@ include::{kib-repo-dir}/glossary.asciidoc[tag=timelion-def]
 include::{kib-repo-dir}/glossary.asciidoc[tag=time-series-data-def]
 --
 
+[[glossary-trace]] trace::
+Defines the amount of time an application spends on a request.
+Traces are made up of a collection of transactions and spans that have a common root.
+//Source: Observability
+
+[[glossary-transaction]] transaction::
+A special kind of <<glossary-span,span>> that has additional attributes associated with it.
+{apm-overview-ref-v}/transactions.html[Transactions] describe an event captured by an
+Elastic <<glossary-apm-agent,APM agent>> instrumenting a service.
+//Source: Observability
+
 [[glossary-tsvb]] TSVB::
 +
 --
@@ -940,6 +1006,11 @@ include::{es-repo-dir}/glossary.asciidoc[tag=type-def]
 --
 include::{kib-repo-dir}/glossary.asciidoc[tag=upgrade-assistant-def]
 --
+
+[[glossary-uptime]] Uptime::
+A metric of system reliability used to monitor the status of network endpoints
+via HTTP/S, TCP, and ICMP.
+//Source: Observability
 
 [discrete]
 [[v-glos]]

--- a/docs/en/glossary/glossary.asciidoc
+++ b/docs/en/glossary/glossary.asciidoc
@@ -920,7 +920,7 @@ include::{kib-repo-dir}/glossary.asciidoc[tag=space-def]
 
 [[glossary-span]] span::
 Information about the execution of a specific code path.
-{apm-overview-ref-v}/spans.html[Spans] measure from the start to the end of an activity
+{apm-overview-ref-v}/transaction-spans.html[Spans] measure from the start to the end of an activity
 and can have a parent/child relationship with other spans.
 //Source: Observability
 


### PR DESCRIPTION
This PR adds the following Observability terms to the Elastic Glossary:

* **Observability**
* **Agent (APM)**
* **Server (APM)**
* **Distributed tracing**
* **Instrumentation**
* **Real User Monitoring (RUM)**
* **Span**
* **Trace**
* **Transaction**
* **Ingestion**
* **Integration**
* **Module**
* **Monitor**
* **Uptime**

I didn't source these terms from the `observability-docs` repo because we don't have any short-term plans to host an Observability glossary.

Closes https://github.com/elastic/observability-docs/issues/34.