### PR TITLE
Remove coming tags

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -28,8 +28,6 @@ Upgrade Assistant provides information about which {dfeeds} need to be updated.
 <titleabbrev>APM</titleabbrev>
 ++++
 
-coming::[7.10.0]
-
 This list summarizes the most important breaking changes in APM.
 For the complete list, go to {apm-server-ref}/breaking-changes.html[APM Server breaking changes].
 
@@ -40,8 +38,6 @@ include::{apm-repo-dir}/apm-breaking-changes.asciidoc[tag=notable-breaking-chang
 ++++
 <titleabbrev>Beats</titleabbrev>
 ++++
-
-coming::[7.10.0]
 
 This list summarizes the most important breaking changes in Beats. For the
 complete list, go to {beats-ref}/breaking-changes.html[Beats breaking changes].
@@ -56,8 +52,6 @@ complete list, go to {beats-ref}/breaking-changes.html[Beats breaking changes].
 <titleabbrev>{es}</titleabbrev>
 ++++
 
-coming::[7.10.0]
-
 This list summarizes the most important breaking changes in {es} {version}. For
 the complete list, go to {ref}/breaking-changes.html[{es} breaking changes].
 
@@ -69,8 +63,6 @@ include::{es-repo-dir}/migration/migrate_7_10.asciidoc[tag=notable-breaking-chan
 ++++
 <titleabbrev>{es} Hadoop</titleabbrev>
 ++++
-
-coming::[7.10.0]
 
 This list summarizes the most important breaking changes in {es} Hadoop {version}.
 For the complete list, go to
@@ -85,8 +77,6 @@ include::{hadoop-repo-dir}/appendix/breaking.adoc[tag=notable-v7-breaking-change
 <titleabbrev>{kib}</titleabbrev>
 ++++
 
-coming::[7.10.0]
-
 This list summarizes the most important breaking changes in {kib} {version}. For
 the complete list, go to {kibana-ref}/breaking-changes.html[{kib} breaking changes].
 
@@ -98,8 +88,6 @@ include::{kib-repo-dir}/migration/migrate_7_10.asciidoc[tag=notable-breaking-cha
 ++++
 <titleabbrev>{ls}</titleabbrev>
 ++++
-
-coming::[7.10.0]
 
 This list summarizes the most important breaking changes in {ls} {version}. For
 the complete list, go to

--- a/docs/en/install-upgrade/highlights.asciidoc
+++ b/docs/en/install-upgrade/highlights.asciidoc
@@ -14,8 +14,6 @@ highlights notable new features and enhancements in {minor-version}].
 <titleabbrev>Observability</titleabbrev>
 ++++
 
-coming::[7.10.0]
-
 This list summarizes the most important enhancements in Observability {minor-version}.
 
 include::{obs-repo-dir}/whats-new.asciidoc[tag=whats-new]
@@ -26,8 +24,6 @@ include::{obs-repo-dir}/whats-new.asciidoc[tag=whats-new]
 ++++
 <titleabbrev>{es}</titleabbrev>
 ++++
-
-coming::[7.10.0]
 
 This list summarizes the most important enhancements in {es} {minor-version}.
 For the complete list, go to {ref}/release-highlights.html[{es} release highlights].
@@ -44,8 +40,6 @@ include::{es-repo-dir}/release-notes/highlights.asciidoc[tag=notable-highlights]
 ++++
 <titleabbrev>{kib}</titleabbrev>
 ++++
-
-coming::[7.10.0]
 
 This list summarizes the most important enhancements in {kib} {minor-version}.
 


### PR DESCRIPTION
This PR removes the "coming" tags from the Installation and Upgrade Guide (https://www.elastic.co/guide/en/elastic-stack/7.10/index.html)