### PR TITLE
[DOCS] Expands supplied configurations docs

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-apache.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-apache.asciidoc
@@ -12,6 +12,9 @@ and data types from the Elastic Common Schema (ECS). For more details, see the
 {dfeed} and job definitions in
 https://github.com/elastic/kibana/tree/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/apache_ecs/ml[GitHub].
 
+These configurations are only available if data exists that matches the 
+following term query: `"event.dataset": "apache.access"`.
+
 low_request_rate_ecs::
 
 * For HTTP web access logs where `event.dataset` is `apache.access`.

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-apache.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-apache.asciidoc
@@ -13,7 +13,8 @@ and data types from the Elastic Common Schema (ECS). For more details, see the
 https://github.com/elastic/kibana/tree/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/apache_ecs/ml[GitHub].
 
 These configurations are only available if data exists that matches the 
-following term query: `"event.dataset": "apache.access"`.
+recognizer query specified in the 
+https://github.com/elastic/kibana/blob/6c58e63a8674478a76758243ec707355a56ee3d9/x-pack/plugins/ml/server/models/data_recognizer/modules/apache_ecs/manifest.json#L8[manifest file].
 
 low_request_rate_ecs::
 

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-apm.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-apm.asciidoc
@@ -16,7 +16,8 @@ https://github.com/elastic/kibana/tree/{branch}/x-pack/plugins/ml/server/models/
 // tag::apm-nodejs-jobs[]
 Detect abnormal traces, anomalous spans, and identify periods of decreased
 throughput. These configurations are only available if data exists that matches 
-the following term query: `"agent.name": "nodejs"`.
+the recognizer query specified in the
+https://github.com/elastic/kibana/blob/6c58e63a8674478a76758243ec707355a56ee3d9/x-pack/plugins/ml/server/models/data_recognizer/modules/apm_nodejs/manifest.json#L8[mainfest file].
 
 abnormal_span_durations_nodejs::
 
@@ -45,7 +46,8 @@ than normal.
 // tag::apm-rum-javascript-jobs[]
 Detect problematic spans and identify user agents that are potentially causing
 issues. These configurations are only available if data exists that matches the 
-following term query: `"agent.name": "js-base"`.
+recognizer query specified in the
+https://github.com/elastic/kibana/blob/6c58e63a8674478a76758243ec707355a56ee3d9/x-pack/plugins/ml/server/models/data_recognizer/modules/apm_jsbase/manifest.json#L8[manifest file].
 
 abnormal_span_durations_jsbase::
 

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-apm.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-apm.asciidoc
@@ -15,7 +15,8 @@ https://github.com/elastic/kibana/tree/{branch}/x-pack/plugins/ml/server/models/
 == NodeJS
 // tag::apm-nodejs-jobs[]
 Detect abnormal traces, anomalous spans, and identify periods of decreased
-throughput.
+throughput. These configurations are only available if data exists that matches 
+the following term query: `"agent.name": "nodejs"`.
 
 abnormal_span_durations_nodejs::
 
@@ -43,7 +44,8 @@ than normal.
 == RUM Javascript
 // tag::apm-rum-javascript-jobs[]
 Detect problematic spans and identify user agents that are potentially causing
-issues.
+issues. These configurations are only available if data exists that matches the 
+following term query: `"agent.name": "js-base"`.
 
 abnormal_span_durations_jsbase::
 
@@ -78,7 +80,9 @@ This job is useful in identifying bots.
 [[apm-transaction-jobs]]
 == Transactions
 // tag::apm-transaction-jobs[]
-Detect anomalies in transactions from your APM services.
+Detect anomalies in transactions from your APM services. These configurations 
+are only available if data exists that matches the following term query: 
+`"processor.event": "transaction"`.
 
 high_mean_transaction_duration::
 

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-auditbeat.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-auditbeat.asciidoc
@@ -13,8 +13,8 @@ systems. For more details, see the {dfeed} and job definitions in the
 https://github.com/elastic/kibana/tree/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules[GitHub].
 
 These configurations are only available if data exists that matches the 
-following term queries: `"event.module": "auditd"` and `"container.runtime": 
-"docker"`.
+recognizer query specified in the
+https://github.com/elastic/kibana/blob/6c58e63a8674478a76758243ec707355a56ee3d9/x-pack/plugins/ml/server/models/data_recognizer/modules/auditbeat_process_docker_ecs/manifest.json#L8[manifest file].
 
 docker_high_count_process_events_ecs::
 
@@ -31,9 +31,9 @@ docker_rare_process_activity_ecs::
 * Detects rare process executions in Docker containers.
 
 
-These configurations are only available if data exists that matches the term 
-query: `"event.module": "auditd"`, `auditd.data.syscall` is an existing field, 
-and `container.runtime` field does not exist.
+These configurations are only available if data exists that matches the 
+recognizer query specified in the
+https://github.com/elastic/kibana/blob/6c58e63a8674478a76758243ec707355a56ee3d9/x-pack/plugins/ml/server/models/data_recognizer/modules/auditbeat_process_hosts_ecs/manifest.json#L8[manifest file].
 
 hosts_high_count_process_events_ecs::
 

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-auditbeat.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-auditbeat.asciidoc
@@ -12,6 +12,10 @@ systems. For more details, see the {dfeed} and job definitions in the
 `auditbeat_*` folders in
 https://github.com/elastic/kibana/tree/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules[GitHub].
 
+These configurations are only available if data exists that matches the 
+following term queries: `"event.module": "auditd"` and `"container.runtime": 
+"docker"`.
+
 docker_high_count_process_events_ecs::
 
 * For Auditbeat data where `event.module` is `auditd` and `container.runtime` is 
@@ -25,6 +29,11 @@ docker_rare_process_activity_ecs::
 `docker`.
 * Models occurrences of process execution for each `container.name`.
 * Detects rare process executions in Docker containers.
+
+
+These configurations are only available if data exists that matches the term 
+query: `"event.module": "auditd"`, `auditd.data.syscall` is an existing field, 
+and `container.runtime` field does not exist.
 
 hosts_high_count_process_events_ecs::
 

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-metricbeat.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-metricbeat.asciidoc
@@ -11,6 +11,10 @@ These {anomaly-job} wizards appear in {kib} if you use the
 monitor your servers. For more details, see the
 {dfeed} and job definitions in https://github.com/elastic/kibana/tree/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/metricbeat_system_ecs/ml[GitHub].
 
+These configurations are only available if data exists that matches the 
+following terms query: `"event.dataset": ["system.cpu", "system.filesystem"]`.
+
+
 high_mean_cpu_iowait_ecs::
 
 * For {metricbeat} data where `event.dataset` is `system.cpu` and 

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-metricbeat.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-metricbeat.asciidoc
@@ -12,7 +12,8 @@ monitor your servers. For more details, see the
 {dfeed} and job definitions in https://github.com/elastic/kibana/tree/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/metricbeat_system_ecs/ml[GitHub].
 
 These configurations are only available if data exists that matches the 
-following terms query: `"event.dataset": ["system.cpu", "system.filesystem"]`.
+recognizer query specified in the
+https://github.com/elastic/kibana/blob/6c58e63a8674478a76758243ec707355a56ee3d9/x-pack/plugins/ml/server/models/data_recognizer/modules/metricbeat_system_ecs/manifest.json#L8[manifest file].
 
 
 high_mean_cpu_iowait_ecs::

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-nginx.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-nginx.asciidoc
@@ -12,9 +12,9 @@ fields and datatypes from the Elastic Common Schema (ECS). For more details, see
 the {dfeed} and job definitions in
 https://github.com/elastic/kibana/tree/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/nginx_ecs/ml[GitHub].
 
-These configurations are only available if data exists that matches the term 
-query: `"event.dataset": "nginx.access"`, and `source.address`, `url.original`, 
-and `http.response.status_code` are existing fields.
+These configurations are only available if data exists that matches the 
+recognizer query specified in the
+https://github.com/elastic/kibana/blob/6c58e63a8674478a76758243ec707355a56ee3d9/x-pack/plugins/ml/server/models/data_recognizer/modules/nginx_ecs/manifest.json#L8[manifest file].
 
 
 low_request_rate_ecs::

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-nginx.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-nginx.asciidoc
@@ -12,6 +12,11 @@ fields and datatypes from the Elastic Common Schema (ECS). For more details, see
 the {dfeed} and job definitions in
 https://github.com/elastic/kibana/tree/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/nginx_ecs/ml[GitHub].
 
+These configurations are only available if data exists that matches the term 
+query: `"event.dataset": "nginx.access"`, and `source.address`, `url.original`, 
+and `http.response.status_code` are existing fields.
+
+
 low_request_rate_ecs::
 
 * For HTTP web access logs where `event.dataset` is `nginx.access`.

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-siem.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-siem.asciidoc
@@ -16,6 +16,9 @@ For more details, see the
 {dfeed} and job definitions in the `siem_*` folders in
 https://github.com/elastic/kibana/tree/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules[GitHub].
 
+These configurations are only available if data exists that matches the 
+following term query: `"agent.type": "auditbeat"`.
+
 [discrete]
 [[security-auditbeat-jobs]]
 == Security {auditbeat}

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-siem.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-siem.asciidoc
@@ -16,12 +16,14 @@ For more details, see the
 {dfeed} and job definitions in the `siem_*` folders in
 https://github.com/elastic/kibana/tree/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules[GitHub].
 
-These configurations are only available if data exists that matches the 
-following term query: `"agent.type": "auditbeat"`.
 
 [discrete]
 [[security-auditbeat-jobs]]
 == Security {auditbeat}
+
+These configurations are only available if data exists that matches the 
+recognizer query specified in the
+https://github.com/elastic/kibana/blob/6c58e63a8674478a76758243ec707355a56ee3d9/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_auditbeat/manifest.json#L8[manifest file].
 
 Detect suspicious network activity and unusual processes in {auditbeat} data.
 
@@ -486,6 +488,10 @@ Required ECS fields when not using {beats}:::
 [[security-auditbeat-authentication-jobs]]
 == Security {auditbeat} authentication
 
+These configurations are only available if data exists that matches the 
+recognizer query specified in the
+https://github.com/elastic/kibana/blob/6c58e63a8674478a76758243ec707355a56ee3d9/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_auditbeat_auth/manifest.json#L8[manifest file].
+
 Detect suspicious authentication events in {auditbeat} data.
 
 // tag::siem-auditbeat-auth-jobs[]
@@ -518,6 +524,10 @@ Required ECS fields when not using {beats}:::
 [discrete]
 [[security-cloudtrail-jobs]]
 == Security CloudTrail
+
+These configurations are only available if data exists that matches the 
+recognizer query specified in the
+https://github.com/elastic/kibana/blob/6c58e63a8674478a76758243ec707355a56ee3d9/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_cloudtrail/manifest.json#L8[manifest file].
 
 Detect suspicious activity recorded in your CloudTrail logs.
 
@@ -631,6 +641,10 @@ Required ECS fields when not using {beats}:::
 [discrete]
 [[security-packetbeat-jobs]]
 == Security {packetbeat}
+
+These configurations are only available if data exists that matches the 
+recognizer query specified in the
+https://github.com/elastic/kibana/blob/6c58e63a8674478a76758243ec707355a56ee3d9/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_packetbeat/manifest.json#L8[manifest file].
 
 Detect suspicious network activity in {packetbeat} data.
 
@@ -805,6 +819,10 @@ Required ECS fields when not using {beats}:::
 [discrete]
 [[security-winlogbeat-jobs]]
 == Security {winlogbeat}
+
+These configurations are only available if data exists that matches the 
+recognizer query specified in the
+https://github.com/elastic/kibana/blob/6c58e63a8674478a76758243ec707355a56ee3d9/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_winlogbeat/manifest.json#L8[manifest file].
 
 Detect unusual processes and network activity in {winlogbeat} data.
 
@@ -1120,6 +1138,10 @@ Required ECS fields when not using {beats}:::
 [discrete]
 [[security-winlogbeat-authentication-jobs]]
 == Security {winlogbeat} authentication
+
+These configurations are only available if data exists that matches the 
+recognizer query specified in the
+https://github.com/elastic/kibana/blob/6c58e63a8674478a76758243ec707355a56ee3d9/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_winlogbeat_auth/manifest.json#L8[manifest file].
 
 Detect suspicious authentication events in {winlogbeat} data.
 

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-uptime.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-uptime.asciidoc
@@ -12,6 +12,10 @@ If you have appropriate {heartbeat} data in {es}, you can enable this
 details, see the {dfeed} and job definitions in 
 https://github.com/elastic/kibana/tree/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/uptime_heartbeat/ml[GitHub].
 
+This configuration is only available if data exists that matches the following 
+term query: `"agent.type": "heartbeat"`.
+
+
 high_latency_by_geo::
 
 * Detects unusually high average latency values (using the

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-uptime.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-uptime.asciidoc
@@ -12,8 +12,9 @@ If you have appropriate {heartbeat} data in {es}, you can enable this
 details, see the {dfeed} and job definitions in 
 https://github.com/elastic/kibana/tree/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/uptime_heartbeat/ml[GitHub].
 
-This configuration is only available if data exists that matches the following 
-term query: `"agent.type": "heartbeat"`.
+These configurations are only available if data exists that matches the 
+recognizer query specified in the
+https://github.com/elastic/kibana/blob/6c58e63a8674478a76758243ec707355a56ee3d9/x-pack/plugins/ml/server/models/data_recognizer/modules/uptime_heartbeat/manifest.json#L8[manifest file].
 
 
 high_latency_by_geo::

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -8,7 +8,10 @@
 {anomaly-jobs-cap} contain the configuration information and metadata necessary 
 to perform an analytics task. {kib} can recognize certain types of data and 
 provide specialized wizards for that context. This page lists the categories of 
-the {anomaly-jobs} that are ready to use via {kib}.
+the {anomaly-jobs} that are ready to use via {kib} in **Machine learning**. 
+Refer to <<create-jobs>> to learn more about creating a job by using supplied 
+configurations. Logs and Metrics supplied configurations are available and can 
+be created via the related solution in {kib}.
 
 * <<ootb-ml-jobs-apache>>
 * <<ootb-ml-jobs-apm>>
@@ -19,3 +22,8 @@ the {anomaly-jobs} that are ready to use via {kib}.
 * <<ootb-ml-jobs-nginx>>
 * <<ootb-ml-jobs-siem>>
 * <<ootb-ml-jobs-uptime>>
+
+
+NOTE: The configurations are only available if data exists that matches the 
+queries specified in the manifest files. These recognizer queries are listed in 
+the descriptions of the individual configurations.

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs.asciidoc
@@ -11,7 +11,7 @@ provide specialized wizards for that context. This page lists the categories of
 the {anomaly-jobs} that are ready to use via {kib} in **Machine learning**. 
 Refer to <<create-jobs>> to learn more about creating a job by using supplied 
 configurations. Logs and Metrics supplied configurations are available and can 
-be created via the related solution in {kib}.
+be created via the related solution UI in {kib}.
 
 * <<ootb-ml-jobs-apache>>
 * <<ootb-ml-jobs-apm>>
@@ -25,5 +25,5 @@ be created via the related solution in {kib}.
 
 
 NOTE: The configurations are only available if data exists that matches the 
-queries specified in the manifest files. These recognizer queries are listed in 
+queries specified in the manifest files. These recognizer queries are linked in 
 the descriptions of the individual configurations.


### PR DESCRIPTION
## Overview

This PR:
* adds the recognizer query link to the descriptions of the supplied configurations,
* puts a link that points to the Creating AD jobs tutorial page to the OOTB ML jobs listing page,
* adds a note about the recognizer queries to the listing page,
* expands the docs with info about where you can create Logs and Metrics related jobs.

### Preview

[OOTB ML jobs](https://stack-docs_1477.docs-preview.app.elstc.co/guide/en/machine-learning/master/ootb-ml-jobs.html)