### PR TITLE
Test snippet links

### DIFF
--- a/docs/en/getting-started/get-started-stack.asciidoc
+++ b/docs/en/getting-started/get-started-stack.asciidoc
@@ -17,7 +17,7 @@ elastic.apm.active: true
 elastic.apm.serverUrl: 'http://127.0.0.1:8200'
 # elastic.apm.secretToken: ... <-- might be required in prod/cloud
 # optional metrics to adjust performance 
-# see https://www.elastic.co/guide/en/apm/agent/nodejs/master/configuration.html[APM agent configuration]
+# see https://www.elastic.co/guide/en/apm/agent/nodejs/master/configuration.html
 elastic.apm.centralConfig: false
 elastic.apm.breakdownMetrics: false
 elastic.apm.transactionSampleRate: 0.1

--- a/docs/en/getting-started/get-started-stack.asciidoc
+++ b/docs/en/getting-started/get-started-stack.asciidoc
@@ -11,6 +11,19 @@ TIP: {ls} adds powerful data parsing and transformation features, but usually
 isn't required. To get started with {ls}, see
 {logstash-ref}/getting-started-with-logstash.html[Getting Started with {ls}].
 
+["source",sh]
+----------
+elastic.apm.active: true
+elastic.apm.serverUrl: 'http://127.0.0.1:8200'
+# elastic.apm.secretToken: ... <-- might be required in prod/cloud
+# optional metrics to adjust performance 
+# see https://www.elastic.co/guide/en/apm/agent/nodejs/master/configuration.html[APM agent configuration]
+elastic.apm.centralConfig: false
+elastic.apm.breakdownMetrics: false
+elastic.apm.transactionSampleRate: 0.1
+elastic.apm.metricsInterval: '120s'
+----------
+
 After completing the installation process, learn how to implement a system
 monitoring solution that uses {metricbeat} to collect server metrics and ship
 the data to {es}. Then use {kib} to search and visualize the data.

--- a/docs/en/getting-started/get-started-stack.asciidoc
+++ b/docs/en/getting-started/get-started-stack.asciidoc
@@ -11,13 +11,13 @@ TIP: {ls} adds powerful data parsing and transformation features, but usually
 isn't required. To get started with {ls}, see
 {logstash-ref}/getting-started-with-logstash.html[Getting Started with {ls}].
 
-["source",sh]
+["source",md]
 ----------
 elastic.apm.active: true
 elastic.apm.serverUrl: 'http://127.0.0.1:8200'
 # elastic.apm.secretToken: ... <-- might be required in prod/cloud
 # optional metrics to adjust performance 
-# see https://www.elastic.co/guide/en/apm/agent/nodejs/master/configuration.html
+# see https://www.elastic.co/guide/en/apm/agent/nodejs/master/configuration.html[test]
 elastic.apm.centralConfig: false
 elastic.apm.breakdownMetrics: false
 elastic.apm.transactionSampleRate: 0.1


### PR DESCRIPTION
This PR checks a doc build issue originally experienced in https://github.com/elastic/kibana/pull/84700

It pertained to a page which contained a shell snippet with
> `# see https://www.elastic.co/guide/en/apm/agent/nodejs/master/configuration.html[APM agent configuration]`

... and resulted in the following doc build failure:
https://elasticsearch-ci.elastic.co/job/elastic+stack-docs+pull-request+build-docs/644/console
> 14:30:09 INFO:build_docs:Bad cross-document links:
14:30:09 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elastic-stack-get-started/master/get-started-elastic-stack.html:
14:30:09 INFO:build_docs:   - en/apm/agent/nodejs/master/configuration.html[APM

Removing the link title solved the error.  For example:
> `# see https://www.elastic.co/guide/en/apm/agent/nodejs/master/configuration.html`
