### PR TITLE
[DOCS] Adds classification AUC ROC metric description

### DIFF
--- a/docs/en/stack/ml/df-analytics/ml-dfanalytics-evaluate.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfanalytics-evaluate.asciidoc
@@ -172,12 +172,13 @@ confused the different classes while it made its predictions.
 The receiver operating characteristic (ROC) curve is a plot that represents the 
 performance of the classification process at different predicted probability 
 thresholds. It compares the true positive rate for a specific class against the 
-rate of every other results ("one versus all" strategy) at the different 
-threshold levels to create the curve. Let's see an example; you have three 
-classes: `A`, `B`, and `C`, you want to calculate AUC ROC for `A`. In this case, 
-the number of correctly classified `A`s (true positives) are compared to the 
-number of misclassified `A`s (false negatives) and the number of `B`s and `C`s 
-that are misclassified as `A`s (false positives).
+rate of all the other classes combined ("one versus all" strategy) at the 
+different threshold levels to create the curve.
+
+Let's see an example. You have three classes: `A`, `B`, and `C`, you want to 
+calculate AUC ROC for `A`. In this case, the number of correctly classified `A`s 
+(true positives) are compared to the number of `B`s and `C`s that are 
+misclassified as `A`s (false positives).
 
 From this plot, you can compute the area under the curve (AUC) value, which is a 
 number between 0 and 1. The closer to 1, the better the algorithm performance.

--- a/docs/en/stack/ml/df-analytics/ml-dfanalytics-evaluate.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfanalytics-evaluate.asciidoc
@@ -176,9 +176,9 @@ rate of all the other classes combined ("one versus all" strategy) at the
 different threshold levels to create the curve.
 
 Let's see an example. You have three classes: `A`, `B`, and `C`, you want to 
-calculate AUC ROC for `A`. In this case, the number of correctly classified `A`s 
-(true positives) are compared to the number of `B`s and `C`s that are 
-misclassified as `A`s (false positives).
+calculate AUC ROC for `A`. In this case, the number of correctly classified ``A``s 
+(true positives) are compared to the number of ``B``s and ``C``s that are 
+misclassified as ``A``s (false positives).
 
 From this plot, you can compute the area under the curve (AUC) value, which is a 
 number between 0 and 1. The closer to 1, the better the algorithm performance.

--- a/docs/en/stack/ml/df-analytics/ml-dfanalytics-evaluate.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfanalytics-evaluate.asciidoc
@@ -176,9 +176,10 @@ rate of all the other classes combined ("one versus all" strategy) at the
 different threshold levels to create the curve.
 
 Let's see an example. You have three classes: `A`, `B`, and `C`, you want to 
-calculate AUC ROC for `A`. In this case, the number of correctly classified ``A``s 
-(true positives) are compared to the number of ``B``s and ``C``s that are 
+calculate AUC ROC for `A`. In this case, the number of correctly classified 
+``A``s (true positives) are compared to the number of ``B``s and ``C``s that are 
 misclassified as ``A``s (false positives).
 
 From this plot, you can compute the area under the curve (AUC) value, which is a 
-number between 0 and 1. The closer to 1, the better the algorithm performance.
+number between 0 and 1. The higher the AUC, the better the model is at 
+predicting ``A``s as ``A``s, in this case.

--- a/docs/en/stack/ml/df-analytics/ml-dfanalytics-evaluate.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfanalytics-evaluate.asciidoc
@@ -134,6 +134,7 @@ This evaluation type is suitable for evaluating {classification} models. The
 performance:
 
 * Multiclass confusion matrix
+* Area under the curve of receiver operating characteristic (AUC ROC) 
 
 [[ml-dfanalytics-mccm]]
 === Multiclass confusion matrix
@@ -163,3 +164,20 @@ The matrix contains the actual labels on the left side while the predicted
 labels are on the top. The proportion of correct and incorrect predictions is 
 broken down for each class. This enables you to examine how the {classanalysis}
 confused the different classes while it made its predictions.
+
+
+[[ml-dfanalytics-class-aucroc]]
+=== Area under the curve of receiver operating characteristic (AUC ROC)
+
+The receiver operating characteristic (ROC) curve is a plot that represents the 
+performance of the classification process at different predicted probability 
+thresholds. It compares the true positive rate for a specific class against the 
+rate of every other results ("one versus all" strategy) at the different 
+threshold levels to create the curve. Let's see an example; you have three 
+classes: `A`, `B`, and `C`, you want to calculate AUC ROC for `A`. In this case, 
+the number of correctly classified `A`s (true positives) are compared to the 
+number of misclassified `A`s (false negatives) and the number of `B`s and `C`s 
+that are misclassified as `A`s (false positives).
+
+From this plot, you can compute the area under the curve (AUC) value, which is a 
+number between 0 and 1. The closer to 1, the better the algorithm performance.

--- a/docs/en/stack/ml/df-analytics/ml-dfanalytics-evaluate.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfanalytics-evaluate.asciidoc
@@ -177,9 +177,9 @@ different threshold levels to create the curve.
 
 Let's see an example. You have three classes: `A`, `B`, and `C`, you want to 
 calculate AUC ROC for `A`. In this case, the number of correctly classified 
-``A``s (true positives) are compared to the number of ``B``s and ``C``s that are 
-misclassified as ``A``s (false positives).
+++A++s (true positives) are compared to the number of ++B++s and ++C++s that are 
+misclassified as ++A++s (false positives).
 
 From this plot, you can compute the area under the curve (AUC) value, which is a 
 number between 0 and 1. The higher the AUC, the better the model is at 
-predicting ``A``s as ``A``s, in this case.
+predicting ++A++s as ++A++s, in this case.


### PR DESCRIPTION
## Overview

This PR expands the DFA evaluation conceptual docs with the description of classification AUC ROC.


### Preview

[AUC ROC](https://stack-docs_1365.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-dfanalytics-evaluate.html#ml-dfanalytics-class-aucroc)