### PR TITLE
[DOCS] Fix classification score details in example

### DIFF
--- a/docs/en/stack/ml/df-analytics/flightdata-classification.asciidoc
+++ b/docs/en/stack/ml/df-analytics/flightdata-classification.asciidoc
@@ -316,14 +316,14 @@ or testing data set. You can filter the table and the confusion matrix such that
 they contain only testing or training data. You can also enable histogram charts
 to get a better understanding of the distribution of values in your data.
 
-If you examine this destination index more closely in the *Discover* app in 
-{kib} or use the standard {es} search command, you can see that the analysis 
-predicts the probability of all possible classes for the dependent variable (in 
-a `top_classes` object). In this case, there are two classes: `true` and 
-`false`. The most probable class is the prediction, which is what's shown in the
-{classification} results table. If you want to understand how sure the model is
-about the prediction, however, you might want to examine the class probability
-values. A higher number means that the model is more confident.
+If you want to understand how certain the model is about each prediction, you
+can examine its probability and score (`ml.prediction_probability` and
+`ml.prediction_score`). The higher these values are, the more confident the
+model is that the data point belongs to the named class. If you examine the
+destination index more closely in the *Discover* app in {kib} or use the
+standard {es} search command, you can see that the analysis predicts the
+probability of all possible classes for the dependent variable. The 
+`top_classes` object contains the predicted classes with the highest scores.
 
 .API example
 [%collapsible]
@@ -333,7 +333,6 @@ values. A higher number means that the model is more confident.
 GET df-flight-delayed/_search
 --------------------------------------------------
 // TEST[skip:TBD]
-
 
 The snippet below shows a part of a document with the annotated results:
 
@@ -372,14 +371,12 @@ The snippet below shows a part of a document with the annotated results:
           }
 ----
 <1> An array of values specifying the probability of the prediction and the 
-`class_score` for each class. 
+score for each class. 
 
-The `top_classes` object contains the predicted classes with the highest 
-scores. The `class_probability` is a value between 0 and 1. The higher the 
-number, the more confident the model is that the data point belongs to the named 
-class. In the example above, `false` has a `class_probability` of 0.91 while 
-`true` has only 0.08, so the prediction will be `false`. The `class_score` is a 
-function of the probability.
+The class with the highest score is the prediction. In this example, `false` has
+a `class_score` of 0.37 while `true` has only 0.08, so the prediction will be
+`false`. For more details about these values, see
+<<dfa-classification-interpret>>.
 
 ////
 It is chosen so that the decision to assign the 


### PR DESCRIPTION
The machine learning [classification example](https://www.elastic.co/guide/en/machine-learning/master/flightdata-classification.html) currently states that the "most probable class is the prediction", but it is the class with the highest score. This PR fixes the text in that section.

### Preview

https://stack-docs_1368.docs-preview.app.elstc.co/guide/en/machine-learning/master/flightdata-classification.html