### PR TITLE
[7.x] [DOCS] Fixes section level in Trained models docs. (#1482)

### DIFF
--- a/docs/en/stack/ml/df-analytics/ml-trained-models.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-trained-models.asciidoc
@@ -162,7 +162,7 @@ curl -H 'Content-Type: application/json' -XPUT "$ES_ADDRESS/_ml/inference/$MODEL
 
 [discrete]
 [[move-trained-model-to-es]]
-=== Moving a model to the {stack}
+== Moving a model to the {stack}
 
 It is possible to add a model to your {es} cluster even if the model is not 
 trained by Elastic {dfanalytics}.


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Fixes section level in Trained models docs. (#1482)