### PR TITLE
[DOCS] Fix highlights include. Fix coming tags

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -28,7 +28,7 @@ Upgrade Assistant provides information about which {dfeeds} need to be updated.
 <titleabbrev>APM</titleabbrev>
 ++++
 
-coming::[7.9.0]
+coming::[7.12.0]
 
 This list summarizes the most important breaking changes in APM. 
 For the complete list, go to {apm-server-ref}/breaking-changes.html[APM Server breaking changes].
@@ -41,12 +41,12 @@ For the complete list, go to {apm-server-ref}/breaking-changes.html[APM Server b
 <titleabbrev>Beats</titleabbrev>
 ++++
 
-coming::[7.9.0]
+coming::[7.12.0]
 
 This list summarizes the most important breaking changes in Beats. For the
 complete list, go to {beats-ref}/breaking-changes.html[Beats breaking changes].
 
-//include::{beats-repo-dir}/release-notes/breaking/breaking-7.7.asciidoc[tag=notable-breaking-changes]
+//include::{beats-repo-dir}/release-notes/breaking/breaking-7.12.asciidoc[tag=notable-breaking-changes]
 
 
 [[elasticsearch-breaking-changes]]
@@ -56,12 +56,12 @@ complete list, go to {beats-ref}/breaking-changes.html[Beats breaking changes].
 <titleabbrev>{es}</titleabbrev>
 ++++
 
-coming::[7.9.0]
+coming::[7.12.0]
 
 This list summarizes the most important breaking changes in {es} {version}. For
 the complete list, go to {ref}/breaking-changes.html[{es} breaking changes].
 
-//include::{es-repo-dir}/migration/migrate_7_8.asciidoc[tag=notable-breaking-changes]
+//include::{es-repo-dir}/migration/migrate_7_12.asciidoc[tag=notable-breaking-changes]
 
 [[elasticsearch-hadoop-breaking-changes]]
 === {es} Hadoop breaking changes
@@ -70,7 +70,7 @@ the complete list, go to {ref}/breaking-changes.html[{es} breaking changes].
 <titleabbrev>{es} Hadoop</titleabbrev>
 ++++
 
-coming::[7.9.0]
+coming::[7.12.0]
 
 This list summarizes the most important breaking changes in {es} Hadoop {version}.
 For the complete list, go to
@@ -85,12 +85,12 @@ include::{hadoop-repo-dir}/appendix/breaking.adoc[tag=notable-v7-breaking-change
 <titleabbrev>{kib}</titleabbrev>
 ++++
 
-coming::[7.9.0]
+coming::[7.12.0]
 
 This list summarizes the most important breaking changes in {kib} {version}. For
 the complete list, go to {kibana-ref}/breaking-changes.html[{kib} breaking changes].
 
-//include::{kib-repo-dir}/migration/migrate_7_8.asciidoc[tag=notable-breaking-changes]
+//include::{kib-repo-dir}/migration/migrate_7_12.asciidoc[tag=notable-breaking-changes]
 
 [[logstash-breaking-changes]]
 === {ls} breaking changes
@@ -99,7 +99,7 @@ the complete list, go to {kibana-ref}/breaking-changes.html[{kib} breaking chang
 <titleabbrev>{ls}</titleabbrev>
 ++++
 
-coming::[7.9.0]
+coming::[7.12.0]
 
 This list summarizes the most important breaking changes in {ls} {version}. For
 the complete list, go to

--- a/docs/en/install-upgrade/highlights.asciidoc
+++ b/docs/en/install-upgrade/highlights.asciidoc
@@ -14,7 +14,7 @@ highlights notable new features and enhancements in {minor-version}].
 <titleabbrev>Observability</titleabbrev>
 ++++
 
-coming::[7.11.0]
+coming::[7.12.0]
 
 This list summarizes the most important enhancements in Observability {minor-version}.
 
@@ -27,7 +27,7 @@ include::{obs-repo-dir}/whats-new.asciidoc[tag=whats-new]
 <titleabbrev>{es}</titleabbrev>
 ++++
 
-coming::[7.11.0]
+coming::[7.12.0]
 
 This list summarizes the most important enhancements in {es} {minor-version}.
 For the complete list, go to {ref}/release-highlights.html[{es} release highlights].
@@ -35,7 +35,7 @@ For the complete list, go to {ref}/release-highlights.html[{es} release highligh
 ////
 :leveloffset: +1
 
-include::{es-repo-dir}/reference/release-notes/highlights.asciidoc[tag=notable-highlights]
+include::{es-repo-dir}/release-notes/highlights.asciidoc[tag=notable-highlights]
 
 :leveloffset: -1
 ////
@@ -47,7 +47,7 @@ include::{es-repo-dir}/reference/release-notes/highlights.asciidoc[tag=notable-h
 <titleabbrev>{kib}</titleabbrev>
 ++++
 
-coming::[7.11.0]
+coming::[7.12.0]
 
 This list summarizes the most important enhancements in {kib} {minor-version}].
 


### PR DESCRIPTION
Changes:

- Removes the `/reference/` dir from the ES highlights include
- Updates the `coming` tags for the 7.12.0 release
- Updates several includes links for 7.12.0