### PR TITLE
docs: change APM to Observability highlights

### DIFF
--- a/docs/en/install-upgrade/highlights.asciidoc
+++ b/docs/en/install-upgrade/highlights.asciidoc
@@ -4,25 +4,22 @@
 Each release brings new features and product improvements. This section
 highlights notable new features and enhancements in {minor-version}.
 
-** <<apm-highlights,APM>>
+** <<observability-highlights,Observability>>
 ** <<beats-highlights,Beats>>
 ** <<elasticsearch-highlights,{es}>>
 ** <<kibana-higlights,{kib}>>
 
-[[apm-highlights]]
-=== APM highlights
+[[observability-highlights]]
+=== Observability highlights
 ++++
-<titleabbrev>APM</titleabbrev>
+<titleabbrev>Observability</titleabbrev>
 ++++
 
 coming[8.0.0]
 
-This list summarizes the most important enhancements in APM.
-For the complete list, go to
-{apm-overview-ref-v}/whats-new.html[APM release highlights].
+This list summarizes the most important enhancements in Observability {minor-version}.
 
-include::{apm-repo-dir}/whats-new.asciidoc[tag=notable-highlights]
-
+include::{obs-repo-dir}/whats-new.asciidoc[tag=whats-new]
 
 [[beats-highlights]]
 === {beats} highlights

--- a/docs/en/install-upgrade/index.asciidoc
+++ b/docs/en/install-upgrade/index.asciidoc
@@ -7,6 +7,7 @@
 :hadoop-repo-dir:    {elasticsearch-hadoop-root}/docs/src/reference/asciidoc
 :kib-repo-dir:       {kibana-root}/docs
 :ls-repo-dir:        {logstash-root}/docs
+:obs-repo-dir:       {observability-docs-root}/docs/en/observability
 
 include::{docs-root}/shared/versions/stack/{source_branch}.asciidoc[]
 include::{docs-root}/shared/attributes.asciidoc[]
@@ -20,3 +21,5 @@ include::upgrading-stack.asciidoc[]
 include::highlights.asciidoc[]
 
 include::breaking.asciidoc[]
+
+include::redirects.asciidoc[]

--- a/docs/en/install-upgrade/redirects.asciidoc
+++ b/docs/en/install-upgrade/redirects.asciidoc
@@ -1,0 +1,10 @@
+["appendix",role="exclude",id="redirects"]
+= Deleted pages
+
+The following pages have moved or been deleted.
+
+[role="exclude",id="apm-highlights"]
+=== APM highlights
+
+This page no longer exists.
+See <<observability-highlights>> for a list of what's new in Elastic Observability.


### PR DESCRIPTION
## Summary

Replaces the APM highlights with Observability.

## Preview

https://stack-docs_1435.docs-preview.app.elstc.co/guide/en/elastic-stack/master/observability-highlights.html

## Related

For https://github.com/elastic/observability-docs/issues/222.
For https://github.com/elastic/apm-server/pull/4385.