### PR TITLE
[7.x] [DOCS] Fixes comment block on trained models page. (#1495)

### DIFF
--- a/docs/en/stack/ml/df-analytics/ml-trained-models.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-trained-models.asciidoc
@@ -174,8 +174,7 @@ The example uses Python to train and move the model, however, you can use any
 Client as long as the format of your trained model meets 
 https://github.com/elastic/ml-json-schemas[the required schema].
 
-////
-This blog post is a step by step description of how to create a random forest 
-classifier {ml} model outside of {es} by using Python, load it into {es}, then 
-operationalize it with ingest pipelines.
-////
+
+// This blog post is a step by step description of how to create a random forest 
+// classifier {ml} model outside of {es} by using Python, load it into {es}, then 
+// operationalize it with ingest pipelines.


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Fixes comment block on trained models page. (#1495)