### PR TITLE
[7.x] [DOCS] Adds link to Uptime OOTB job description. (#1414)

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-uptime.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-uptime.asciidoc
@@ -7,7 +7,8 @@
 // tag::uptime-jobs[]
 
 If you have appropriate {heartbeat} data in {es}, you can enable this
-{anomaly-job} in the Elastic Uptime app in {kib}. For more
+{anomaly-job} in the 
+{observability-guide}/monitor-uptime.html[{uptime-app}] in {kib}. For more 
 details, see the {dfeed} and job definitions in 
 https://github.com/elastic/kibana/tree/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/uptime_heartbeat/ml[GitHub].
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Adds link to Uptime OOTB job description. (#1414)