### PR TITLE
[7.10] [DOCS] Fixes a typo in language identification docs. (#1489)

### DIFF
--- a/docs/en/stack/ml/df-analytics/ml-lang-ident.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-lang-ident.asciidoc
@@ -4,7 +4,7 @@
 
 experimental::[]
 
-{lang-ident-cap} is an trained model that you can use to determine the language
+{lang-ident-cap} is a trained model that you can use to determine the language
 of text. You can reference the {lang-ident} model in an
 {ref}/inference-processor.html[{infer} processor] of an ingest pipeline by 
 using its model ID (`lang_ident_model_1`). The input field name is `text`. If 
@@ -19,11 +19,12 @@ character stream.
 
 {lang-ident-cap} takes into account Unicode boundaries when the feature set is 
 built. If the text has diacritical marks, then the model uses that information 
-for identifying the language of the text.  In certain cases, the model can 
+for identifying the language of the text. In certain cases, the model can 
 detect the source language even if it is not written in the script that the 
 language traditionally uses. These languages are marked in the supported 
 languages table (see below) with the `Latn` subtag. {lang-ident-cap} supports 
 Unicode input.
+
 
 [[ml-lang-ident-supported-languages]]
 == Supported languages
@@ -77,6 +78,7 @@ script.
 | hmn     | Hmong              | ny      | Chichewa       |         |   
 |===
 
+
 [[ml-lang-ident-example]]
 == Example of {lang-ident}
 
@@ -120,6 +122,7 @@ POST _ingest/pipeline/_simulate
 <2> Specifies the number of languages to report by descending order of 
 probability.
 <3> The source object that contains the text to identify.
+
 
 In the example above, the `num_top_classes` value indicates that only the top 
 five languages (that is to say, the ones with the highest probability) are 
@@ -184,6 +187,7 @@ The request returns the following response:
 
 <1> Contains scores for the most probable languages.
 <2> The ISO identifier of the language with the highest probability.
+
 
 [[ml-lang-ident-readings]]
 == Further reading


### PR DESCRIPTION
Backports the following commits to 7.10:
 - [DOCS] Fixes a typo in language identification docs. (#1489)