### PR TITLE
[7.10] [DOCS] Fixes API quick reference for trained models (#1486)

### DIFF
--- a/docs/en/stack/ml/df-analytics/ml-dfanalytics-apis.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfanalytics-apis.asciidoc
@@ -18,11 +18,11 @@ The evaluation API endpoint has the following base:
 ----
 // NOTCONSOLE
 
-All the {infer} endpoints have the following base:
+All the trained models endpoints have the following base:
 
 [source,js]
 ----
-/_ml/inference/
+/_ml/trained_models/
 ----
 // NOTCONSOLE
 
@@ -36,7 +36,7 @@ All the {infer} endpoints have the following base:
 * {ref}/stop-dfanalytics.html[Stop {dfanalytics-jobs}]
 * {ref}/evaluate-dfanalytics.html[Evaluate {dfanalytics}]
 * {ref}/explain-dfanalytics.html[Explain {dfanalytics}]
-* {ref}/put-inference.html[Create trained model]
-* {ref}/get-inference.html[Get trained model]
-* {ref}/get-inference-stats.html[Get trained model statistics]
-* {ref}/delete-inference.html[Delete trained model]
+* {ref}/put-trained-models.html[Create trained models]
+* {ref}/get-trained-models.html[Get trained models]
+* {ref}/get-trained-models-stats.html[Get trained models statistics]
+* {ref}/delete-trained-models.html[Delete trained models]


### PR DESCRIPTION
Backports the following commits to 7.10:
 - [DOCS] Fixes API quick reference for trained models (#1486)