### PR TITLE
[7.11][DOCS] Add machine learning overview to tutorial (#1470)

### DIFF
--- a/docs/en/stack/ml/get-started/ml-getting-started.asciidoc
+++ b/docs/en/stack/ml/get-started/ml-getting-started.asciidoc
@@ -1,6 +1,54 @@
 [[ml-getting-started]]
 == Getting started with {ml}
 
+{ml-cap} features analyze your data and generate models for its patterns of
+behavior. The type of analysis that you choose depends on the questions or
+problems you want to address and the type of data you have available.
+
+[discrete]
+[[get-started-unsupervised]]
+=== Unsupervised {ml}
+
+There are two types of analysis that can deduce the patterns and relationships
+within your data without training or intervention: _{anomaly-detect}_ and
+_{oldetection}_.
+
+<<xpack-ml,{anomaly-detect-cap}>> requires time series data. It constructs a
+probability model and can run continuously to identify unusual events as they
+occur. The model evolves over time; you can use its insights to forecast future
+behavior.
+
+<<dfa-outlier-detection,{oldetection-cap}>> does not require time series data;
+it identifies unusual points in a data set by analyzing how close each data
+point is to others and the density of the cluster of points around it. It does
+not run continuously; it generates a copy of your data set where each data point
+is annotated with an {olscore}. The score indicates the extent to which a data
+point is an outlier compared to other data points.
+
+[discrete]
+[[get-started-supervised]]
+=== Supervised {ml}
+
+There are two types of analysis that require training data sets:
+_{classification}_ and _{regression}_.
+
+In both cases, the result is a copy of your data set where each data point is
+annotated with predictions and a trained model, which you can deploy to make
+predictions for new data. For more information, refer to
+<<ml-supervised-workflow>>.
+
+<<dfa-classification,{classification-cap}>> learns relationships between your
+data points in order to predict discrete categorical values, such as whether a
+DNS request originates from a malicious or benign domain.
+
+<<dfa-regression,{regression-cap}>> learns relationships between your data
+points in order to predict continuous numerical values, such as the response
+time for a web request.
+
+[discrete]
+[[get-started-prereqs]]
+=== Try it out
+
 Ready to take {ml} for a test drive? Follow this tutorial to:
 
 * Try out the **{data-viz}**
@@ -13,10 +61,6 @@ will hopefully be inspired to use it to detect anomalies in your own data.
 Need more context? Check out the
 {ref}/elasticsearch-intro.html[{es} introduction] to learn the lingo and
 understand the basics of how {es} works.
-
-[discrete]
-[[get-started-prereqs]]
-=== Prerequisites
 
 . Before you can play with the {ml-features}, you must install {es} and {kib}.
 {es} stores the data and the analysis results. {kib} provides a helpful user 


### PR DESCRIPTION
Backports https://github.com/elastic/stack-docs/pull/1470