### PR TITLE
[7.x] docs: update apm include (#1387)

### DIFF
--- a/docs/en/install-upgrade/highlights.asciidoc
+++ b/docs/en/install-upgrade/highlights.asciidoc
@@ -1,5 +1,5 @@
 [[elastic-stack-highlights]]
-== Highlights 
+== Highlights
 
 Each release brings new features and product improvements. This section
 highlights notable new features and enhancements in {minor-version}].
@@ -9,7 +9,6 @@ highlights notable new features and enhancements in {minor-version}].
 ** <<elasticsearch-highlights,{es}>>
 ** <<kibana-higlights,{kib}>>
 
-////
 [[apm-highlights]]
 === APM highlights
 ++++
@@ -18,10 +17,9 @@ highlights notable new features and enhancements in {minor-version}].
 
 This list summarizes the most important enhancements in APM.
 For the complete list, go to
-{apm-overview-ref-v}/apm-release-notes.html[APM release highlights].
+{apm-overview-ref-v}/whats-new.html[APM release highlights].
 
-include::{apm-repo-dir}/apm-release-notes.asciidoc[tag=notable-v7-highlights]
-////
+include::{apm-repo-dir}/whats-new.asciidoc[tag=notable-highlights]
 
 [[beats-highlights]]
 === {beats} highlights

--- a/docs/en/install-upgrade/highlights.asciidoc
+++ b/docs/en/install-upgrade/highlights.asciidoc
@@ -9,6 +9,7 @@ highlights notable new features and enhancements in {minor-version}].
 ** <<elasticsearch-highlights,{es}>>
 ** <<kibana-higlights,{kib}>>
 
+////
 [[apm-highlights]]
 === APM highlights
 ++++
@@ -20,6 +21,7 @@ For the complete list, go to
 {apm-overview-ref-v}/whats-new.html[APM release highlights].
 
 include::{apm-repo-dir}/whats-new.asciidoc[tag=notable-highlights]
+////
 
 [[beats-highlights]]
 === {beats} highlights


### PR DESCRIPTION
Backports the following commits to 7.x:
 - docs: update apm include (#1387)