### PR TITLE
[7.x] Redirect Beats highlights to the observability what's new topic (#1440)

### DIFF
--- a/docs/en/install-upgrade/highlights.asciidoc
+++ b/docs/en/install-upgrade/highlights.asciidoc
@@ -5,7 +5,6 @@ Each release brings new features and product improvements. This section
 highlights notable new features and enhancements in {minor-version}].
 
 ** <<observability-highlights,Observability>>
-** <<beats-highlights,Beats>>
 ** <<elasticsearch-highlights,{es}>>
 ** <<kibana-higlights,{kib}>>
 
@@ -21,18 +20,6 @@ This list summarizes the most important enhancements in Observability {minor-ver
 
 include::{obs-repo-dir}/whats-new.asciidoc[tag=whats-new]
 
-[[beats-highlights]]
-=== {beats} highlights
-++++
-<titleabbrev>Beats</titleabbrev>
-++++
-
-coming::[7.11.0]
-
-This list summarizes the most important enhancements in {beats} {minor-version}.
-
-include::{beats-repo-dir}/release-notes/whats-new.asciidoc[tag=notable-highlights]
-
 [[elasticsearch-highlights]]
 === {es} highlights
 [subs="attributes"]
@@ -42,7 +29,7 @@ include::{beats-repo-dir}/release-notes/whats-new.asciidoc[tag=notable-highlight
 
 coming::[7.11.0]
 
-This list summarizes the most important enhancements in {es} {minor-version}].
+This list summarizes the most important enhancements in {es} {minor-version}.
 For the complete list, go to {ref}/release-highlights.html[{es} release highlights].
 
 ////

--- a/docs/en/install-upgrade/redirects.asciidoc
+++ b/docs/en/install-upgrade/redirects.asciidoc
@@ -8,3 +8,9 @@ The following pages have moved or been deleted.
 
 This page no longer exists.
 See <<observability-highlights>> for a list of what's new in Elastic Observability.
+
+[role="exclude",id="beats-highlights"]
+=== Beats highlights
+
+This page no longer exists.
+See <<observability-highlights>> for a list of what's new in Elastic Observability.


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Redirect Beats highlights to the observability what's new topic (#1440)