### PR TITLE
[DOCS] Adds scroll_size related recommendation to AD at scale

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/anomaly-detection-scale.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/anomaly-detection-scale.asciidoc
@@ -132,7 +132,7 @@ new job.
 
 The `scroll_size` parameter of a {dfeed} specifies the number of hits to return 
 from {es} searches. The higher the `scroll_size` the more results are returned 
-by the search. When your {anomaly-job} has a high throughput, increasing 
+by a single search. When your {anomaly-job} has a high throughput, increasing 
 `scroll_size` may decrease the time the job needs to analyze incoming data. This 
 only applies to {dfeeds} that do not use aggregations. You cannot increase 
 `scroll_size` to more than the value of `index.max_result_window` which is 

--- a/docs/en/stack/ml/anomaly-detection/anomaly-detection-scale.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/anomaly-detection-scale.asciidoc
@@ -127,8 +127,24 @@ new job.
 
 
 [discrete]
+[[set-scroll-size]]
+== 6. Set the `scroll_size` of the {dfeed}
+
+The `scroll_size` parameter of a {dfeed} specifies the number of hits to return 
+from {es} searches. The higher the `scroll_size` the more results are returned 
+by the search. When your {anomaly-job} has a high throughput, increasing 
+`scroll_size` may decrease the time the job needs to analyze incoming data. This 
+only applies to {dfeeds} that do not use aggregations. You cannot increase 
+`scroll_size` to more than the value of `index.max_result_window` which is 
+10,000 by default. If you update the settings of a {dfeed}, you must stop and 
+start the {dfeed} for the change to be applied.
+
+Increasing `scroll_size` may also increase the pressure on your cluster.
+
+
+[discrete]
 [[set-model-memory-limit]]
-== 6. Set the model memory limit
+== 7. Set the model memory limit
 
 The `model_memory_limit` job configuration option sets the approximate maximum 
 amount of memory resources required for analytical processing. If this variable 
@@ -146,7 +162,7 @@ memory settings of an existing job, but the job must be closed.
 
 [discrete]
 [[pre-aggregate-data]]
-== 7. Pre-aggregate your data
+== 8. Pre-aggregate your data
 
 You can speed up the analysis by summarizing your data with aggregations. 
 
@@ -166,7 +182,7 @@ Please consult <<ml-configuring-aggregation>> to learn more.
 
 [discrete]
 [[results-retention]]
-== 8. Optimize the results retention
+== 9. Optimize the results retention
 
 Set a results retention window to reduce the amount of results stored.
 
@@ -181,7 +197,7 @@ setting for existing jobs.
 
 [discrete]
 [[renormalization-window]]
-== 9. Optimize the renormalization window
+== 10. Optimize the renormalization window
 
 Reduce the renormalization window to reduce processing workload.
 
@@ -197,7 +213,7 @@ will take effect after the job has been reopened.
 
 [discrete]
 [[model-snapshot-retention]]
-== 10. Optimize the model snapshot retention
+== 11. Optimize the model snapshot retention
 
 Model snapshots are taken periodically, to ensure resilience in the event of a 
 system failure and to allow you to manually revert to a specific point in time. 
@@ -222,7 +238,7 @@ For more information, refer to <<ml-model-snapshots>>.
 
 [discrete]
 [[search-queries]]
-== 11. Optimize your search queries
+== 12. Optimize your search queries
 
 If you are operating on a big scale, make sure that your {dfeed} query is as 
 efficient as possible. There are different ways to write {es} queries and some 
@@ -236,7 +252,7 @@ query.
 
 [discrete]
 [[population-analysis]]
-== 12. Consider using population analysis
+== 13. Consider using population analysis
 
 Population analysis is more memory efficient than individual analysis of each 
 series. It builds a profile of what a "typical" entity does over a specified 
@@ -249,7 +265,7 @@ For more information, refer to <<ml-configuring-populations>>.
 
 [discrete]
 [[forecasting]]
-== 13. Reduce the cost of forecasting
+== 14. Reduce the cost of forecasting
 
 There are two main performance factors to consider when you create a forecast: 
 indexing load and memory usage. Check the cluster monitoring data to learn the 

--- a/docs/en/stack/ml/anomaly-detection/anomaly-detection-scale.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/anomaly-detection-scale.asciidoc
@@ -133,13 +133,12 @@ new job.
 The `scroll_size` parameter of a {dfeed} specifies the number of hits to return 
 from {es} searches. The higher the `scroll_size` the more results are returned 
 by a single search. When your {anomaly-job} has a high throughput, increasing 
-`scroll_size` may decrease the time the job needs to analyze incoming data. This 
-only applies to {dfeeds} that do not use aggregations. You cannot increase 
-`scroll_size` to more than the value of `index.max_result_window` which is 
-10,000 by default. If you update the settings of a {dfeed}, you must stop and 
-start the {dfeed} for the change to be applied.
-
-Increasing `scroll_size` may also increase the pressure on your cluster.
+`scroll_size` may decrease the time the job needs to analyze incoming data, 
+however may also increase the pressure on your cluster. This only applies to 
+{dfeeds} that *do not* use aggregations. You cannot increase `scroll_size` to 
+more than the value of `index.max_result_window` which is 10,000 by default. If 
+you update the settings of a {dfeed}, you must stop and start the {dfeed} for 
+the change to be applied.
 
 
 [discrete]


### PR DESCRIPTION
## Overview

This PR adds a new item to the Anomaly Detection at scale piece about setting the `scroll_size` of a datafeed.

### Preview

[AD at scale - Set the `scroll_size` of a datafeed](https://stack-docs_1445.docs-preview.app.elstc.co/guide/en/machine-learning/master/anomaly-detection-scale.html#set-scroll-size)