### PR TITLE
[7.10] docs: change APM to Observability (#1435)

### DIFF
--- a/docs/en/install-upgrade/highlights.asciidoc
+++ b/docs/en/install-upgrade/highlights.asciidoc
@@ -4,24 +4,22 @@
 Each release brings new features and product improvements. This section
 highlights notable new features and enhancements in {minor-version}].
 
-//** <<apm-highlights,APM>>
+** <<observability-highlights,Observability>>
 ** <<beats-highlights,Beats>>
 ** <<elasticsearch-highlights,{es}>>
 ** <<kibana-higlights,{kib}>>
 
-////
-[[apm-highlights]]
-=== APM highlights
+[[observability-highlights]]
+=== Observability highlights
 ++++
-<titleabbrev>APM</titleabbrev>
+<titleabbrev>Observability</titleabbrev>
 ++++
 
-This list summarizes the most important enhancements in APM.
-For the complete list, go to
-{apm-overview-ref-v}/whats-new.html[APM release highlights].
+coming::[7.10.0]
 
-include::{apm-repo-dir}/whats-new.asciidoc[tag=notable-highlights]
-////
+This list summarizes the most important enhancements in Observability {minor-version}.
+
+include::{obs-repo-dir}/whats-new.asciidoc[tag=whats-new]
 
 [[beats-highlights]]
 === {beats} highlights

--- a/docs/en/install-upgrade/index.asciidoc
+++ b/docs/en/install-upgrade/index.asciidoc
@@ -7,6 +7,7 @@
 :hadoop-repo-dir:    {elasticsearch-hadoop-root}/docs/src/reference/asciidoc
 :kib-repo-dir:       {kibana-root}/docs
 :ls-repo-dir:        {logstash-root}/docs
+:obs-repo-dir:       {observability-docs-root}/docs/en/observability
 
 include::{docs-root}/shared/versions/stack/{source_branch}.asciidoc[]
 include::{docs-root}/shared/attributes.asciidoc[]
@@ -20,3 +21,5 @@ include::upgrading-stack.asciidoc[]
 include::highlights.asciidoc[]
 
 include::breaking.asciidoc[]
+
+include::redirects.asciidoc[]

--- a/docs/en/install-upgrade/redirects.asciidoc
+++ b/docs/en/install-upgrade/redirects.asciidoc
@@ -1,0 +1,10 @@
+["appendix",role="exclude",id="redirects"]
+= Deleted pages
+
+The following pages have moved or been deleted.
+
+[role="exclude",id="apm-highlights"]
+=== APM highlights
+
+This page no longer exists.
+See <<observability-highlights>> for a list of what's new in Elastic Observability.


### PR DESCRIPTION
Backports the following commits to 7.10:
 - docs: change APM to Observability (#1435)