### PR TITLE
[7.x][DOCS] Remove links from OOTB jobs

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-logs-ui.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-logs-ui.asciidoc
@@ -6,9 +6,8 @@
 ++++
 
 // tag::logs-jobs[]
-These {anomaly-jobs} appear by default in the
-{kibana-ref}/xpack-logs.html[Logs app] in {kib}. For more details, see the
-{dfeed} and job definitions in the `logs_ui_*` folders in
+These {anomaly-jobs} appear by default in the Logs app in {kib}. For more 
+details, see the {dfeed} and job definitions in the `logs_ui_*` folders in
 https://github.com/elastic/kibana/tree/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules[GitHub].
 
 log_entry_categories_count::

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-metrics-ui.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-metrics-ui.asciidoc
@@ -6,8 +6,7 @@
 ++++
 
 // tag::metrics-jobs[]
-These {anomaly-jobs} can be created in the
-{observability-guide}/analyze-metrics.html[Metrics app] in {kib}.
+These {anomaly-jobs} can be created in the Metrics app in {kib}.
 
 The jobs below detect anomalous memory and network behavior on hosts and 
 Kubernetes pods. For more details, see the {dfeed} and job definitions in the 

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-uptime.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-uptime.asciidoc
@@ -7,9 +7,8 @@
 // tag::uptime-jobs[]
 
 If you have appropriate {heartbeat} data in {es}, you can enable this
-{anomaly-job} in the 
-{uptime-guide}/uptime-overview.html[Elastic Uptime] app in {kib}. For more
-details, see the {dfeed} and job definitions in 
+{anomaly-job} in the Elastic Uptime app in {kib}. For more details, see the 
+{dfeed} and job definitions in 
 https://github.com/elastic/kibana/tree/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/uptime_heartbeat/ml[GitHub].
 
 high_latency_by_geo::


### PR DESCRIPTION
## Overview

This PR removes the links that point to the Kibana guide from the Metrics, Logs, and Uptime related OOTB job definition pages. https://github.com/elastic/kibana/pull/79978 will move Metrics, Logs, and Uptime related content from the Kibana guide to the Observability guide. As the links handled in this PR point to the Kibana guide, they make the docs CI check fail in the above-mentioned PR. Removal of these links will solve the issue.

Applies to 7.x and 7.10.

### Preview

[Metrics OOTB jobs]()
[Logs OOTB jobs]()
[Uptime OOTB jobs]()

### Note

**Add the appropriate links, after https://github.com/elastic/kibana/pull/79978 is merged.**