### PR TITLE
[DOCS] Remove legacy rollup glossary items

### DIFF
--- a/docs/en/glossary/glossary.asciidoc
+++ b/docs/en/glossary/glossary.asciidoc
@@ -586,7 +586,7 @@ parsing, and visualization of logs and metrics. Also known as a <<glossary-modul
 {ml-cap} jobs contain the configuration information and metadata
 necessary to perform an analytics task. There are two types:
 <<glossary-anomaly-detection-job,{anomaly-jobs}>> and
-<<glossary-dataframe-job,{dfanalytics-jobs}>>. See also <<glossary-rollup-job>>.
+<<glossary-dataframe-job,{dfanalytics-jobs}>>.
 //Source: X-Pack
 
 [discrete]
@@ -843,18 +843,6 @@ by making sure that only authorized hosts become part of the installation.
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=rollup-def]
---
-
-[[glossary-rollup-index]] rollup index::
-+
---
-include::{es-repo-dir}/glossary.asciidoc[tag=rollup-index-def]
---
-
-[[glossary-rollup-job]] {rollup-job}::
-+
---
-include::{es-repo-dir}/glossary.asciidoc[tag=rollup-job-def]
 --
 
 [[glossary-routing]] routing::


### PR DESCRIPTION
Per elastic/elasticsearch#42720, we're refactoring rollups to phase out rollup jobs and special rollup indices.

The functionality may be around for a while, but I'd like to remove these items from the glossary. They're pulled from ES `master` where I'm removing the source defs. Once the refactor is finished, rollup jobs/indices are not something new users are likely to run into or something we want to promote.

If wanted, I can hold off on merging until closer to launch.

Relates to elastic/elasticsearch#65519

