### PR TITLE
[DOCS] Remove unnecessary license details

### DIFF
--- a/docs/en/install-upgrade/upgrading-stack.asciidoc
+++ b/docs/en/install-upgrade/upgrading-stack.asciidoc
@@ -28,15 +28,6 @@ with {version}.
 
 . Upgrade to 6.8 and use the {kibana-ref}/upgrade-assistant.html[{kib} Upgrade Assistant] to {ref}/docs-reindex.html[reindex]
 any indices that are not compatible with {version}.
-+
-[role="xpack"]
-.Upgrade Assistant
-******
-The Upgrade Assistant and migration APIs are enabled with both the Basic and
-Trial licenses. You can install the default distribution of 6.8 to use the
-Upgrade Assistant to prepare to upgrade even if you are upgrading to the OSS
-distribution of {version}.
-******
 
 . Use the Upgrade Assistant to identify any changes you need to make to your
 cluster configuration.

--- a/docs/en/install-upgrade/upgrading-stack.asciidoc
+++ b/docs/en/install-upgrade/upgrading-stack.asciidoc
@@ -26,8 +26,10 @@ By default, deprecation warnings are logged when the log level is set to `WARN`.
 . Review the <<elastic-stack-breaking-changes>> and upgrade your code to work
 with {version}.
 
-. Upgrade to 6.8 and use the {kibana-ref}/upgrade-assistant.html[{kib} Upgrade Assistant] to {ref}/docs-reindex.html[reindex]
-any indices that are not compatible with {version}.
+. Upgrade to last version of {prev-major-version} and use the
+{kibana-ref}/upgrade-assistant.html[{kib} Upgrade Assistant] to
+{ref}/docs-reindex.html[reindex] any indices that are not compatible with 
+{version}.
 
 . Use the Upgrade Assistant to identify any changes you need to make to your
 cluster configuration.


### PR DESCRIPTION
As per the new licensing change for Elasticsearch and Kibana (explained in great detail [in this blog post](https://www.elastic.co/blog/licensing-change)) this pull request removes outdated information about basic and trial licenses from the Installation and Upgrade Guide.

### Preview

https://stack-docs_1527.docs-preview.app.elstc.co/guide/en/elastic-stack/master/upgrading-elastic-stack.html