### PR TITLE
[DOCS] Adds security_linux and security_windows modules

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-siem.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-siem.asciidoc
@@ -5,19 +5,15 @@
 <titleabbrev>Security</titleabbrev>
 ++++
 
-These {anomaly-jobs} appear by default in the Anomaly Detection interface of
-the {security-guide}/machine-learning.html[{security-app}] in {kib}. They
-help you automatically detect file system and network anomalies on your hosts.
-However, if you don't use Beats or the {agent}, you need to map your data to 
-the ECS fields that are listed for each job.
-
-IMPORTANT: If the {agent} or Beat is version 7.10 or higher, use the
-<<security-linux-jobs>> and <<security-windows-jobs>> jobs. For earlier 
-versions, use the <<security-auditbeat-jobs>> and <<security-winlogbeat-jobs>>
-jobs. After you upgrade to 7.10 or later versions and start using the new jobs,
-disable the old jobs.
-
 // tag::siem-jobs[]
+These {anomaly-jobs} automatically detect file system and network anomalies on
+your hosts. They appear in the Anomaly Detection interface of the
+{security-guide}/machine-learning.html[{security-app}] in {kib} when you have
+data that matches their configuration. Each job lists the type of {agent}
+integration or Beat that collects the pertinent data. If you do not use the
+{agent} or Beats, you must map your data to the ECS fields that are listed
+for each job.
+
 For more details, see the
 {dfeed} and job definitions in the `security_*` and `siem_*` folders in
 https://github.com/elastic/kibana/tree/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules[GitHub].
@@ -26,11 +22,21 @@ https://github.com/elastic/kibana/tree/{branch}/x-pack/plugins/ml/server/models/
 [[security-auditbeat-jobs]]
 == Security: {auditbeat}
 
+Detect suspicious network activity and unusual processes in {auditbeat} data.
+
 These configurations are only available if data exists that matches the 
 recognizer query specified in the
 https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_auditbeat/manifest.json#L8[manifest file].
 
-Detect suspicious network activity and unusual processes in {auditbeat} data.
+IMPORTANT: In 7.11 or later versions, use the <<security-linux-jobs>> jobs
+instead.footnote:duplicatelinuxjobs[If you cannot upgrade all your Beats to
+version 7.11 or later and you have both <<security-linux-jobs>> and
+<<security-auditbeat-jobs>> jobs running, you can avoid duplication by stopping
+the following jobs: `linux_anomalous_network_activity_ecs`, 
+`linux_anomalous_network_port_activity_ecs`,
+`linux_anomalous_process_all_hosts_ecs`, `linux_anomalous_user_name_ecs`, 
+`linux_rare_metadata_process`, `linux_rare_metadata_user`,
+`rare_process_by_host_linux_ecs`.]
 
 // tag::siem-auditbeat-jobs[]
 linux_anomalous_network_activity_ecs::
@@ -83,9 +89,10 @@ Job details:::
 Required {beats} or {agent} integrations:::
 
 * {auditbeat} (Linux)
-
 +
 NOTE: This job is available only when you use {auditbeat} to ship data.
+footnote:compatible[Some jobs use fields that are not ECS-compliant. These jobs
+are available only when you use {beats} or the {agent} to ship data.]
 
 linux_anomalous_network_service::
 
@@ -102,9 +109,8 @@ Job details:::
 Required {beats} or {agent} integrations:::
 
 * {auditbeat} (Linux)
-
 +
-NOTE: This job is available only when you use {auditbeat} to ship data.
+NOTE: This job is available only when you use {auditbeat} to ship data.footnote:compatible[]
 
 linux_anomalous_network_url_activity_ecs::
 
@@ -647,11 +653,13 @@ Required ECS fields when not using {beats}:::
 [[security-linux-jobs]]
 == Security: Linux
 
+Detect suspicious activity using ECS Linux events. Tested with {auditbeat} and {agent}.
+
 These configurations are only available if data exists that matches the 
 recognizer query specified in the
 https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux/manifest.json#L8[manifest file].
 
-Detect suspicious activity using ECS Linux events. Tested with {auditbeat} and {agent}.
+IMPORTANT: In 7.11 or later versions, use these jobs instead of the <<security-auditbeat-jobs>> jobs.footnote:duplicatelinuxjobs[]
 
 // tag::security-linux-jobs[]
 v2_linux_anomalous_network_port_activity_ecs::
@@ -734,10 +742,6 @@ usernames only when personnel log in to make authorized or unauthorized
 changes, or threat actors have acquired credentials and log in for malicious 
 purposes. Unusual usernames can also indicate pivoting, where compromised 
 credentials are used to try and move laterally from one host to another.
-+
-NOTE: If you collect data from the Windows security event log and you configure 
-it to audit process creation, this job can use the 4688 events that occur every 
-time a new process starts.
 
 Job details:::
 
@@ -1035,12 +1039,26 @@ Required ECS fields when not using {beats}:::
 [[security-windows-jobs]]
 == Security: Windows
 
-These configurations are only available if data exists that matches the 
-recognizer query specified in the
-https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows/manifest.json#L8[manifest file].
-
 Detects suspicious activity using ECS Windows events. Tested with {winlogbeat} 
 and {agent}.
+
+These configurations are available only if data exists that matches the 
+recognizer query specified in the
+https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows/manifest.json#L8[manifest file].
+If there are additional requirements such as installing the Windows System
+Monitor (Sysmon) or auditing process creation in the Windows security event log,
+they are listed for each job.
+
+IMPORTANT: In 7.11 or later versions, use these jobs instead of the
+<<security-winlogbeat-jobs>> jobs.footnote:duplicatewindowsjobs[If you cannot
+upgrade all your Beats to version 7.11 or later and you have both
+<<security-windows-jobs,Security:Windows jobs>> and
+<<security-winlogbeat-jobs,Security:Winlogbeat jobs>> running, you can avoid 
+duplication by stopping the following jobs: `rare_process_by_host_windows_ecs`, 
+`windows_anomalous_network_activity_ecs`, `windows_anomalous_path_activity_ecs`, 
+`windows_anomalous_process_all_hosts_ecs`, `windows_anomalous_process_creation`, 
+`windows_anomalous_user_name_ecs`, `windows_rare_metadata_process`, 
+`windows_rare_metadata_user`]
 
 // tag::security-windows-jobs[]
 v2_rare_process_by_host_windows_ecs::
@@ -1050,10 +1068,6 @@ of unauthorized services, malware, or persistence mechanisms.
 +
 Processes are considered rare when they only run occasionally as compared with
 other processes running on the host.
-+
-NOTE: If you collect data from the Windows security event log and you configure 
-it to audit process creation, this job can use the 4688 events that occur every 
-time a new process starts.
 
 Job details:::
 
@@ -1068,7 +1082,22 @@ Job details:::
 Required {beats} or {agent} integrations:::
 
 * beta:[] {elastic-endpoint} integration
-* {winlogbeat}
+* {winlogbeat}, colecting data from the Windows System Monitor (Sysmon) or the
+Windows security event log
++
+TIP: If you collect data from the Windows security event log and you configure
+it to audit process creation, this job can analyze the 4688 events that occur
+every time a new process starts.footnote:auditing[The Windows security 4688
+events have `event.category: process`, `event.type: start`, and
+`event.provider: Microsoft-Windows-Security-Auditing`. The following jobs can
+use these events: `v2_rare_process_by_host_windows_ecs`,
+`v2_windows_anomalous_user_name_ecs`, 
+`v2_windows_anomalous_process_all_hosts_ecs`, and
+`v2_windows_anomalous_process_creation`. The Windows security event log cannot
+be used as a data source for jobs that pertain to network events since it does
+not contain that type of information. Network events can be collected by the
+{elastic-endpoint} integration, by {winlogbeat} from the Windows System Monitor,
+or by another ECS-compatible Windows agent.]
 
 Required ECS fields:::
 
@@ -1102,7 +1131,7 @@ other processes (using the
 Required {beats} or {agent} integrations:::
 
 * beta:[] {elastic-endpoint} integration
-* {winlogbeat}
+* {winlogbeat}, collecting data from Windows System Monitor (Sysmon)
 
 Required ECS fields:::
 
@@ -1137,7 +1166,7 @@ Job details:::
 
 Required {beats} or {agent} integrations:::
 
-* {winlogbeat}
+* {winlogbeat}, collecting data from the Windows System Monitor (Sysmon)
 
 Required ECS fields:::
 
@@ -1172,7 +1201,11 @@ Job details:::
 Required {beats} or {agent} integrations:::
 
 * beta:[] {elastic-endpoint} integration
-* {winlogbeat}
+* {winlogbeat}, colecting data from the Windows System Monitor (Sysmon) or from the Windows security event log with process creation auditing enabled.
++
+TIP: If you collect data from the Windows security event log and you configure
+it to audit process creation, this job can analyze the 4688 events that occur
+every time a new process starts.footnote:auditing[]
 
 Required ECS fields:::
 
@@ -1186,8 +1219,8 @@ Required ECS fields:::
 
 v2_windows_anomalous_process_creation::
 
-Identifies unusual process relationships that can indicate
-malware execution or persistence mechanisms.
+Identifies unusual process relationships that can indicate malware execution or
+persistence mechanisms.
 +
 Malicious scripts often call on other applications and processes as part of
 their exploit payload. For example, when a malicious Office document runs
@@ -1214,7 +1247,12 @@ relationships (using the
 Required {beats} or {agent} integrations:::
 
 * beta:[] {elastic-endpoint} integration
-* {winlogbeat}
+* {winlogbeat}, collecting data from the Windows System Monitor (Sysmon) or the 
+Windows security event log
++
+TIP: If you collect data from the Windows security event log and you configure
+it to audit process creation, this job can analyze the 4688 events that occur
+every time a new process starts.footnote:auditing[]
 
 Required ECS fields:::
 
@@ -1243,10 +1281,6 @@ usernames only when personnel log in to make authorized or unauthorized
 changes, or threat actors have acquired credentials and log in for malicious 
 purposes. Unusual usernames can also indicate pivoting, where compromised 
 credentials are used to try and move laterally from one host to another.
-+
-NOTE: If you collect data from the Windows security event log and you configure 
-it to audit process creation, this job can use the 4688 events that occur every 
-time a new process starts.
 
 Job details:::
 
@@ -1259,7 +1293,12 @@ Job details:::
 Required {beats} or {agent} integrations:::
 
 * beta:[] {elastic-endpoint} integration
-* {winlogbeat}
+* {winlogbeat}, collecting data from the Windows System Monitor (Sysmon) or the 
+Windows security event log
++
+TIP: If you collect data from the Windows security event log and you configure
+it to audit process creation, this job can analyze the 4688 events that occur
+every time a new process starts.footnote:auditing[]
 
 Required ECS fields:::
 
@@ -1276,10 +1315,6 @@ v2_windows_rare_metadata_process::
 Looks for anomalous access to the metadata service by an unusual process. The 
 metadata service may be targeted in order to harvest credentials or user data 
 scripts containing secrets.
-+
-NOTE: If you collect data from the Windows security event log and you configure 
-it to audit process creation, this job can use the 4688 events that occur every 
-time a new process starts.
 
 Job details:::
 
@@ -1294,7 +1329,7 @@ processes (using the
 Required {beats} or {agent} integrations:::
 
 * beta:[] {elastic-endpoint} integration
-* {winlogbeat}
+* {winlogbeat}, collecting data from the Windows System Monitor (Sysmon)
 
 Required ECS fields:::
 
@@ -1321,7 +1356,7 @@ Job details:::
 Required {beats} or {agent} integrations:::
 
 * beta:[] {elastic-endpoint} integration
-* {winlogbeat}
+* {winlogbeat}, collecting data from the Windows System Monitor (Sysmon)
 
 Required ECS fields:::
 
@@ -1336,11 +1371,13 @@ Required ECS fields:::
 [[security-winlogbeat-jobs]]
 == Security: {winlogbeat}
 
+Detect unusual processes and network activity in {winlogbeat} data.
+
 These configurations are only available if data exists that matches the 
 recognizer query specified in the
 https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_winlogbeat/manifest.json#L8[manifest file].
 
-Detect unusual processes and network activity in {winlogbeat} data.
+IMPORTANT: In 7.11 or later versions, use the <<security-windows-jobs>> jobs instead.footnote:duplicatewindowsjobs[]
 
 // tag::siem-winlogbeat-jobs[]
 rare_process_by_host_windows_ecs::
@@ -1514,9 +1551,8 @@ Job details:::
 Required {beats} or {agent} integrations:::
 
 * {winlogbeat} (Windows)
-
 +
-NOTE: This job is available only when you use {winlogbeat} to ship data.
+NOTE: This job is available only when you use {winlogbeat} to ship data.footnote:compatible[]
 
 windows_anomalous_service::
 
@@ -1536,9 +1572,8 @@ Job details:::
 Required {beats} or {agent} integrations:::
 
 * {winlogbeat} (Windows)
-
 +
-NOTE: This job is available only when you use {winlogbeat} to ship data.
+NOTE: This job is available only when you use {winlogbeat} to ship data.footnote:compatible[]
 
 windows_anomalous_user_name_ecs::
 
@@ -1678,9 +1713,8 @@ Job details:::
 Required {beats} or {agent} integrations:::
 
 * {winlogbeat} (Windows)
-
 +
-NOTE: This job is available only when you use {winlogbeat} to ship data.
+NOTE: This job is available only when you use {winlogbeat} to ship data.footnote:compatible[]
 
 // end::siem-winlogbeat-auth-jobs[]
 // end::siem-jobs[]

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-siem.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-siem.asciidoc
@@ -6,10 +6,16 @@
 ++++
 
 These {anomaly-jobs} appear by default in the Anomaly Detection interface of
-the {security-guide}/machine-learning.html[Elastic Security app] in {kib}. They
+the {security-guide}/machine-learning.html[{security-app}] in {kib}. They
 help you automatically detect file system and network anomalies on your hosts.
-However, if you don't use Beats, you need to map your data to the ECS fields
-that are listed for every job.
+However, if you don't use Beats or the {agent}, you need to map your data to 
+the ECS fields that are listed for every job.
+
+IMPORTANT: If the {agent} or Beat is version 7.10 or higher, use the
+<<security-linux-jobs>> and <<security-windows-jobs>> jobs. For earlier 
+versions, use the <<security-auditbeat-jobs>> and <<security-winlogbeat-jobs>>
+jobs. After you upgrade to 7.10 or later versions and start using the new jobs,
+disable the old jobs.
 
 // tag::siem-jobs[]
 For more details, see the
@@ -756,6 +762,11 @@ processes (using the
 {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
 * Works on ECS compatible events across multiple indices.
 
+Required {beats} or {agent} integrations:::
+
+* {elastic-endpoint} integration
+* {winlogbeat}
+
 Required ECS fields:::
 
 * `destination.ip`
@@ -1027,6 +1038,11 @@ Job details:::
 {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
 * Works on ECS compatible events across multiple indices.
 
+Required {beats} or {agent} integrations:::
+
+* {elastic-endpoint} integration
+* {winlogbeat}
+
 Required ECS fields:::
 
 * `event.category`
@@ -1055,6 +1071,11 @@ Job details:::
 other processes (using the
 {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
 * Works on ECS compatible events across multiple indices.
+
+Required {beats} or {agent} integrations:::
+
+* {elastic-endpoint} integration
+* {winlogbeat}
 
 Required ECS fields:::
 
@@ -1154,6 +1175,11 @@ relationships (using the
 {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
 * Works on ECS compatible events across multiple indices.
 
+Required {beats} or {agent} integrations:::
+
+* {elastic-endpoint} integration
+* {winlogbeat}
+
 Required ECS fields:::
 
 * `event.category`
@@ -1190,6 +1216,11 @@ Job details:::
 (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
 * Works on ECS compatible events across multiple indices
 
+Required {beats} or {agent} integrations:::
+
+* {elastic-endpoint} integration
+* {winlogbeat}
+
 Required ECS fields:::
 
 * `event.category`
@@ -1216,6 +1247,11 @@ processes (using the
 {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
 * Works on ECS compatible events across multiple indices.
 
+Required {beats} or {agent} integrations:::
+
+* {elastic-endpoint} integration
+* {winlogbeat}
+
 Required ECS fields:::
 
 * `destination.ip`
@@ -1237,6 +1273,11 @@ Job details:::
 * Models user activity.
 * Detects users that are rarely or unusually active compared to other users 
 (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
+
+Required {beats} or {agent} integrations:::
+
+* {elastic-endpoint} integration
+* {winlogbeat}
 
 Required ECS fields:::
 

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-siem.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-siem.asciidoc
@@ -13,13 +13,12 @@ that are listed for every job.
 
 // tag::siem-jobs[]
 For more details, see the
-{dfeed} and job definitions in the `siem_*` folders in
+{dfeed} and job definitions in the `security_*` and `siem_*` folders in
 https://github.com/elastic/kibana/tree/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules[GitHub].
-
 
 [discrete]
 [[security-auditbeat-jobs]]
-== Security {auditbeat}
+== Security: {auditbeat}
 
 These configurations are only available if data exists that matches the 
 recognizer query specified in the
@@ -284,7 +283,7 @@ scripts containing secrets.
 
 Job details:::
 * Analyzes host activity logs where `agent.type` is `auditbeat` and
-`destination.ip` is commands the metadata service.
+`destination.ip` is the metadata service.
 * Models process activity.
 * Detects processes that are rarely or unusually active compared to other processes 
   (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
@@ -486,7 +485,7 @@ Required ECS fields when not using {beats}:::
 
 [discrete]
 [[security-auditbeat-authentication-jobs]]
-== Security {auditbeat} authentication
+== Security: {auditbeat} authentication
 
 These configurations are only available if data exists that matches the 
 recognizer query specified in the
@@ -523,7 +522,7 @@ Required ECS fields when not using {beats}:::
 
 [discrete]
 [[security-cloudtrail-jobs]]
-== Security CloudTrail
+== Security: CloudTrail
 
 These configurations are only available if data exists that matches the 
 recognizer query specified in the
@@ -639,8 +638,190 @@ Required ECS fields when not using {beats}:::
 // end::security-cloudtrail-jobs[]
 
 [discrete]
+[[security-linux-jobs]]
+== Security: Linux
+
+These configurations are only available if data exists that matches the 
+recognizer query specified in the
+https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux/manifest.json#L8[manifest file].
+
+Detect suspicious activity using ECS Linux events. Tested with {auditbeat} and {agent}.
+
+// tag::security-linux-jobs[]
+v2_linux_anomalous_network_port_activity_ecs::
+
+Identifies unusual destination port activity that can indicate
+command-and-control, persistence mechanism, or data exfiltration activity.
++
+Rarely used destination port activity is generally unusual in Linux fleets, and 
+can indicate unauthorized access or threat actor activity.
+
+Job details:::
+
+* Analyzes network activity logs where `host.os.type` is `linux` or 
+`host.os.family` is `debian`, `redhat`, `suse`, or `ubuntu`.
+* Models destination port activity.
+* Detects destination port activity that occurs rarely compared to other port 
+activities (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
+* Works on ECS compatible events across multiple indices.
+
+Required ECS fields:::
+
+* `destination.ip`
+* `destination.port`
+* `event.category`
+* `event.type`
+* `host.name`
+* `host.os.family`
+* `host.os.type`
+* `process.name`
+* `user.name`
+
+v2_linux_anomalous_process_all_hosts_ecs::
+
+Looks for processes that are unusual to all Linux hosts. Such unusual processes may indicate unauthorized services, malware, or persistence mechanisms. 
++
+This reduces the detection of false positives since automated maintenance
+processes usually only run occasionally on a single machine but are common to
+all or many hosts in a fleet.
+
+Job details:::
+
+* Analyzes host activity logs where `host.os.type` is `linux` or `host.os.family`
+is `debian`, `redhat`, `suse`, or `ubuntu`.
+* Models the occurrences of processes on all Linux hosts.
+* Detects processes that occur rarely compared to other processes on all Linux 
+hosts (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
+* Works on ECS compatible events across multiple indices.
+
+Required ECS fields:::
+
+* `event.category`
+* `event.type`
+* `host.name`
+* `host.os.family`
+* `host.os.type`
+* `process.name`
+* `user.name`
+
+v2_linux_anomalous_user_name_ecs::
+
+Searches for activity from users who are not normally active, which can
+indicate unauthorized changes, activity by unauthorized users, lateral
+movement, and compromised credentials.
++
+In organizations, new usernames are not often created apart from specific types 
+of system activities, such as creating new accounts for new employees. These 
+user accounts quickly become active and routine.
++
+Events from rarely used usernames can point to suspicious activity. 
+Additionally, automated Linux fleets tend to see activity from rarely used 
+usernames only when personnel log in to make authorized or unauthorized 
+changes, or threat actors have acquired credentials and log in for malicious 
+purposes. Unusual usernames can also indicate pivoting, where compromised 
+credentials are used to try and move laterally from one host to another.
+
+Job details:::
+
+* Analyzes host activity logs where `host.os.type` is `linux` or `host.os.family`
+is `debian`, `redhat`, `suse`, or `ubuntu`.
+* Models user activity.
+* Detects users that are rarely or unusually active compared to other users 
+(using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
+* Works on ECS compatible events across multiple indices.  
+
+Required ECS fields:::
+
+* `event.category`
+* `event.type`
+* `host.name`
+* `host.os.family`
+* `host.os.type`
+* `process.name`
+* `user.name`
+
+v2_linux_rare_metadata_process::
+
+Looks for anomalous access to the metadata service by an unusual process. The 
+metadata service may be targeted in order to harvest credentials or user data 
+scripts containing secrets.  
+
+Job details:::
+* Analyzes host activity logs where `destination.ip` is the metadata service and 
+`host.os.type` is `linux` or `host.os.family` is `debian`, `redhat`, `suse`, or
+`ubuntu`.
+* Models process activity.
+* Detects processes that are rarely or unusually active compared to other 
+processes (using the
+{ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
+* Works on ECS compatible events across multiple indices.
+
+Required ECS fields:::
+
+* `destination.ip`
+* `host.name`
+* `host.os.family`
+* `host.os.type`
+* `process.name`
+* `user.name`
+
+v2_linux_rare_metadata_user::
+
+Looks for anomalous access to the metadata service by an unusual user. The 
+metadata service may be targeted in order to harvest credentials or user data 
+scripts containing secrets. 
+
+Job details:::
+
+* Analyzes host activity logs where `destination.ip` is the metadata service and
+`host.os.type` is `linux` or `host.os.family` is `debian`, `redhat`, `suse`, or
+`ubuntu`.
+* Models user activity.
+* Detects users that are rarely or unusually active compared to other users 
+(using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
+* Works on ECS compatible events across multiple indices.
+
+Required ECS fields:::
+
+* `destination.ip`
+* `host.name`
+* `host.os.family`
+* `host.os.type`
+* `user.name`
+
+v2_rare_process_by_host_linux_ecs::
+
+Looks for processes that are unusual to a particular Linux host. Such unusual 
+processes might indicate unauthorized services, malware, or persistence 
+mechanisms. 
++
+Processes are considered rare when they only run occasionally as compared with
+other processes running on the host.
+
+Job details:::
+
+* Analyzes host activity logs where `host.os.type` is `linux` or 
+`host.os.family` is `debian`, `redhat`, `suse`, or `ubuntu`.
+* Models occurrences of process activities on the host. 
+* Detects unusually rare processes compared to other processes on the host 
+(using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
+* Works on ECS compatible events across multiple indices.
+
+Required ECS fields:::
+
+* `event.category`
+* `event.type`
+* `host.name`
+* `host.os.family`
+* `host.os.type`
+* `process.name`
+* `user.name`
+
+// end::security-linux-jobs[]
+
+[discrete]
 [[security-packetbeat-jobs]]
-== Security {packetbeat}
+== Security: {packetbeat}
 
 These configurations are only available if data exists that matches the 
 recognizer query specified in the
@@ -817,8 +998,258 @@ Required ECS fields when not using {beats}:::
 // end::siem-packetbeat-jobs[]
 
 [discrete]
+[[security-windows-jobs]]
+== Security: Windows
+
+These configurations are only available if data exists that matches the 
+recognizer query specified in the
+https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows/manifest.json#L8[manifest file].
+
+Detects suspicious activity using ECS Windows events. Tested with {winlogbeat} 
+and {agent}.
+
+// tag::security-windows-jobs[]
+v2_rare_process_by_host_windows_ecs::
+
+Detects unusually rare processes on Windows hosts, which can indicate execution 
+of unauthorized services, malware, or persistence mechanisms.
++
+Processes are considered rare when they only run occasionally as compared with
+other processes running on the host.
+
+Job details:::
+
+* Analyzes host activity logs where `host.os.family` or `host.os.type` is 
+`windows`.
+* Models occurrences of process activities on the host. 
+* Detects unusually rare processes compared to other processes on the host 
+(using the
+{ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
+* Works on ECS compatible events across multiple indices.
+
+Required ECS fields:::
+
+* `event.category`
+* `event.type`
+* `host.name`
+* `host.os.family`
+* `host.os.type`
+* `process.name`
+* `user.name`
+
+v2_windows_anomalous_network_activity_ecs::
+
+Looks for unusual processes using the network which could indicate command-and-
+control, lateral movement, persistence, or data exfiltration activity.
++
+A process with unusual network activity can denote process exploitation or
+injection, where the process is used to run persistence mechanisms that allow a
+malicious actor remote access or control of the host, data exfiltration, and
+execution of unauthorized network applications.
+
+Job details:::
+
+* Analyzes network activity logs where `host.os.family` is `windows`.
+* Models the occurrences of processes that cause network activity.
+* Detects network activity caused by processes that occur rarely compared to 
+other processes (using the
+{ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
+* Works on ECS compatible events across multiple indices.
+
+Required ECS fields:::
+
+* `destination.ip`
+* `event.category`
+* `event.type`
+* `host.name`
+* `host.os.family`
+* `host.os.type`
+* `process.name`
+* `user.name`
+
+v2_windows_anomalous_path_activity_ecs::
+
+Looks for activity in unusual paths, which might indicate execution of malware 
+or persistence mechanisms.
++
+Windows payloads often execute from user profile paths. In corporate Windows 
+environments, software installation is centrally managed and it is unusual for 
+programs to be executed from user or temporary directories. Processes executed 
+from these locations can denote that a user downloaded software directly from 
+the internet or a malicious script/macro executed malware.
+
+Job details:::
+
+* Analyzes host activity logs where `host.os.family` or `host.os.type` is 
+`windows`.
+* Models occurrences of processes in paths.
+* Detects activity in unusual paths (using the
+{ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
+* Works on ECS compatible events across multiple indices.
+
+Required ECS fields:::
+
+* `event.category`
+* `event.type`
+* `host.os.family`
+* `host.name`
+* `host.os.type`
+* `process.name`
+* `process.working_directory`
+* `user.name`
+
+v2_windows_anomalous_process_all_hosts_ecs::
+
+Looks for processes that are unusual to all Windows hosts. Such unusual 
+processes may indicate execution of unauthorized services, malware, or 
+persistence mechanisms.
++
+This reduces the detection of false positives since automated maintenance
+processes usually only run occasionally on a single machine but are common to
+all or many hosts in a fleet.
+
+Job details:::
+
+* Analyzes host activity logs where `host.os.family` or `host.os.type` is 
+`windows`.
+* Models the occurrences of processes on all hosts.
+* Detects processes that occur rarely compared to other processes on all hosts 
+(using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
+* Works on ECS compatible events across multiple indices.
+
+Required ECS fields:::
+
+* `event.category`
+* `event.type`
+* `host.name`
+* `host.os.family`
+* `process.executable`
+* `process.name`
+* `user.name`
+
+v2_windows_anomalous_process_creation::
+
+Identifies unusual process relationships that can indicate
+malware execution or persistence mechanisms.
++
+Malicious scripts often call on other applications and processes as part of
+their exploit payload. For example, when a malicious Office document runs
+scripts as part of an exploit payload, Excel or Word may start a script
+interpreter process, which, in turn, runs a script that downloads and executes
+malware. Another common scenario is Outlook running an unusual process when
+malware is downloaded in an email.
++
+Monitoring and identifying anomalous process relationships is an excellent way
+of detecting new and emerging malware that is not yet recognized by anti-virus
+scanners.
+
+Job details:::
+
+* Analyzes host activity logs where `host.os.family` or `host.os.family` is 
+`windows`.
+* Models occurrences of process creation activities (`partition_field_name` is 
+`process.parent.name`).
+* Detects process relationships that are rare compared to other process 
+relationships (using the
+{ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
+* Works on ECS compatible events across multiple indices.
+
+Required ECS fields:::
+
+* `event.category`
+* `event.type`
+* `host.name`
+* `host.os.family`
+* `host.os.type`
+* `process.name`
+* `process.parent.name`
+* `user.name`
+
+v2_windows_anomalous_user_name_ecs::
+
+Searches for activity from users who are not normally active, which can
+indicate unauthorized changes, activity by unauthorized users, lateral
+movement, and compromised credentials.
++
+In organizations, new usernames are not often created apart from specific types 
+of system activities, such as creating new accounts for new employees. These 
+user accounts quickly become active and routine.
++
+Events from rarely used usernames can point to suspicious activity. 
+Additionally, automated Linux fleets tend to see activity from rarely used 
+usernames only when personnel log in to make authorized or unauthorized 
+changes, or threat actors have acquired credentials and log in for malicious 
+purposes. Unusual usernames can also indicate pivoting, where compromised 
+credentials are used to try and move laterally from one host to another.
+
+Job details:::
+
+* Analyzes host activity logs where `host.os.type` or `host.os.family` is `windows`.
+* Models user activity.
+* Detects users that are rarely or unusually active compared to other users 
+(using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
+* Works on ECS compatible events across multiple indices
+
+Required ECS fields:::
+
+* `event.category`
+* `event.type`
+* `host.name`
+* `host.os.family`
+* `host.os.type`
+* `process.name`
+* `user.name`
+
+v2_windows_rare_metadata_process::
+
+Looks for anomalous access to the metadata service by an unusual process. The 
+metadata service may be targeted in order to harvest credentials or user data 
+scripts containing secrets.
+
+Job details:::
+
+* Analyzes host activity logs where `host.os.family` is `windows` and
+`destination.ip` is the metadata service.
+* Models process activity.
+* Detects processes that are rarely or unusually active compared to other 
+processes (using the
+{ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
+* Works on ECS compatible events across multiple indices.
+
+Required ECS fields:::
+
+* `destination.ip`
+* `host.name`
+* `host.os.family`
+* `process.name`
+* `user.name`
+
+v2_windows_rare_metadata_user::
+
+Looks for anomalous access to the metadata service by an unusual user. The 
+metadata service may be targeted in order to harvest credentials or user data 
+scripts containing secrets.
+
+Job details:::
+
+* Analyzes host activity logs where `host.os.family` is `windows` and
+`destination.ip` is the metadata service.
+* Models user activity.
+* Detects users that are rarely or unusually active compared to other users 
+(using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
+
+Required ECS fields:::
+
+* `destination.ip`
+* `host.name`
+* `host.os.family`
+* `user.name`
+
+// end::security-windows-jobs[]
+
+[discrete]
 [[security-winlogbeat-jobs]]
-== Security {winlogbeat}
+== Security: {winlogbeat}
 
 These configurations are only available if data exists that matches the 
 recognizer query specified in the
@@ -1137,7 +1568,7 @@ Required ECS fields when not using {beats}:::
 
 [discrete]
 [[security-winlogbeat-authentication-jobs]]
-== Security {winlogbeat} authentication
+== Security: {winlogbeat} authentication
 
 These configurations are only available if data exists that matches the 
 recognizer query specified in the

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-siem.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-siem.asciidoc
@@ -653,7 +653,7 @@ Required ECS fields when not using {beats}:::
 [[security-linux-jobs]]
 == Security: Linux
 
-Detect suspicious activity using ECS Linux events. Tested with {auditbeat} and {agent}.
+Detect suspicious activity using ECS Linux events.
 
 These configurations are only available if data exists that matches the 
 recognizer query specified in the
@@ -681,6 +681,7 @@ activities (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function])
 
 Required {beats} or {agent} integrations:::
 
+* beta:[] {elastic-endpoint} integration
 * {auditbeat}
 
 Required ECS fields:::
@@ -714,6 +715,7 @@ hosts (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
 
 Required {beats} or {agent} integrations:::
 
+* beta:[] {elastic-endpoint} integration
 * {auditbeat}
 
 Required ECS fields:::
@@ -754,6 +756,7 @@ is `debian`, `redhat`, `suse`, or `ubuntu`.
 
 Required {beats} or {agent} integrations:::
 
+* beta:[] {elastic-endpoint} integration
 * {auditbeat}
 
 Required ECS fields:::
@@ -784,6 +787,7 @@ processes (using the
 
 Required {beats} or {agent} integrations:::
 
+* beta:[] {elastic-endpoint} integration
 * {auditbeat}
 
 Required ECS fields:::
@@ -813,6 +817,7 @@ Job details:::
 
 Required {beats} or {agent} integrations:::
 
+* beta:[] {elastic-endpoint} integration
 * {auditbeat}
 
 Required ECS fields:::
@@ -843,6 +848,7 @@ Job details:::
 
 Required {beats} or {agent} integrations:::
 
+* beta:[] {elastic-endpoint} integration
 * {auditbeat}
 
 Required ECS fields:::
@@ -1039,8 +1045,7 @@ Required ECS fields when not using {beats}:::
 [[security-windows-jobs]]
 == Security: Windows
 
-Detects suspicious activity using ECS Windows events. Tested with {winlogbeat} 
-and {agent}.
+Detects suspicious activity using ECS Windows events.
 
 These configurations are available only if data exists that matches the 
 recognizer query specified in the

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-siem.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-siem.asciidoc
@@ -51,7 +51,7 @@ Job details:::
 * Detects network activity caused by processes that occur rarely compared to 
   other processes (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
 
-Required {beats}:::
+Required {beats} or {agent} integrations:::
 
 * {auditbeat}
 
@@ -80,7 +80,7 @@ Job details:::
   activities (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
 
 +
-Required {beats}:::
+Required {beats} or {agent} integrations:::
 
 * {auditbeat} (Linux)
 
@@ -99,7 +99,7 @@ Job details:::
 * Detects listening port activity that occurs rarely compared to 
   other port activities (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
 
-Required {beats}:::
+Required {beats} or {agent} integrations:::
 
 * {auditbeat} (Linux)
 
@@ -125,7 +125,7 @@ Job details:::
 * Detects a web URL request that is rare compared to other web URL 
   requests (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
 
-Required {beats}:::
+Required {beats} or {agent} integrations:::
 
 * {auditbeat} (Linux)
 
@@ -154,7 +154,7 @@ Job details:::
 * Detects processes that occur rarely compared to other processes on all 
   hosts (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
 
-Required {beats}:::
+Required {beats} or {agent} integrations:::
 
 * {auditbeat}
 
@@ -191,7 +191,7 @@ Job details:::
 * Detects users that are rarely or unusually active compared to other users 
   (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
 
-Required {beats}:::
+Required {beats} or {agent} integrations:::
 
 * {auditbeat}
 
@@ -220,7 +220,7 @@ Job details:::
 * Detects users that are rarely or unusually active compared to other users 
   (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
 
-Required {beats}:::
+Required {beats} or {agent} integrations:::
 
 * {auditbeat}
 
@@ -248,7 +248,7 @@ Job details:::
 * Detects users that are rarely or unusually active compared to other users 
   (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
 
-Required {beats}:::
+Required {beats} or {agent} integrations:::
 
 * {auditbeat}
 
@@ -270,7 +270,7 @@ Job details:::
 * Detects processes that are rarely or unusually active compared to other processes 
   (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
 
-Required {beats}:::
+Required {beats} or {agent} integrations:::
 
 * {auditbeat}
 
@@ -294,7 +294,7 @@ Job details:::
 * Detects processes that are rarely or unusually active compared to other processes 
   (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
 
-Required {beats}:::
+Required {beats} or {agent} integrations:::
 
 * {auditbeat}
 
@@ -318,7 +318,7 @@ Job details:::
 * Detects users that are rarely or unusually active compared to other users 
   (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
 
-Required {beats}:::
+Required {beats} or {agent} integrations:::
 
 * {auditbeat}
 
@@ -339,7 +339,7 @@ Job details:::
 * Detects users that are rarely or unusually active compared to other users 
   (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
 
-Required {beats}:::
+Required {beats} or {agent} integrations:::
 
 * {auditbeat}
 
@@ -365,7 +365,7 @@ Job details:::
 * Detects users that are rarely or unusually active compared to other users 
   (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
 
-Required {beats}:::
+Required {beats} or {agent} integrations:::
 
 * {auditbeat}
 
@@ -393,7 +393,7 @@ Job details:::
 * Detects users that are rarely or unusually active compared to other users 
   (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
 
-Required {beats}:::
+Required {beats} or {agent} integrations:::
 
 * {auditbeat}
 
@@ -421,7 +421,7 @@ Job details:::
 * Detects users that are rarely or unusually active compared to other users 
   (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
 
-Required {beats}:::
+Required {beats} or {agent} integrations:::
 
 * {auditbeat}
 
@@ -449,7 +449,7 @@ Job details:::
 * Detects users that are rarely or unusually active compared to other users 
   (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
 
-Required {beats}:::
+Required {beats} or {agent} integrations:::
 
 * {auditbeat}
 
@@ -475,7 +475,7 @@ Job details:::
 * Models occurrences of process activities on the host. 
 * Detects unusually rare processes compared to other processes on the host (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
 
-Required {beats}:::
+Required {beats} or {agent} integrations:::
 
 * {auditbeat}
 
@@ -512,7 +512,7 @@ Job details:::
 * Detects unusually high number of authentication attempts (using the 
   {ml-docs}/ml-count-functions.html#ml-nonzero-count[`high_non_zero_count` function]).
 
-Required {beats}:::
+Required {beats} or {agent} integrations:::
 
 * {auditbeat} (Linux)
 
@@ -550,7 +550,7 @@ Job details:::
 the `aws.cloudtrail.error_message` field is unusual
 (using the {ml-docs}/ml-count-functions.html#ml-distinct-count[`high_distinct_count` function]).
 
-Required {beats}:::
+Required {beats} or {agent} integrations:::
 
 * {filebeat}
 
@@ -570,7 +570,7 @@ Job details:::
 * Detects `aws.cloudtrail.error_code` values that have never or rarely occurred
 before (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
 
-Required {beats}:::
+Required {beats} or {agent} integrations:::
 
 * {filebeat}
 
@@ -589,7 +589,7 @@ Job details:::
 * Detects unusually rare `event.action` values compared to other cities (using
 the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
 
-Required {beats}:::
+Required {beats} or {agent} integrations:::
 
 * {filebeat}
 
@@ -609,7 +609,7 @@ Job details:::
 * Detects unusually rare `event.action` values compared to other countries
 (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
 
-Required {beats}:::
+Required {beats} or {agent} integrations:::
 
 * {filebeat}
 
@@ -630,7 +630,7 @@ Job details:::
 * Detects unusually rare `event.action` values compared to other users (using
 the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
 
-Required {beats}:::
+Required {beats} or {agent} integrations:::
 
 * {filebeat}
 
@@ -671,6 +671,10 @@ Job details:::
 activities (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
 * Works on ECS compatible events across multiple indices.
 
+Required {beats} or {agent} integrations:::
+
+* {auditbeat}
+
 Required ECS fields:::
 
 * `destination.ip`
@@ -699,6 +703,10 @@ is `debian`, `redhat`, `suse`, or `ubuntu`.
 * Detects processes that occur rarely compared to other processes on all Linux 
 hosts (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
 * Works on ECS compatible events across multiple indices.
+
+Required {beats} or {agent} integrations:::
+
+* {auditbeat}
 
 Required ECS fields:::
 
@@ -736,6 +744,10 @@ is `debian`, `redhat`, `suse`, or `ubuntu`.
 (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
 * Works on ECS compatible events across multiple indices.  
 
+Required {beats} or {agent} integrations:::
+
+* {auditbeat}
+
 Required ECS fields:::
 
 * `event.category`
@@ -764,8 +776,7 @@ processes (using the
 
 Required {beats} or {agent} integrations:::
 
-* {elastic-endpoint} integration
-* {winlogbeat}
+* {auditbeat}
 
 Required ECS fields:::
 
@@ -792,6 +803,10 @@ Job details:::
 (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
 * Works on ECS compatible events across multiple indices.
 
+Required {beats} or {agent} integrations:::
+
+* {auditbeat}
+
 Required ECS fields:::
 
 * `destination.ip`
@@ -817,6 +832,10 @@ Job details:::
 * Detects unusually rare processes compared to other processes on the host 
 (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
 * Works on ECS compatible events across multiple indices.
+
+Required {beats} or {agent} integrations:::
+
+* {auditbeat}
 
 Required ECS fields:::
 
@@ -857,7 +876,7 @@ Job details:::
 * Detects unusual DNS activity (using the 
   {ml-docs}/ml-info-functions.html#ml-info-content[`high_info_content` function]).
 
-Required {beats}:::
+Required {beats} or {agent} integrations:::
 
 * {packetbeat} (Windows and Linux)
 
@@ -894,7 +913,7 @@ Job details:::
 * Detects DNS activity that is rare compared to other DNS activities (using the 
   {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
 
-Required {beats}:::
+Required {beats} or {agent} integrations:::
 
 * {packetbeat} (Windows and Linux)
 
@@ -926,7 +945,7 @@ Job details:::
 * Detects HTTP or TLS domain activity that is rare compared to other 
   activities (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
 
-Required {beats}:::
+Required {beats} or {agent} integrations:::
 
 * {packetbeat} (Windows and Linux)
 
@@ -961,7 +980,7 @@ Job details:::
 * Detects URL activity that rarely occurs compared to other URL activities 
   (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
 
-Required {beats}:::
+Required {beats} or {agent} integrations:::
 
 * {packetbeat} (Windows and Linux)
 
@@ -994,7 +1013,7 @@ Job details:::
 * Detects HTTP user agent activity that occurs rarely compared to other HTTP 
   user agent activities (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
 
-Required {beats}:::
+Required {beats} or {agent} integrations:::
 
 * {packetbeat} (Windows and Linux)
 
@@ -1108,6 +1127,10 @@ Job details:::
 {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
 * Works on ECS compatible events across multiple indices.
 
+Required {beats} or {agent} integrations:::
+
+* {winlogbeat}
+
 Required ECS fields:::
 
 * `event.category`
@@ -1137,6 +1160,11 @@ Job details:::
 * Detects processes that occur rarely compared to other processes on all hosts 
 (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
 * Works on ECS compatible events across multiple indices.
+
+Required {beats} or {agent} integrations:::
+
+* {elastic-endpoint} integration
+* {winlogbeat}
 
 Required ECS fields:::
 
@@ -1314,7 +1342,7 @@ Job details:::
 * Models occurrences of process activities on the host. 
 * Detects unusually rare processes compared to other processes on the host (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
 
-Required {beats}:::
+Required {beats} or {agent} integrations:::
 
 * {winlogbeat}
 
@@ -1344,7 +1372,7 @@ Job details:::
 * Detects network activity caused by processes that occur rarely compared to 
   other processes (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
 
-Required {beats}:::
+Required {beats} or {agent} integrations:::
 
 * {winlogbeat}
 
@@ -1374,7 +1402,7 @@ Job details:::
 * Models occurrences of processes in paths.
 * Detects activity in unusual paths (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
 
-Required {beats}:::
+Required {beats} or {agent} integrations:::
 
 * {winlogbeat} (Windows)
 
@@ -1403,7 +1431,7 @@ Job details:::
 * Detects processes that occur rarely compared to other processes on all 
   hosts (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
 
-Required {beats}:::
+Required {beats} or {agent} integrations:::
 
 * {winlogbeat}
 
@@ -1440,7 +1468,7 @@ Job details:::
 * Detects process relationships that are rare compared to other process 
   relationships (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
 
-Required {beats}:::
+Required {beats} or {agent} integrations:::
 
 * {winlogbeat} (Windows)
 
@@ -1467,7 +1495,7 @@ Job details:::
   script activities (using the 
   {ml-docs}/ml-info-functions.html#ml-info-content[`high_info_content` function]).
 
-Required {beats}:::
+Required {beats} or {agent} integrations:::
 
 * {winlogbeat} (Windows)
 
@@ -1489,7 +1517,7 @@ Job details:::
 * Models occurrences of Windows service activities.
 * Detects Windows service activities that occur rarely compared to other Windows service activities (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
 
-Required {beats}:::
+Required {beats} or {agent} integrations:::
 
 * {winlogbeat} (Windows)
 
@@ -1520,7 +1548,7 @@ Job details:::
 * Detects users that are rarely or unusually active compared to other users 
   (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
 
-Required {beats}:::
+Required {beats} or {agent} integrations:::
 
 * {winlogbeat}
 
@@ -1546,7 +1574,7 @@ Job details:::
 * Detects processes that are rarely or unusually active compared to other processes 
   (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
 
-Required {beats}:::
+Required {beats} or {agent} integrations:::
 
 * {winlogbeat} (Windows)
 
@@ -1570,7 +1598,7 @@ Job details:::
 * Detects users that are rarely or unusually active compared to other users 
   (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
 
-Required {beats}:::
+Required {beats} or {agent} integrations:::
 
 * {winlogbeat} (Windows)
 
@@ -1593,7 +1621,7 @@ Job details:::
 * Models occurrences of user context switches.
 * Detects user context switches that occur rarely compared to other user context switches (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
 
-Required {beats}:::
+Required {beats} or {agent} integrations:::
 
 * {winlogbeat} (Windows)
 
@@ -1631,7 +1659,7 @@ Job details:::
 * Detects user remote login activities that occur rarely compared to other 
   user remote login activities (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
 
-Required {beats}:::
+Required {beats} or {agent} integrations:::
 
 * {winlogbeat} (Windows)
 

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-siem.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-siem.asciidoc
@@ -9,7 +9,7 @@ These {anomaly-jobs} appear by default in the Anomaly Detection interface of
 the {security-guide}/machine-learning.html[{security-app}] in {kib}. They
 help you automatically detect file system and network anomalies on your hosts.
 However, if you don't use Beats or the {agent}, you need to map your data to 
-the ECS fields that are listed for every job.
+the ECS fields that are listed for each job.
 
 IMPORTANT: If the {agent} or Beat is version 7.10 or higher, use the
 <<security-linux-jobs>> and <<security-windows-jobs>> jobs. For earlier 
@@ -734,6 +734,10 @@ usernames only when personnel log in to make authorized or unauthorized
 changes, or threat actors have acquired credentials and log in for malicious 
 purposes. Unusual usernames can also indicate pivoting, where compromised 
 credentials are used to try and move laterally from one host to another.
++
+NOTE: If you collect data from the Windows security event log and you configure 
+it to audit process creation, this job can use the 4688 events that occur every 
+time a new process starts.
 
 Job details:::
 
@@ -1046,6 +1050,10 @@ of unauthorized services, malware, or persistence mechanisms.
 +
 Processes are considered rare when they only run occasionally as compared with
 other processes running on the host.
++
+NOTE: If you collect data from the Windows security event log and you configure 
+it to audit process creation, this job can use the 4688 events that occur every 
+time a new process starts.
 
 Job details:::
 
@@ -1059,7 +1067,7 @@ Job details:::
 
 Required {beats} or {agent} integrations:::
 
-* {elastic-endpoint} integration
+* beta:[] {elastic-endpoint} integration
 * {winlogbeat}
 
 Required ECS fields:::
@@ -1093,7 +1101,7 @@ other processes (using the
 
 Required {beats} or {agent} integrations:::
 
-* {elastic-endpoint} integration
+* beta:[] {elastic-endpoint} integration
 * {winlogbeat}
 
 Required ECS fields:::
@@ -1163,7 +1171,7 @@ Job details:::
 
 Required {beats} or {agent} integrations:::
 
-* {elastic-endpoint} integration
+* beta:[] {elastic-endpoint} integration
 * {winlogbeat}
 
 Required ECS fields:::
@@ -1205,7 +1213,7 @@ relationships (using the
 
 Required {beats} or {agent} integrations:::
 
-* {elastic-endpoint} integration
+* beta:[] {elastic-endpoint} integration
 * {winlogbeat}
 
 Required ECS fields:::
@@ -1235,6 +1243,10 @@ usernames only when personnel log in to make authorized or unauthorized
 changes, or threat actors have acquired credentials and log in for malicious 
 purposes. Unusual usernames can also indicate pivoting, where compromised 
 credentials are used to try and move laterally from one host to another.
++
+NOTE: If you collect data from the Windows security event log and you configure 
+it to audit process creation, this job can use the 4688 events that occur every 
+time a new process starts.
 
 Job details:::
 
@@ -1246,7 +1258,7 @@ Job details:::
 
 Required {beats} or {agent} integrations:::
 
-* {elastic-endpoint} integration
+* beta:[] {elastic-endpoint} integration
 * {winlogbeat}
 
 Required ECS fields:::
@@ -1264,6 +1276,10 @@ v2_windows_rare_metadata_process::
 Looks for anomalous access to the metadata service by an unusual process. The 
 metadata service may be targeted in order to harvest credentials or user data 
 scripts containing secrets.
++
+NOTE: If you collect data from the Windows security event log and you configure 
+it to audit process creation, this job can use the 4688 events that occur every 
+time a new process starts.
 
 Job details:::
 
@@ -1277,7 +1293,7 @@ processes (using the
 
 Required {beats} or {agent} integrations:::
 
-* {elastic-endpoint} integration
+* beta:[] {elastic-endpoint} integration
 * {winlogbeat}
 
 Required ECS fields:::
@@ -1304,7 +1320,7 @@ Job details:::
 
 Required {beats} or {agent} integrations:::
 
-* {elastic-endpoint} integration
+* beta:[] {elastic-endpoint} integration
 * {winlogbeat}
 
 Required ECS fields:::

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-siem.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-siem.asciidoc
@@ -657,7 +657,9 @@ Detect suspicious activity using ECS Linux events.
 
 These configurations are only available if data exists that matches the 
 recognizer query specified in the
-https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux/manifest.json#L8[manifest file].
+https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux/manifest.json#L8[manifest file]. For
+example, all of these jobs analyze network activity logs where `host.os.type` is 
+`linux` or `host.os.family` is `debian`, `redhat`, `suse`, or `ubuntu`.
 
 IMPORTANT: In 7.11 or later versions, use these jobs instead of the <<security-auditbeat-jobs>> jobs.footnote:duplicatelinuxjobs[]
 
@@ -672,8 +674,6 @@ can indicate unauthorized access or threat actor activity.
 
 Job details:::
 
-* Analyzes network activity logs where `host.os.type` is `linux` or 
-`host.os.family` is `debian`, `redhat`, `suse`, or `ubuntu`.
 * Models destination port activity.
 * Detects destination port activity that occurs rarely compared to other port 
 activities (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
@@ -706,8 +706,6 @@ all or many hosts in a fleet.
 
 Job details:::
 
-* Analyzes host activity logs where `host.os.type` is `linux` or `host.os.family`
-is `debian`, `redhat`, `suse`, or `ubuntu`.
 * Models the occurrences of processes on all Linux hosts.
 * Detects processes that occur rarely compared to other processes on all Linux 
 hosts (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
@@ -747,8 +745,6 @@ credentials are used to try and move laterally from one host to another.
 
 Job details:::
 
-* Analyzes host activity logs where `host.os.type` is `linux` or `host.os.family`
-is `debian`, `redhat`, `suse`, or `ubuntu`.
 * Models user activity.
 * Detects users that are rarely or unusually active compared to other users 
 (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
@@ -776,9 +772,8 @@ metadata service may be targeted in order to harvest credentials or user data
 scripts containing secrets.  
 
 Job details:::
-* Analyzes host activity logs where `destination.ip` is the metadata service and 
-`host.os.type` is `linux` or `host.os.family` is `debian`, `redhat`, `suse`, or
-`ubuntu`.
+
+* Analyzes host activity logs where `destination.ip` is the metadata service
 * Models process activity.
 * Detects processes that are rarely or unusually active compared to other 
 processes (using the
@@ -807,9 +802,7 @@ scripts containing secrets.
 
 Job details:::
 
-* Analyzes host activity logs where `destination.ip` is the metadata service and
-`host.os.type` is `linux` or `host.os.family` is `debian`, `redhat`, `suse`, or
-`ubuntu`.
+* Analyzes host activity logs where `destination.ip` is the metadata service
 * Models user activity.
 * Detects users that are rarely or unusually active compared to other users 
 (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
@@ -839,8 +832,6 @@ other processes running on the host.
 
 Job details:::
 
-* Analyzes host activity logs where `host.os.type` is `linux` or 
-`host.os.family` is `debian`, `redhat`, `suse`, or `ubuntu`.
 * Models occurrences of process activities on the host. 
 * Detects unusually rare processes compared to other processes on the host 
 (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
@@ -1049,7 +1040,10 @@ Detects suspicious activity using ECS Windows events.
 
 These configurations are available only if data exists that matches the 
 recognizer query specified in the
-https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows/manifest.json#L8[manifest file].
+https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows/manifest.json#L8[manifest file]. For
+example, all of these jobs analyze host activity logs where `host.os.family` or 
+`host.os.type` is `windows`.
+
 If there are additional requirements such as installing the Windows System
 Monitor (Sysmon) or auditing process creation in the Windows security event log,
 they are listed for each job.
@@ -1076,8 +1070,6 @@ other processes running on the host.
 
 Job details:::
 
-* Analyzes host activity logs where `host.os.family` or `host.os.type` is 
-`windows`.
 * Models occurrences of process activities on the host. 
 * Detects unusually rare processes compared to other processes on the host 
 (using the
@@ -1126,7 +1118,6 @@ execution of unauthorized network applications.
 
 Job details:::
 
-* Analyzes network activity logs where `host.os.family` is `windows`.
 * Models the occurrences of processes that cause network activity.
 * Detects network activity caused by processes that occur rarely compared to 
 other processes (using the
@@ -1162,8 +1153,6 @@ the internet or a malicious script/macro executed malware.
 
 Job details:::
 
-* Analyzes host activity logs where `host.os.family` or `host.os.type` is 
-`windows`.
 * Models occurrences of processes in paths.
 * Detects activity in unusual paths (using the
 {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
@@ -1196,8 +1185,6 @@ all or many hosts in a fleet.
 
 Job details:::
 
-* Analyzes host activity logs where `host.os.family` or `host.os.type` is 
-`windows`.
 * Models the occurrences of processes on all hosts.
 * Detects processes that occur rarely compared to other processes on all hosts 
 (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
@@ -1240,8 +1227,6 @@ scanners.
 
 Job details:::
 
-* Analyzes host activity logs where `host.os.family` or `host.os.family` is 
-`windows`.
 * Models occurrences of process creation activities (`partition_field_name` is 
 `process.parent.name`).
 * Detects process relationships that are rare compared to other process 
@@ -1289,7 +1274,6 @@ credentials are used to try and move laterally from one host to another.
 
 Job details:::
 
-* Analyzes host activity logs where `host.os.type` or `host.os.family` is `windows`.
 * Models user activity.
 * Detects users that are rarely or unusually active compared to other users 
 (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
@@ -1323,8 +1307,7 @@ scripts containing secrets.
 
 Job details:::
 
-* Analyzes host activity logs where `host.os.family` is `windows` and
-`destination.ip` is the metadata service.
+* Analyzes host activity logs where `destination.ip` is the metadata service.
 * Models process activity.
 * Detects processes that are rarely or unusually active compared to other 
 processes (using the
@@ -1352,8 +1335,7 @@ scripts containing secrets.
 
 Job details:::
 
-* Analyzes host activity logs where `host.os.family` is `windows` and
-`destination.ip` is the metadata service.
+* Analyzes host activity logs where `destination.ip` is the metadata service.
 * Models user activity.
 * Detects users that are rarely or unusually active compared to other users 
 (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).


### PR DESCRIPTION
Related to https://github.com/elastic/kibana/pull/85065

This PR adds documentation for the new modules in https://www.elastic.co/guide/en/machine-learning/master/ootb-ml-jobs-siem.html, based on the details in https://github.com/elastic/kibana/tree/master/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux and https://github.com/elastic/kibana/tree/master/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows and the existing job descriptions.

### Preview

* https://stack-docs_1504.docs-preview.app.elstc.co/guide/en/machine-learning/master/ootb-ml-jobs-siem.html#security-linux-jobs
* https://stack-docs_1504.docs-preview.app.elstc.co/guide/en/machine-learning/master/ootb-ml-jobs-siem.html#security-windows-jobs