### PR TITLE
[7.x] [DOCS] Adds DFA limitation item about number of training documents (#1370)

### DIFF
--- a/docs/en/stack/ml/df-analytics/ml-dfa-limitations.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-limitations.asciidoc
@@ -58,6 +58,17 @@ training percent. Run a few {dfanalytics-jobs} to see how the runtime scales
 with the increased number of data points and how the quality of results scales
 with an increased training percentage.
 
+
+[float]
+[[dfa-training-docs]]
+== {dfanalytics-jobs-cap} cannot use more than 2^32^ documents for training
+
+A {dfanalytics-job} that would use more than 2^32^ documents for training cannot 
+be started. The limitation applies only for documents participating in training 
+the model. If your source index contains more than 2^32^ documents, set the 
+`training_percent` to a value that represents less than 2^32^ documents.
+
+
 [float]
 [[dfa-missing-fields-limitations]]
 == Documents with missing values in analyzed fields are skipped


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Adds DFA limitation item about number of training documents (#1370)