### PR TITLE
[DOCS] Adds Metrics AD configurations to OOTB jobs

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/index.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/index.asciidoc
@@ -42,7 +42,7 @@ include::ootb-ml-jobs-logs-ui.asciidoc[leveloffset=+2]
 
 include::ootb-ml-jobs-metricbeat.asciidoc[leveloffset=+2]
 
-include::ootb-ml-jobs-metrics-ui.asccidoc[leveloffset=+2]
+include::ootb-ml-jobs-metrics-ui.asciidoc[leveloffset=+2]
 
 include::ootb-ml-jobs-nginx.asciidoc[leveloffset=+2]
 

--- a/docs/en/stack/ml/anomaly-detection/index.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/index.asciidoc
@@ -42,6 +42,8 @@ include::ootb-ml-jobs-logs-ui.asciidoc[leveloffset=+2]
 
 include::ootb-ml-jobs-metricbeat.asciidoc[leveloffset=+2]
 
+include::ootb-ml-jobs-metrics-ui.asccidoc[leveloffset=+2]
+
 include::ootb-ml-jobs-nginx.asciidoc[leveloffset=+2]
 
 include::ootb-ml-jobs-siem.asciidoc[leveloffset=+2]

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-metrics-ui.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-metrics-ui.asciidoc
@@ -46,7 +46,7 @@ hosts_network_out::
 
 k8s_memory_usage::
 
-* For memory usage via the Metrics UI.
+* For memory usage data about Kubernetes pods in the {metrics-app}.
 * Models system memory usage.
 * Detects unusual increases in memory usage across Kubernetes pods.
 

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-metrics-ui.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-metrics-ui.asciidoc
@@ -7,20 +7,12 @@
 
 // tag::metrics-jobs[]
 These {anomaly-jobs} can be created in the
-{kibana-ref}/xpack-infra.html[Metrics app] in {kib}. When you create one of 
-these jobs, you need to select a field that splits the data to establish 
-separate baselines for the job. This is called a partion field. Each value of 
-the partition field is modeled individually which enables more independent 
-anomaly scoring.
-
-When you select partition field for a job, take into account field cardinality; 
-the number of different values that the field contains. If the partition field 
-has more than 1000 distinct values per job, you are advised that there might be 
-high memory usage.
+{observability-guide}/analyze-metrics.html[Metrics app] in {kib}.
 
 The jobs below detect anomalous memory and network behavior on hosts and 
 Kubernetes pods. For more details, see the {dfeed} and job definitions in the 
-`metrics_ui_*` folders in https://github.com/elastic/kibana/tree/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules[GitHub].
+`metrics_ui_*` folders in 
+https://github.com/elastic/kibana/tree/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules[GitHub].
 
 
 hosts_memory_usage::

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-metrics-ui.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-metrics-ui.asciidoc
@@ -1,0 +1,60 @@
+[role="xpack"]
+[[ootb-ml-jobs-metrics-ui]]
+= Metrics {anomaly-detect} configurations
+++++
+<titleabbrev>Metrics</titleabbrev>
+++++
+
+// tag::metrics-jobs[]
+These {anomaly-jobs} can be created in the
+{kibana-ref}/xpack-infra.html[Metrics app] in {kib}. 
+
+
+The jobs below detect anomalous memory and network behavior on hosts and 
+Kubernetes pods. For more details, see the {dfeed} and job definitions in the 
+`metrics_ui_*` folders in https://github.com/elastic/kibana/tree/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules[GitHub].
+
+
+hosts_memory_usage::
+
+* For memory usage via the Metrics UI.
+* Models system memory usage.
+* Detects unusual increases in memory usage across hosts.
+
+
+hosts_network_in::
+
+* For network traffic via the Metrics UI.
+* Models inbound network traffic.
+* Detects unusually high inbound traffic across hosts.
+
+
+hosts_network_out::
+
+* For network traffic via the Metrics UI. 
+* Models outbound network traffic.
+* Detects unusually high outbound traffic across hosts.
+
+
+k8s_memory_usage::
+
+* For memory usage via the Metrics UI.
+* Models system memory usage.
+* Detects unusual increases in memory usage across Kubernetes pods.
+
+
+k8s_network_in::
+
+* For network traffic via the Metrics UI. 
+* Models inbound network traffic.
+* Detects unusually high inbound traffic across Kubernetes pods.
+
+
+k8s_network_out::
+
+* For network traffic via the Metrics UI. 
+* Models outbound network traffic.
+* Detects unusually high outbound traffic across Kubernetes pods.
+
+  
+// end::metrics-jobs[]

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-metrics-ui.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-metrics-ui.asciidoc
@@ -25,21 +25,21 @@ Kubernetes pods. For more details, see the {dfeed} and job definitions in the
 
 hosts_memory_usage::
 
-* For memory usage via the Metrics UI.
+* For memory usage data about hosts in the {metrics-app}.
 * Models system memory usage.
 * Detects unusual increases in memory usage across hosts.
 
 
 hosts_network_in::
 
-* For network traffic via the Metrics UI.
+* For network traffic across hosts in the {metrics-app}.
 * Models inbound network traffic.
 * Detects unusually high inbound traffic across hosts.
 
 
 hosts_network_out::
 
-* For network traffic via the Metrics UI. 
+* For network traffic across hosts in the {metrics-app}. 
 * Models outbound network traffic.
 * Detects unusually high outbound traffic across hosts.
 
@@ -53,14 +53,14 @@ k8s_memory_usage::
 
 k8s_network_in::
 
-* For network traffic via the Metrics UI. 
+* For network traffic accross Kubernetes pods in the {metrics-app}. 
 * Models inbound network traffic.
 * Detects unusually high inbound traffic across Kubernetes pods.
 
 
 k8s_network_out::
 
-* For network traffic via the Metrics UI. 
+* For network traffic across Kubernetes pods in the {metrics-app}. 
 * Models outbound network traffic.
 * Detects unusually high outbound traffic across Kubernetes pods.
 

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-metrics-ui.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-metrics-ui.asciidoc
@@ -7,8 +7,16 @@
 
 // tag::metrics-jobs[]
 These {anomaly-jobs} can be created in the
-{kibana-ref}/xpack-infra.html[Metrics app] in {kib}. 
+{kibana-ref}/xpack-infra.html[Metrics app] in {kib}. When you create one of 
+these jobs, you need to select a field that splits the data to establish 
+separate baselines for the job. This is called a partion field. Each value of 
+the partition field is modeled individually which enables more independent 
+anomaly scoring.
 
+When you select partition field for a job, take into account field cardinality; 
+the number of different values that the field contains. If the partition field 
+has more than 1000 distinct values per job, you are advised that there might be 
+high memory usage.
 
 The jobs below detect anomalous memory and network behavior on hosts and 
 Kubernetes pods. For more details, see the {dfeed} and job definitions in the 

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -15,6 +15,7 @@ the {anomaly-jobs} that are ready to use via {kib}.
 * <<ootb-ml-jobs-auditbeat>>
 * <<ootb-ml-jobs-logs-ui>>
 * <<ootb-ml-jobs-metricbeat>>
+* <<ootb-ml-jobs-metrics-ui>>
 * <<ootb-ml-jobs-nginx>>
 * <<ootb-ml-jobs-siem>>
 * <<ootb-ml-jobs-uptime>>


### PR DESCRIPTION
## Overview

This PR adds documentation to Metrics integration ML modules added in https://github.com/elastic/kibana/pull/76460

### Preview

[Metrics jobs](https://stack-docs_1366.docs-preview.app.elstc.co/guide/en/machine-learning/master/ootb-ml-jobs-metrics-ui.html)