### PR TITLE
[DOCS] Updating cross links

### DIFF
--- a/docs/en/getting-started/get-started-stack.asciidoc
+++ b/docs/en/getting-started/get-started-stack.asciidoc
@@ -189,8 +189,8 @@ endif::[]
 For other operating systems, go to the
 https://www.elastic.co/downloads/elasticsearch[{es} download] page.
 
-TIP: The default {ref}/cluster.name.html[cluster.name] and
-{ref}/node.name.html[node.name] are `elasticsearch` and your hostname,
+TIP: The default {ref}/important-settings.html#cluster.name.html[cluster.name] and
+{ref}/important-settings.html#node.name[node.name] are `elasticsearch` and your hostname,
 respectively. If you plan to keep using this cluster or add more nodes, it is a
 good idea to change these default values to unique names. For details about
 changing these and other settings in the `elasticsearch.yml` file, see


### PR DESCRIPTION
[#63849](https://github.com/elastic/elasticsearch/pull/63849) combines all important configuration settings for ES into a single page. This PR updates two cross links to fix the build errors in #63849.