### PR TITLE
Update flightdata-classification.asciidoc

### DIFF
--- a/docs/en/stack/ml/df-analytics/flightdata-classification.asciidoc
+++ b/docs/en/stack/ml/df-analytics/flightdata-classification.asciidoc
@@ -410,7 +410,7 @@ matrix. You can optionally filter the table to contain only testing data so you
 can see how well the model performs on previously unseen data. In this example,
 there are 2952 documents in the testing data that have the `true` class. 1893 of
 them are predicted as `false`; this is called a _false negative_. 1059 are
-predicted correctly as `true`; this is called a _true positive_. The confusion
+predicted correctly as `true`; this is called a _true negative_. The confusion
 matrix therefore shows us that 36% of the actual `true` values were correctly
 predicted and 64% were incorrectly predicted in the test data set.
 


### PR DESCRIPTION
This paragraph is explaining the bottom row of a confusion matrix.  It correctly states the first column as 'false negative,' but then incorrectly says the second column (i.e. bottom right) is a true positive. TP is in the upper left.  See https://en.wikipedia.org/wiki/Confusion_matrix    It's not called a 'confusion' matrix for nothing!   Easy to mislabel. This is particularly confusing (haha) because the categories are True and False, which muddles the idea of Positive (row 1) vs Negative (row 2) predictions.