### PR TITLE
[7.x] [DOCS] Adds Moving trained models between clusters to docs (#1439)

### DIFF
--- a/docs/en/stack/ml/df-analytics/ml-trained-models.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-trained-models.asciidoc
@@ -13,16 +13,169 @@ information about this process, see <<ml-supervised-workflow>> and
 <<ml-inference>>.
 
 You can also supply trained models that are not created by {dfanalytics-job} but
-adhere to the appropriate https://github.com/elastic/ml-json-schemas[JSON schema].
-If you want to use these trained models in the {stack}, you must store them in
-{es} documents by using the {ref}/put-trained-models.html[create trained models API].
+adhere to the appropriate 
+https://github.com/elastic/ml-json-schemas[JSON schema]. If you want to use 
+these trained models in the {stack}, you must store them in {es} documents by 
+using the {ref}/put-trained-models.html[create trained models API].
 
-In {kib}, you can view and manage your trained models within
-*{ml-app}* > *Data Frame Analytics*:
+In {kib}, you can view and manage your trained models within *{ml-app}* > *Data 
+Frame Analytics*:
 
 [role="screenshot"]
 image::images/trained-model-management.png["List of trained models in the {ml-app} app in {kib}"]
 
-Alternatively, you can use APIs like
+Alternatively, you can use APIs like 
 {ref}/get-trained-models.html[get trained models] and
 {ref}/delete-trained-models.html[delete trained models].
+
+
+[discrete]
+[[move-between-clusters]]
+== Moving a trained model between clusters
+
+It is a common scenario that the {ml} models are trained in a development or 
+test environment and then used in a production environment. In this case, you 
+need to move your trained model from one cluster to another. The trained model 
+APIs enable you to move your trained model between clusters. The following 
+description shows you the process step by step.
+
+1. (Optional) In the cluster where you trained the model, make the call below by 
+using the console in **Dev Tools** to get the configuration information of your 
+trained models.
++
+--
+
+[source,console]
+--------------------------------------------------
+GET _ml/trained_models/
+--------------------------------------------------
+// TEST[skip:setup kibana sample data]
+
+The API response contains the `model_id` of the trained models. Check the 
+`model_id` of the trained model you want to move, you need to add it to the API 
+call in the next step.
+--
+
+2. Use the {ref}/get-trained-models.html[GET trained model API] to get the 
+trained model definition. You need to specify the following query parameters in 
+the call:
++
+--
+* `for_export`: This parameter allows the model to be in an acceptable format to 
+be retrieved and then added to another cluster. Set it to `true`.
+
+* `include`: Set this to `definition` for the API to include the definition in 
+the response.
+
+* `decompress_definition`: It specifies in what format the included model 
+definition should be returned. Set it to `false` for getting a custom compressed 
+format. It is also valid to use the JSON format, but it is not optimal. As the 
+decompressed definition may be significantly larger, it is recommended to use 
+the compressed format.
+   
+The following call is an example to get the trained model definition. (Replace 
+`<model_id>` with the actual ID of the trained model.)
+
+[source,console]
+--------------------------------------------------
+GET _ml/trained_models/<model_id>?for_export=true&include=definition&decompress_definition=false
+--------------------------------------------------
+// TEST[skip:setup kibana sample data]
+
+The API response returns a `trained_model_configs` array that contains a 
+`compressed_definition` object and the analytics and inference configuration 
+information.
+--
+
+3. Copy the content of `trained_model_configs`.
+
+4. Use the {ref}/put-trained-models.html[Create trained model API] in the 
+cluster you want to move the trained model to. Paste the content of the 
+`trained_model_configs` to the request body of the API call. The API response 
+contains the model information with metadata.
+
+Your trained model is ready to be used as a <<ml-inference-processor,processor>> 
+in an ingest pipeline or as an <<ml-inference-aggregation,aggregation>>.
+
+[NOTE]
+--
+The trained model definition can be so large that it may take a long time for a 
+computer clipboard to copy and paste it. It is recommended to do it 
+programmatically, for example via a bash script or via Client code. You can find 
+examples below.
+--
+
+The following Python snippet exports the trained model that you reference to a 
+JSON file:
+
+[source, py]
+--------------------------------------------------
+import json
+from elasticsearch import Elasticsearch
+from elasticsearch.client.ml import MlClient
+es_client = Elasticsearch('URL to your ES instance', http_auth=(username, password), use_ssl=True)
+ml_client = MlClient(es_client)
+result = ml_client.get_trained_models(model_id='your-model-id', decompress_definition=False, include=definition)
+compressed_df = result['trained_model_configs'][0]
+with open('model_filename.json', 'w') as handle:
+    handle.write(json.dumps(compressed_df))
+--------------------------------------------------
+// NOTCONSOLE
+
+
+The following Python snippet imports the model that stored in the JSON file to 
+a cluster:
+
+[source, py]
+--------------------------------------------------
+import json
+from elasticsearch import Elasticsearch
+from elasticsearch.client.ml import MlClient
+es_client = Elasticsearch(args.es, http_auth=(username, password), use_ssl=True, timeout=60)
+ml_client = MlClient(es_client)
+with open(filename, 'r') as handle:
+  compressed_model = json.loads(handle.read())
+for field in ('version', 'create_time', 'estimated_heap_memory_usage_bytes', 'estimated_operations', 'license_level', 'id','created_by'):
+  if field in compressed_model:
+    del compressed_model[field]
+ml_client.put_trained_model(model_id=model_id, body=compressed_model)
+--------------------------------------------------
+// NOTCONSOLE
+
+
+You can achieve the same by running a bash script. Populate the environment 
+variables:
+
+`ES_ADDRESS="https://username:password@elasticsearch-address"`
+
+`MODEL="my_model_name"`
+
+
+Then run the script:
+
+[source, bash]
+--------------------------------------------------
+curl -H 'Content-Type: application/json' -XPUT "$ES_ADDRESS/_ml/inference/$MODEL" -d@$MODEL.json
+--------------------------------------------------
+// NOTCONSOLE
+
+
+[discrete]
+[[move-trained-model-to-es]]
+=== Moving a model to the {stack}
+
+It is possible to add a model to your {es} cluster even if the model is not 
+trained by Elastic {dfanalytics}.
+
+You can find an example of training a model, then adding it to {es} by using 
+eland 
+https://eland.readthedocs.io/en/latest/examples/introduction_to_eland_webinar.html#Machine-Learning-Demo[in eland docs].
+The example uses Python to train and move the model, however, you can use any 
+Client as long as the format of your trained model meets 
+https://github.com/elastic/ml-json-schemas[the required schema].
+
+////
+This blog post is a step by step description of how to create a random forest 
+classifier {ml} model outside of {es} by using Python, load it into {es}, then 
+operationalize it with ingest pipelines.
+////


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Adds Moving trained models between clusters to docs (#1439)