### PR TITLE
[DOCS] Update coming tags in Installation and Upgrade Guide

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -28,7 +28,7 @@ Upgrade Assistant provides information about which {dfeeds} need to be updated.
 <titleabbrev>APM</titleabbrev>
 ++++
 
-coming::[7.9.0]
+coming::[7.10.0]
 
 This list summarizes the most important breaking changes in APM. 
 For the complete list, go to {apm-server-ref}/breaking-changes.html[APM Server breaking changes].
@@ -41,7 +41,7 @@ For the complete list, go to {apm-server-ref}/breaking-changes.html[APM Server b
 <titleabbrev>Beats</titleabbrev>
 ++++
 
-coming::[7.9.0]
+coming::[7.10.0]
 
 This list summarizes the most important breaking changes in Beats. For the
 complete list, go to {beats-ref}/breaking-changes.html[Beats breaking changes].
@@ -56,12 +56,12 @@ complete list, go to {beats-ref}/breaking-changes.html[Beats breaking changes].
 <titleabbrev>{es}</titleabbrev>
 ++++
 
-coming::[7.9.0]
+coming::[7.10.0]
 
 This list summarizes the most important breaking changes in {es} {version}. For
 the complete list, go to {ref}/breaking-changes.html[{es} breaking changes].
 
-//include::{es-repo-dir}/migration/migrate_7_8.asciidoc[tag=notable-breaking-changes]
+include::{es-repo-dir}/migration/migrate_7_10.asciidoc[tag=notable-breaking-changes]
 
 [[elasticsearch-hadoop-breaking-changes]]
 === {es} Hadoop breaking changes
@@ -70,7 +70,7 @@ the complete list, go to {ref}/breaking-changes.html[{es} breaking changes].
 <titleabbrev>{es} Hadoop</titleabbrev>
 ++++
 
-coming::[7.9.0]
+coming::[7.10.0]
 
 This list summarizes the most important breaking changes in {es} Hadoop {version}.
 For the complete list, go to
@@ -85,7 +85,7 @@ include::{hadoop-repo-dir}/appendix/breaking.adoc[tag=notable-v7-breaking-change
 <titleabbrev>{kib}</titleabbrev>
 ++++
 
-coming::[7.9.0]
+coming::[7.10.0]
 
 This list summarizes the most important breaking changes in {kib} {version}. For
 the complete list, go to {kibana-ref}/breaking-changes.html[{kib} breaking changes].
@@ -99,7 +99,7 @@ the complete list, go to {kibana-ref}/breaking-changes.html[{kib} breaking chang
 <titleabbrev>{ls}</titleabbrev>
 ++++
 
-coming::[7.9.0]
+coming::[7.10.0]
 
 This list summarizes the most important breaking changes in {ls} {version}. For
 the complete list, go to

--- a/docs/en/install-upgrade/highlights.asciidoc
+++ b/docs/en/install-upgrade/highlights.asciidoc
@@ -29,7 +29,7 @@ include::{apm-repo-dir}/whats-new.asciidoc[tag=notable-highlights]
 <titleabbrev>Beats</titleabbrev>
 ++++
 
-coming::[7.9.0]
+coming::[7.10.0]
 
 This list summarizes the most important enhancements in {beats} {minor-version}.
 
@@ -42,7 +42,7 @@ include::{beats-repo-dir}/release-notes/whats-new.asciidoc[tag=notable-highlight
 <titleabbrev>{es}</titleabbrev>
 ++++
 
-coming::[7.9.0]
+coming::[7.10.0]
 
 This list summarizes the most important enhancements in {es} {minor-version}].
 For the complete list, go to {ref}/release-highlights.html[{es} release highlights].
@@ -62,7 +62,7 @@ include::{es-repo-dir}/reference/release-notes/highlights.asciidoc[tag=notable-h
 <titleabbrev>{kib}</titleabbrev>
 ++++
 
-coming::[7.9.0]
+coming::[7.10.0]
 
 This list summarizes the most important enhancements in {kib} {minor-version}].
 


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/63479

This PR updates the "coming" tags and enables the Elasticsearch breaking changes content.