### PR TITLE
[DOCS] Changes links in OOTB job descriptions

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-logs-ui.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-logs-ui.asciidoc
@@ -7,8 +7,8 @@
 
 // tag::logs-jobs[]
 These {anomaly-jobs} appear by default in the
-{kibana-ref}/xpack-logs.html[Logs app] in {kib}. For more details, see the
-{dfeed} and job definitions in the `logs_ui_*` folders in
+{observability-guide}/monitor-logs.html[{logs-app}] in {kib}. For more details, 
+see the {dfeed} and job definitions in the `logs_ui_*` folders in
 https://github.com/elastic/kibana/tree/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules[GitHub].
 
 log_entry_categories_count::

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-metrics-ui.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-metrics-ui.asciidoc
@@ -7,7 +7,7 @@
 
 // tag::metrics-jobs[]
 These {anomaly-jobs} can be created in the
-{observability-guide}/analyze-metrics.html[Metrics app] in {kib}.
+{observability-guide}/analyze-metrics.html[{metrics-app}] in {kib}.
 
 The jobs below detect anomalous memory and network behavior on hosts and 
 Kubernetes pods. For more details, see the {dfeed} and job definitions in the 

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-uptime.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-uptime.asciidoc
@@ -7,8 +7,7 @@
 // tag::uptime-jobs[]
 
 If you have appropriate {heartbeat} data in {es}, you can enable this
-{anomaly-job} in the 
-{uptime-guide}/uptime-overview.html[Elastic Uptime] app in {kib}. For more
+{anomaly-job} in the Elastic Uptime app in {kib}. For more
 details, see the {dfeed} and job definitions in 
 https://github.com/elastic/kibana/tree/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/uptime_heartbeat/ml[GitHub].
 


### PR DESCRIPTION
## Overview

This PR changes the links on the metrics and logs related OOTB job pages to point to the Observability guide instead of the Kibana docs. It also removes the link from the uptime OOTB job page.

### Preview

[Logs jobs](https://stack-docs_1402.docs-preview.app.elstc.co/guide/en/machine-learning/master/ootb-ml-jobs-logs-ui.html)
[Uptime jobs](https://stack-docs_1402.docs-preview.app.elstc.co/guide/en/machine-learning/master/ootb-ml-jobs-uptime.html)

### Note

Backport these changes to 7.x, and 7.10 after https://github.com/elastic/kibana/pull/79978 is merged. Then add the uptime link to the uptime OOTB job page in a separate PR.