### PR TITLE
[7.9] docs: update apm include (#1387)

### DIFF
--- a/docs/en/install-upgrade/highlights.asciidoc
+++ b/docs/en/install-upgrade/highlights.asciidoc
@@ -17,9 +17,9 @@ highlights notable new features and enhancements in {minor-version}].
 
 This list summarizes the most important enhancements in APM.
 For the complete list, go to
-{apm-overview-ref-v}/apm-release-notes.html[APM release highlights].
+{apm-overview-ref-v}/whats-new.html[APM release highlights].
 
-include::{apm-repo-dir}/apm-release-notes.asciidoc[tag=notable-v79-highlights]
+include::{apm-repo-dir}/whats-new.asciidoc[tag=notable-highlights]
 
 [[beats-highlights]]
 === {beats} highlights


### PR DESCRIPTION
Backports the following commits to 7.9:
 - docs: update apm include (#1387)