### PR TITLE
[DOCS] Changes links in stack getting started to point to the Observability guide

### DIFF
--- a/docs/en/getting-started/get-started-stack.asciidoc
+++ b/docs/en/getting-started/get-started-stack.asciidoc
@@ -681,9 +681,9 @@ how, read:
 
 Want to get up and running quickly with metrics monitoring and
 centralized log analytics? Try out the Metrics app and the Logs app in {kib}.
-For more details, see the 
-{observability-guide}/analyze-metrics.html[Metrics Monitoring Guide] and the 
-{observability-guide}/monitor-logs.html[Logs Monitoring Guide].
+For more details, see  
+{observability-guide}/analyze-metrics.html[Analyze metrics] and  
+{observability-guide}/monitor-logs.html[Monitor logs].
 
 Later, when you're ready to set up a production environment, also see the
 {stack-ref}/installing-elastic-stack.html[{stack} Installation and Upgrade

--- a/docs/en/getting-started/get-started-stack.asciidoc
+++ b/docs/en/getting-started/get-started-stack.asciidoc
@@ -681,8 +681,9 @@ how, read:
 
 Want to get up and running quickly with metrics monitoring and
 centralized log analytics? Try out the Metrics app and the Logs app in {kib}.
-For more details, see the {metrics-guide}[Metrics Monitoring Guide]
-and the {logs-guide}[Logs Monitoring Guide].
+For more details, see the 
+{observability-guide}/analyze-metrics.html[Metrics Monitoring Guide] and the 
+{observability-guide}/monitor-logs.html[Logs Monitoring Guide].
 
 Later, when you're ready to set up a production environment, also see the
 {stack-ref}/installing-elastic-stack.html[{stack} Installation and Upgrade


### PR DESCRIPTION
## Overview

This PR updates the links at the end of the `Getting started with the Elastic Stack` page to point to the relevant pages in the Observability guide.

### Related PR

https://github.com/elastic/docs/pull/1985

### Preview

[GS with the Stack – What's next?](https://stack-docs_1422.docs-preview.app.elstc.co/guide/en/elastic-stack-get-started/master/get-started-elastic-stack.html#whats_next)