### PR TITLE
[DOCS] Clarify machine learning setup

### DIFF
--- a/docs/en/stack/ml/setup.asciidoc
+++ b/docs/en/stack/ml/setup.asciidoc
@@ -39,7 +39,9 @@ information, see {ref}/modules-node.html#ml-node[{ml-cap} nodes] and
 The {stack-security-features} provide roles and privileges that make it easier
 to control which users can manage or view {ml} objects such as jobs, {dfeeds},
 results, and model snapshots. {kib} also enables you to control access to the
-{ml-features} within each space. For more information, see {ref}/security-privileges.html[Security privileges] and
+{ml-features} within each space. You can manage your roles, privileges, and
+spaces in the **{stack-manage-app}** app in {kib}. For more information, see
+{ref}/security-privileges.html[Security privileges] and
 {kibana-ref}/kibana-privileges.html[{kib} privileges].
 
 For full access to the {ml-features} in {kib}, you must have:
@@ -71,8 +73,8 @@ IMPORTANT: You cannot limit access to specific {ml} objects in each space. If
 the {ml} feature is visible in your space and you have `read` or `all` {kib}
 privileges for the feature, you have access to *all* {ml} objects in that space.
 
-If you call {ml} APIs directly, you must have the index privileges listed above
-as well as `machine_learning_admin` or `machine_learning_user` built-in roles.
+If you do not use {kib} and instead call {ml} APIs directly, you must have the
+index privileges listed above as well as `machine_learning_admin` or `machine_learning_user` built-in roles.
 
 WARNING: The `machine_learning_admin` and `machine_learning_user` roles grant
 access to the {ml-features} in all {kib} spaces. Therefore, when you use {kib}, 


### PR DESCRIPTION
This PR updates the machine learning security privilege setup information (https://www.elastic.co/guide/en/machine-learning/master/setup.html#setup-privileges) to mention the use of the Stack Management app and clarify that the use of the built-in roles is for scenarios where you're not using Kibana.

### Preview

https://stack-docs_1453.docs-preview.app.elstc.co/guide/en/machine-learning/master/setup.html#setup-privileges