### PR TITLE
[DOCS] Add metadata and discovery analysis jobs for security integration

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-siem.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-siem.asciidoc
@@ -23,33 +23,6 @@ https://github.com/elastic/kibana/tree/{branch}/x-pack/plugins/ml/server/models/
 Detect suspicious network activity and unusual processes in {auditbeat} data.
 
 // tag::siem-auditbeat-jobs[]
-rare_process_by_host_linux_ecs::
-
-Identifies rare processes that do not usually run on individual hosts, which
-can indicate execution of unauthorized services, malware, or persistence
-mechanisms.
-+
-Processes are considered rare when they only run occasionally as compared with
-other processes running on the host.
-
-Job details:::
-
-* Analyzes host activity logs where `agent.type` is `auditbeat` (Linux).
-* Models occurrences of process activities on the host. 
-* Detects unusually rare processes compared to other processes on the host (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
-
-Required {beats}:::
-
-* {auditbeat}
-
-Required ECS fields when not using {beats}:::
-
-* `host.name`
-* `process.name`
-* `user.name`
-* `event.action`
-* `agent.type`
-
 linux_anomalous_network_activity_ecs::
 
 Identifies OS processes that do not usually use the network but have
@@ -207,6 +180,234 @@ Job details:::
 * Models user activity.
 * Detects users that are rarely or unusually active compared to other users 
   (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
+
+Required {beats}:::
+
+* {auditbeat}
+
+Required ECS fields when not using {beats}:::
+
+* `host.name`
+* `process.name`
+* `user.name`
+* `event.action`
+* `agent.type`
+
+linux_network_configuration_discovery::
+
+Looks for commands related to system network configuration discovery from an
+unusual user context. This can be due to uncommon troubleshooting activity or
+due to a compromised account. A compromised account may be used by a threat
+actor to engage in system network configuration discovery in order to increase
+their understanding of connected networks and hosts. This information may be
+used to shape follow-up behaviors such as lateral movement or additional
+discovery.
+
+Job details::: TBD
+
+Required {beats}:::
+
+* {auditbeat}
+
+Required ECS fields when not using {beats}:::
+
+* `host.name`
+* `process.args`
+* `process.name`
+* `user.name`
+
+linux_network_connection_discovery::
+
+Looks for commands related to system network connection discovery from an
+unusual user context. This can be due to uncommon troubleshooting activity or
+due to a compromised account. A compromised account may be used by a threat
+actor to engage in system network connection discovery in order to increase
+their understanding of connected services and systems. This information may be
+used to shape follow-up behaviors such as lateral movement or additional
+discovery.
+
+Job details::: TBD
+
+Required {beats}:::
+
+* {auditbeat}
+
+Required ECS fields when not using {beats}:::
+
+* `host.name`
+* `process.args`
+* `process.name`
+* `user.name`
+
+linux_rare_kernel_module_arguments::
+
+Looks for unusual kernel modules which are often used for stealth.
+
+Job details::: TBD
+
+Required {beats}:::
+
+* {auditbeat}
+
+Required ECS fields when not using {beats}:::
+
+* `host.name`
+* `process.title`
+* `process.working_directory`
+* `user.name`
+
+linux_rare_metadata_process::
+
+Looks for anomalous access to the metadata service by an unusual process. The
+metadata service may be targeted in order to harvest credentials or user data
+scripts containing secrets.    
+
+Job details::: TBD
+
+Required {beats}:::
+
+* {auditbeat}
+
+Required ECS fields when not using {beats}:::
+
+* `host.name`
+* `process.name`
+* `user.name`
+
+linux_rare_metadata_user::
+
+Looks for anomalous access to the metadata service by an unusual user. The
+metadata service may be targeted in order to harvest credentials or user data
+scripts containing secrets.   
+
+Job details::: TBD
+
+Required {beats}:::
+
+* {auditbeat}
+
+Required ECS fields when not using {beats}:::
+
+* `host.name`
+* `user.name`
+
+linux_rare_sudo_user::
+
+Looks for sudo activity from an unusual user context.
+
+Job details::: TBD
+
+Required {beats}:::
+
+* {auditbeat}
+
+Required ECS fields when not using {beats}:::
+
+* `host.name`
+* `process.args`
+* `process.name`
+* `user.name`
+
+linux_rare_user_compiler::
+
+Looks for compiler activity by a user context which does not normally run
+compilers. This can be ad-hoc software changes or unauthorized software
+deployment. This can also be due to local privilege elevation via locally run
+exploits or malware activity.
+
+Job details::: TBD
+
+Required {beats}:::
+
+* {auditbeat}
+
+Required ECS fields when not using {beats}:::
+
+* `host.name`
+* `process.title`
+* `process.working_directory`
+* `user.name`
+
+linux_system_information_discovery::
+
+Looks for commands related to system information discovery from an unusual user
+context. This can be due to uncommon troubleshooting activity or due to a
+compromised account. A compromised account may be used to engage in system
+information discovery in order to gather detailed information about system
+configuration and software versions. This may be a precursor to selection of a 
+persistence mechanism or a method of privilege elevation.  
+
+Job details::: TBD
+
+Required {beats}:::
+
+* {auditbeat}
+
+Required ECS fields when not using {beats}:::
+
+* `host.name`
+* `process.args`
+* `process.name`
+* `user.name`
+
+linux_system_process_discovery::
+
+Looks for commands related to system process discovery from an unusual user
+context. This can be due to uncommon troubleshooting activity or due to a
+compromised account. A compromised account may be used to engage in system
+process discovery in order to increase their understanding of software
+applications running on a target host or network. This may be a precursor to
+selection of a persistence mechanism or a method of privilege elevation.
+
+Job details::: TBD
+
+Required {beats}:::
+
+* {auditbeat}
+
+Required ECS fields when not using {beats}:::
+
+* `host.name`
+* `process.args`
+* `process.name`
+* `user.name`
+
+linux_system_user_discovery::
+
+Looks for commands related to system user or owner discovery from an unusual
+user context. This can be due to uncommon troubleshooting activity or due to a 
+compromised account. A compromised account may be used to engage in system owner
+or user discovery in order to identify currently active or primary users of a
+system. This may be a precursor to additional discovery, credential dumping or
+privilege elevation activity.
+
+Job details::: TBD
+
+Required {beats}:::
+
+* {auditbeat}
+
+Required ECS fields when not using {beats}:::
+
+* `host.name`
+* `process.args`
+* `process.name`
+* `user.name`
+
+rare_process_by_host_linux_ecs::
+
+Identifies rare processes that do not usually run on individual hosts, which
+can indicate execution of unauthorized services, malware, or persistence
+mechanisms.
++
+Processes are considered rare when they only run occasionally as compared with
+other processes running on the host.
+
+Job details:::
+
+* Analyzes host activity logs where `agent.type` is `auditbeat` (Linux).
+* Models occurrences of process activities on the host. 
+* Detects unusually rare processes compared to other processes on the host (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
 
 Required {beats}:::
 
@@ -781,6 +982,41 @@ Required ECS fields when not using {beats}:::
 * `user.name`
 * `event.action`
 * `agent.type`
+
+windows_rare_metadata_process::
+
+Looks for anomalous access to the metadata service by an unusual process. The
+metadata service may be targeted in order to harvest credentials or user data
+scripts containing secrets.
+
+Job details::: TBD
+
+Required {beats}:::
+
+* {winlogbeat} (Windows)
+
+Required ECS fields when not using {beats}:::
+
+* `host.name`
+* `process.name`
+* `user.name`
+
+windows_rare_metadata_user::
+
+Looks for anomalous access to the metadata service by an unusual user. The
+metadata service may be targeted in order to harvest credentials or user data
+scripts containing secrets.  
+
+Job details::: TBD
+
+Required {beats}:::
+
+* {winlogbeat} (Windows)
+
+Required ECS fields when not using {beats}:::
+
+* `host.name`
+* `user.name`
 
 windows_rare_user_runas_event::
 

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-siem.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-siem.asciidoc
@@ -200,10 +200,15 @@ unusual user context. This can be due to uncommon troubleshooting activity or
 due to a compromised account. A compromised account may be used by a threat
 actor to engage in system network configuration discovery in order to increase
 their understanding of connected networks and hosts. This information may be
-used to shape follow-up behaviors such as lateral movement or additional
+used to shape follow-up behavior such as lateral movement or additional
 discovery.
 
-Job details::: TBD
+Job details:::
+* Analyzes host activity logs where `agent.type` is `auditbeat` and
+`process.name` is commands like `arp`, `echo`, or `ifconfig`, for example.
+* Models user activity.
+* Detects users that are rarely or unusually active compared to other users 
+  (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
 
 Required {beats}:::
 
@@ -226,7 +231,12 @@ their understanding of connected services and systems. This information may be
 used to shape follow-up behaviors such as lateral movement or additional
 discovery.
 
-Job details::: TBD
+Job details:::
+* Analyzes host activity logs where `agent.type` is `auditbeat` and
+`process.name` is commands like `netstat`, `ss`, or `route`, for example.
+* Models user activity.
+* Detects users that are rarely or unusually active compared to other users 
+  (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
 
 Required {beats}:::
 
@@ -243,7 +253,12 @@ linux_rare_kernel_module_arguments::
 
 Looks for unusual kernel modules which are often used for stealth.
 
-Job details::: TBD
+Job details:::
+* Analyzes host activity logs where `agent.type` is `auditbeat` and
+`process.name` is commands like `insmod`, `kmod`, or `rmod`, for example.
+* Models occurrences of process activity.
+* Detects processes that are rarely or unusually active compared to other processes 
+  (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
 
 Required {beats}:::
 
@@ -262,7 +277,12 @@ Looks for anomalous access to the metadata service by an unusual process. The
 metadata service may be targeted in order to harvest credentials or user data
 scripts containing secrets.    
 
-Job details::: TBD
+Job details:::
+* Analyzes host activity logs where `agent.type` is `auditbeat` and
+`destination.ip` is commands the metadata service.
+* Models process activity.
+* Detects processes that are rarely or unusually active compared to other processes 
+  (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
 
 Required {beats}:::
 
@@ -280,7 +300,13 @@ Looks for anomalous access to the metadata service by an unusual user. The
 metadata service may be targeted in order to harvest credentials or user data
 scripts containing secrets.   
 
-Job details::: TBD
+Job details:::
+
+* Analyzes host activity logs where `agent.type` is `auditbeat` and
+`destination.ip` is the metadata service.
+* Models user activity.
+* Detects users that are rarely or unusually active compared to other users 
+  (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
 
 Required {beats}:::
 
@@ -295,7 +321,13 @@ linux_rare_sudo_user::
 
 Looks for sudo activity from an unusual user context.
 
-Job details::: TBD
+Job details:::
+
+* Analyzes host activity logs where `agent.type` is `auditbeat`,
+`process.name` is `sudo`, and `event.action` is `executed`.
+* Models user activity.
+* Detects users that are rarely or unusually active compared to other users 
+  (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
 
 Required {beats}:::
 
@@ -315,7 +347,13 @@ compilers. This can be ad-hoc software changes or unauthorized software
 deployment. This can also be due to local privilege elevation via locally run
 exploits or malware activity.
 
-Job details::: TBD
+Job details:::
+
+* Analyzes host activity logs where `agent.type` is `auditbeat` and
+`process.name` is commands like `compile`, `make`, or `gcc`, for example.
+* Models user activity.
+* Detects users that are rarely or unusually active compared to other users 
+  (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
 
 Required {beats}:::
 
@@ -337,7 +375,13 @@ information discovery in order to gather detailed information about system
 configuration and software versions. This may be a precursor to selection of a 
 persistence mechanism or a method of privilege elevation.  
 
-Job details::: TBD
+Job details:::
+
+* Analyzes host activity logs where `agent.type` is `auditbeat` and
+`process.name` is commands like `cat`, `grep`, or `hostname`, for example.
+* Models user activity.
+* Detects users that are rarely or unusually active compared to other users 
+  (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
 
 Required {beats}:::
 
@@ -359,7 +403,13 @@ process discovery in order to increase their understanding of software
 applications running on a target host or network. This may be a precursor to
 selection of a persistence mechanism or a method of privilege elevation.
 
-Job details::: TBD
+Job details:::
+
+* Analyzes host activity logs where `agent.type` is `auditbeat` and
+`process.name` is commands like `ps` or `top`, for example.
+* Models user activity.
+* Detects users that are rarely or unusually active compared to other users 
+  (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
 
 Required {beats}:::
 
@@ -381,7 +431,13 @@ or user discovery in order to identify currently active or primary users of a
 system. This may be a precursor to additional discovery, credential dumping or
 privilege elevation activity.
 
-Job details::: TBD
+Job details:::
+
+* Analyzes host activity logs where `agent.type` is `auditbeat` and
+`process.name` is commands like `users`, `whoami`, or `who`, for example.
+* Models user activity.
+* Detects users that are rarely or unusually active compared to other users 
+  (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
 
 Required {beats}:::
 
@@ -989,7 +1045,13 @@ Looks for anomalous access to the metadata service by an unusual process. The
 metadata service may be targeted in order to harvest credentials or user data
 scripts containing secrets.
 
-Job details::: TBD
+Job details:::
+
+* Analyzes host activity logs where `agent.type` is `winlogbeat` (Windows) and
+  `destination.ip` is the metadata service.
+* Models process activity.
+* Detects processes that are rarely or unusually active compared to other processes 
+  (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
 
 Required {beats}:::
 
@@ -1007,7 +1069,13 @@ Looks for anomalous access to the metadata service by an unusual user. The
 metadata service may be targeted in order to harvest credentials or user data
 scripts containing secrets.  
 
-Job details::: TBD
+Job details:::
+
+* Analyzes host activity logs where `agent.type` is `winlogbeat` (Windows) and
+  `destination.ip` is the metadata service.
+* Models user activity.
+* Detects users that are rarely or unusually active compared to other users 
+  (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
 
 Required {beats}:::
 


### PR DESCRIPTION
Related to https://github.com/elastic/kibana/pull/76023

This PR adds the new machine learning jobs for the Elastic Security app to the list in https://www.elastic.co/guide/en/machine-learning/master/ootb-ml-jobs-siem.html

### Preview

* https://stack-docs_1363.docs-preview.app.elstc.co/guide/en/machine-learning/master/ootb-ml-jobs-siem.html
* https://stack-docs_1363.docs-preview.app.elstc.co/guide/en/security/master/prebuilt-ml-jobs.html