### PR TITLE
[7.10] [DOCS] Changes links in stack getting started to point to the Observability guide (#1422)

### DIFF
--- a/docs/en/getting-started/get-started-stack.asciidoc
+++ b/docs/en/getting-started/get-started-stack.asciidoc
@@ -681,8 +681,9 @@ how, read:
 
 Want to get up and running quickly with metrics monitoring and
 centralized log analytics? Try out the Metrics app and the Logs app in {kib}.
-For more details, see the {metrics-guide}[Metrics Monitoring Guide]
-and the {logs-guide}[Logs Monitoring Guide].
+For more details, see  
+{observability-guide}/analyze-metrics.html[Analyze metrics] and  
+{observability-guide}/monitor-logs.html[Monitor logs].
 
 Later, when you're ready to set up a production environment, also see the
 {stack-ref}/installing-elastic-stack.html[{stack} Installation and Upgrade


### PR DESCRIPTION
Backports the following commits to 7.10:
 - [DOCS] Changes links in stack getting started to point to the Observability guide (#1422)