### PR TITLE
[7.x] [DOCS] Adds classification AUC ROC metric description (#1365)

### DIFF
--- a/docs/en/stack/ml/df-analytics/ml-dfanalytics-evaluate.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfanalytics-evaluate.asciidoc
@@ -134,6 +134,7 @@ This evaluation type is suitable for evaluating {classification} models. The
 performance:
 
 * Multiclass confusion matrix
+* Area under the curve of receiver operating characteristic (AUC ROC) 
 
 [[ml-dfanalytics-mccm]]
 === Multiclass confusion matrix
@@ -163,3 +164,22 @@ The matrix contains the actual labels on the left side while the predicted
 labels are on the top. The proportion of correct and incorrect predictions is 
 broken down for each class. This enables you to examine how the {classanalysis}
 confused the different classes while it made its predictions.
+
+
+[[ml-dfanalytics-class-aucroc]]
+=== Area under the curve of receiver operating characteristic (AUC ROC)
+
+The receiver operating characteristic (ROC) curve is a plot that represents the 
+performance of the classification process at different predicted probability 
+thresholds. It compares the true positive rate for a specific class against the 
+rate of all the other classes combined ("one versus all" strategy) at the 
+different threshold levels to create the curve.
+
+Let's see an example. You have three classes: `A`, `B`, and `C`, you want to 
+calculate AUC ROC for `A`. In this case, the number of correctly classified 
+++A++s (true positives) are compared to the number of ++B++s and ++C++s that are 
+misclassified as ++A++s (false positives).
+
+From this plot, you can compute the area under the curve (AUC) value, which is a 
+number between 0 and 1. The higher the AUC, the better the model is at 
+predicting ++A++s as ++A++s, in this case.


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Adds classification AUC ROC metric description (#1365)