### PR TITLE
[DOCS] Fixes branch in path to module

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-apache.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-apache.asciidoc
@@ -14,7 +14,7 @@ https://github.com/elastic/kibana/tree/{branch}/x-pack/plugins/ml/server/models/
 
 These configurations are only available if data exists that matches the 
 recognizer query specified in the 
-https://github.com/elastic/kibana/blob/6c58e63a8674478a76758243ec707355a56ee3d9/x-pack/plugins/ml/server/models/data_recognizer/modules/apache_ecs/manifest.json#L8[manifest file].
+https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/apache_ecs/manifest.json#L8[manifest file].
 
 low_request_rate_ecs::
 

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-apm.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-apm.asciidoc
@@ -17,7 +17,7 @@ https://github.com/elastic/kibana/tree/{branch}/x-pack/plugins/ml/server/models/
 Detect abnormal traces, anomalous spans, and identify periods of decreased
 throughput. These configurations are only available if data exists that matches 
 the recognizer query specified in the
-https://github.com/elastic/kibana/blob/6c58e63a8674478a76758243ec707355a56ee3d9/x-pack/plugins/ml/server/models/data_recognizer/modules/apm_nodejs/manifest.json#L8[mainfest file].
+https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/apm_nodejs/manifest.json#L8[mainfest file].
 
 abnormal_span_durations_nodejs::
 
@@ -47,7 +47,7 @@ than normal.
 Detect problematic spans and identify user agents that are potentially causing
 issues. These configurations are only available if data exists that matches the 
 recognizer query specified in the
-https://github.com/elastic/kibana/blob/6c58e63a8674478a76758243ec707355a56ee3d9/x-pack/plugins/ml/server/models/data_recognizer/modules/apm_jsbase/manifest.json#L8[manifest file].
+https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/apm_jsbase/manifest.json#L8[manifest file].
 
 abnormal_span_durations_jsbase::
 

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-auditbeat.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-auditbeat.asciidoc
@@ -14,7 +14,7 @@ https://github.com/elastic/kibana/tree/{branch}/x-pack/plugins/ml/server/models/
 
 These configurations are only available if data exists that matches the 
 recognizer query specified in the
-https://github.com/elastic/kibana/blob/6c58e63a8674478a76758243ec707355a56ee3d9/x-pack/plugins/ml/server/models/data_recognizer/modules/auditbeat_process_docker_ecs/manifest.json#L8[manifest file].
+https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/auditbeat_process_docker_ecs/manifest.json#L8[manifest file].
 
 docker_high_count_process_events_ecs::
 
@@ -33,7 +33,7 @@ docker_rare_process_activity_ecs::
 
 These configurations are only available if data exists that matches the 
 recognizer query specified in the
-https://github.com/elastic/kibana/blob/6c58e63a8674478a76758243ec707355a56ee3d9/x-pack/plugins/ml/server/models/data_recognizer/modules/auditbeat_process_hosts_ecs/manifest.json#L8[manifest file].
+https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/auditbeat_process_hosts_ecs/manifest.json#L8[manifest file].
 
 hosts_high_count_process_events_ecs::
 

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-metricbeat.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-metricbeat.asciidoc
@@ -13,7 +13,7 @@ monitor your servers. For more details, see the
 
 These configurations are only available if data exists that matches the 
 recognizer query specified in the
-https://github.com/elastic/kibana/blob/6c58e63a8674478a76758243ec707355a56ee3d9/x-pack/plugins/ml/server/models/data_recognizer/modules/metricbeat_system_ecs/manifest.json#L8[manifest file].
+https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/metricbeat_system_ecs/manifest.json#L8[manifest file].
 
 
 high_mean_cpu_iowait_ecs::

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-nginx.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-nginx.asciidoc
@@ -14,7 +14,7 @@ https://github.com/elastic/kibana/tree/{branch}/x-pack/plugins/ml/server/models/
 
 These configurations are only available if data exists that matches the 
 recognizer query specified in the
-https://github.com/elastic/kibana/blob/6c58e63a8674478a76758243ec707355a56ee3d9/x-pack/plugins/ml/server/models/data_recognizer/modules/nginx_ecs/manifest.json#L8[manifest file].
+https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/nginx_ecs/manifest.json#L8[manifest file].
 
 
 low_request_rate_ecs::

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-siem.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-siem.asciidoc
@@ -23,7 +23,7 @@ https://github.com/elastic/kibana/tree/{branch}/x-pack/plugins/ml/server/models/
 
 These configurations are only available if data exists that matches the 
 recognizer query specified in the
-https://github.com/elastic/kibana/blob/6c58e63a8674478a76758243ec707355a56ee3d9/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_auditbeat/manifest.json#L8[manifest file].
+https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_auditbeat/manifest.json#L8[manifest file].
 
 Detect suspicious network activity and unusual processes in {auditbeat} data.
 
@@ -490,7 +490,7 @@ Required ECS fields when not using {beats}:::
 
 These configurations are only available if data exists that matches the 
 recognizer query specified in the
-https://github.com/elastic/kibana/blob/6c58e63a8674478a76758243ec707355a56ee3d9/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_auditbeat_auth/manifest.json#L8[manifest file].
+https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_auditbeat_auth/manifest.json#L8[manifest file].
 
 Detect suspicious authentication events in {auditbeat} data.
 
@@ -527,7 +527,7 @@ Required ECS fields when not using {beats}:::
 
 These configurations are only available if data exists that matches the 
 recognizer query specified in the
-https://github.com/elastic/kibana/blob/6c58e63a8674478a76758243ec707355a56ee3d9/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_cloudtrail/manifest.json#L8[manifest file].
+https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_cloudtrail/manifest.json#L8[manifest file].
 
 Detect suspicious activity recorded in your CloudTrail logs.
 
@@ -644,7 +644,7 @@ Required ECS fields when not using {beats}:::
 
 These configurations are only available if data exists that matches the 
 recognizer query specified in the
-https://github.com/elastic/kibana/blob/6c58e63a8674478a76758243ec707355a56ee3d9/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_packetbeat/manifest.json#L8[manifest file].
+https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_packetbeat/manifest.json#L8[manifest file].
 
 Detect suspicious network activity in {packetbeat} data.
 
@@ -822,7 +822,7 @@ Required ECS fields when not using {beats}:::
 
 These configurations are only available if data exists that matches the 
 recognizer query specified in the
-https://github.com/elastic/kibana/blob/6c58e63a8674478a76758243ec707355a56ee3d9/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_winlogbeat/manifest.json#L8[manifest file].
+https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_winlogbeat/manifest.json#L8[manifest file].
 
 Detect unusual processes and network activity in {winlogbeat} data.
 
@@ -1141,7 +1141,7 @@ Required ECS fields when not using {beats}:::
 
 These configurations are only available if data exists that matches the 
 recognizer query specified in the
-https://github.com/elastic/kibana/blob/6c58e63a8674478a76758243ec707355a56ee3d9/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_winlogbeat_auth/manifest.json#L8[manifest file].
+https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_winlogbeat_auth/manifest.json#L8[manifest file].
 
 Detect suspicious authentication events in {winlogbeat} data.
 

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-uptime.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-uptime.asciidoc
@@ -14,7 +14,7 @@ https://github.com/elastic/kibana/tree/{branch}/x-pack/plugins/ml/server/models/
 
 These configurations are only available if data exists that matches the 
 recognizer query specified in the
-https://github.com/elastic/kibana/blob/6c58e63a8674478a76758243ec707355a56ee3d9/x-pack/plugins/ml/server/models/data_recognizer/modules/uptime_heartbeat/manifest.json#L8[manifest file].
+https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/uptime_heartbeat/manifest.json#L8[manifest file].
 
 
 high_latency_by_geo::


### PR DESCRIPTION
This PR fixes the URL for the manifest files in pages such as https://www.elastic.co/guide/en/machine-learning/master/ootb-ml-jobs-apache.html
It uses the "branch" attribute from shared files such as https://github.com/elastic/docs/blob/master/shared/versions/stack/master.asciidoc.