### PR TITLE
[DOCS] Add space limitations for ML objects

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/ml-limitations.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-limitations.asciidoc
@@ -308,6 +308,6 @@ same values.
 
 {kibana-ref}/xpack-spaces.html[Spaces] enable you to organize your
 {anomaly-jobs} in {kib} and to see only the jobs and other saved objects
-that belong to that space. However, this limited scope does not apply to 
-<<ml-calendars,calendars>> and <<ml-rules,filters>>; they are visible in all of 
-your spaces.
+that belong to your space. However, this limited scope does not apply to 
+<<ml-calendars,calendars>> and <<ml-rules,filters>>; they are visible in all
+spaces.

--- a/docs/en/stack/ml/anomaly-detection/ml-limitations.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-limitations.asciidoc
@@ -257,8 +257,7 @@ single dot. If there are only two data points, they are joined by a line.
 
 If you create jobs in {kib}, you must use {dfeeds}. If the data that you want to
 analyze is not stored in {es}, you cannot use {dfeeds} and therefore you cannot
-create your jobs in {kib}. You can, however, use the {ml} APIs to create jobs
-and to send batches of data directly to the jobs. For more information, see
+create your jobs in {kib}. You can, however, use the {ml} APIs to create jobs. For more information, see
 <<ml-datafeeds>> and <<ml-api-quickref>>.
 
 
@@ -305,42 +304,10 @@ same values.
 
 [discrete]
 [[ml-space-limitations]]
-=== {ml-cap} objects do not belong to {kib} spaces
+=== Calendars and filters are visible in all {kib} spaces
 
-If you create {kibana-ref}/xpack-spaces.html[spaces] in {kib}, you see only the  
-saved objects that belong to that space. This limited scope does not apply to 
-{ml} objects; they are visible in all of your spaces.  
-
-However, the {kib} {ml-features} interact with some saved objects (such as 
-index patterns, dashboards, and visualizations) that might not be available in 
-all spaces. For example:
-
-* experimental[] If you upload a file on the *Machine Learning* page in {kib}, 
-the {ml-features} identify the file format and field mappings. You can then 
-optionally import that data into an {es} index and create an index pattern. This 
-index pattern belongs to the space that is active when you import the file. If 
-you want to use the index pattern in other spaces, you must create it as needed.  
-* Likewise, if you use the single-metric, multi-metric, or population job 
-wizards to create a job in {kib}, you can encounter problems if you subsequently 
-try to clone the job in a different space. In particular, problems occur when 
-you try to clone the job in a space that does not contain appropriate index 
-patterns. 
-* If you used a supplied configuration to create jobs (for example, for Apache 
-or NGINX web access logs), visualizations and dashboards are automatically 
-generated. These objects belong to the space that was active when you created 
-the job. If you change your active space, custom URLs from the {ml} results to 
-the dashboards or visualizations might fail.
-
-
-////
-[discrete]
-=== Jobs close on the {dfeed} end date
-//See x-pack-elasticsearch/#1037
-
-If you start a {dfeed} and specify an end date, it will close the job when
-the {dfeed} stops. This behavior avoids having numerous open one-time jobs.
-
-If you do not specify an end date when you start a {dfeed}, the job
-remains open when you stop the {dfeed}. This behavior avoids the overhead
-of closing and re-opening large jobs when there are pauses in the {dfeed}.
-////
+{kibana-ref}/xpack-spaces.html[Spaces] enable you to organize your
+{anomaly-jobs} in {kib} and to see only the jobs and other saved objects
+that belong to that space. However, this limited scope does not apply to 
+<<ml-calendars,calendars>> and <<ml-rules,filters>>; they are visible in all of 
+your spaces.

--- a/docs/en/stack/ml/df-analytics/ml-dfa-limitations.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-limitations.asciidoc
@@ -11,6 +11,15 @@ beta::[]
 The following limitations and known problems apply to the {version} release of 
 the Elastic {dfanalytics} feature:
 
+[discrete]
+[[dfa-space-limitations]]
+== Trained models are visible in all {kib} spaces
+
+{kibana-ref}/xpack-spaces.html[Spaces] enable you to organize your
+{dfanalytics-jobs} in {kib} and to see only the jobs and other saved objects
+that belong to that space. However, this limited scoped does not apply to
+<<ml-trained-models,trained models>>; they are are visible in all spaces. 
+
 [float]
 [[dfa-ccs-limitations]]
 == {ccs-cap} is not supported

--- a/docs/en/stack/ml/df-analytics/ml-dfa-limitations.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-limitations.asciidoc
@@ -17,7 +17,7 @@ the Elastic {dfanalytics} feature:
 
 {kibana-ref}/xpack-spaces.html[Spaces] enable you to organize your
 {dfanalytics-jobs} in {kib} and to see only the jobs and other saved objects
-that belong to that space. However, this limited scoped does not apply to
+that belong to your space. However, this limited scoped does not apply to
 <<ml-trained-models,trained models>>; they are are visible in all spaces. 
 
 [float]


### PR DESCRIPTION
This PR updates the anomaly detection and data frame analytics limitations with details about space-aware machine learning objects.

### Preview

* https://stack-docs_1503.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-dfa-limitations.html#dfa-space-limitations
* https://stack-docs_1503.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-limitations.html#ml-space-limitations