### PR TITLE
Updates instructions on how to import models

### DIFF
--- a/docs/en/stack/ml/df-analytics/ml-trained-models.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-trained-models.asciidoc
@@ -144,9 +144,6 @@ Elasticsearch cluster, for example by adding nodes.
 
 It is possible to import a model to your {es} cluster even if the model is not
 trained by Elastic {dfanalytics}. https://eland.readthedocs.io/[Eland] supports
-several types of models from libraries like
-scikit-learn[https://scikit-learn.org/stable/] and XGBoost[https://xgboost.readthedocs.io/].
-In Eland the
-https://eland.readthedocs.io/en/7.10.1b1/reference/api/eland.ml.MLModel.import_model.html#eland-ml-mlmodel-import-model[MLModel.import_model]
-API documentation contains details on importing a model and the types of models
-we support.
+https://www.elastic.co/guide/en/elasticsearch/client/eland/current/machine-learning.html[importing models]
+directly. Please refer to the latest
+https://eland.readthedocs.io/[Eland documentation] for more details.

--- a/docs/en/stack/ml/df-analytics/ml-trained-models.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-trained-models.asciidoc
@@ -145,5 +145,6 @@ Elasticsearch cluster, for example by adding nodes.
 It is possible to import a model to your {es} cluster even if the model is not
 trained by Elastic {dfanalytics}. https://eland.readthedocs.io/[Eland] supports
 https://www.elastic.co/guide/en/elasticsearch/client/eland/current/machine-learning.html[importing models]
-directly. Please refer to the latest
-https://eland.readthedocs.io/[Eland documentation] for more details.
+directly through its APIs. Please refer to the latest
+https://eland.readthedocs.io/[Eland documentation] for more information
+on supported model types and other details of using Eland to import models with.

--- a/docs/en/stack/ml/df-analytics/ml-trained-models.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-trained-models.asciidoc
@@ -143,15 +143,9 @@ Elasticsearch cluster, for example by adding nodes.
 == Importing an external model to the {stack}
 
 It is possible to import a model to your {es} cluster even if the model is not
-trained by Elastic {dfanalytics}.
-
-You can find an example of training a model, then importing it to {es} with
-`eland` in the
-https://eland.readthedocs.io/en/latest/examples/introduction_to_eland_webinar.html#Machine-Learning-Demo[eland machine learning demo].
-The example uses Python to train, save and import the model. However, you can
-use any client as long as the model conforms to the 
-https://github.com/elastic/ml-json-schemas[schema].
-
-// This blog post is a step by step description of how to create a random forest
-// classifier {ml} model outside of {es} by using Python, load it into {es},
-// then operationalize it with ingest pipelines.
+trained by Elastic {dfanalytics}. https://eland.readthedocs.io/[`eland`] supports several types of models from
+libraries like scikit-learn[https://scikit-learn.org/stable/] and XGBoost[https://xgboost.readthedocs.io/].
+In `eland` the
+https://eland.readthedocs.io/en/7.10.1b1/reference/api/eland.ml.MLModel.import_model.html#eland-ml-mlmodel-import-model[MLModel.import_model]
+API documentation contains details on importing a model and the types of models
+we support.

--- a/docs/en/stack/ml/df-analytics/ml-trained-models.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-trained-models.asciidoc
@@ -143,9 +143,10 @@ Elasticsearch cluster, for example by adding nodes.
 == Importing an external model to the {stack}
 
 It is possible to import a model to your {es} cluster even if the model is not
-trained by Elastic {dfanalytics}. https://eland.readthedocs.io/[`eland`] supports several types of models from
-libraries like scikit-learn[https://scikit-learn.org/stable/] and XGBoost[https://xgboost.readthedocs.io/].
-In `eland` the
+trained by Elastic {dfanalytics}. https://eland.readthedocs.io/[Eland] supports
+several types of models from libraries like
+scikit-learn[https://scikit-learn.org/stable/] and XGBoost[https://xgboost.readthedocs.io/].
+In Eland the
 https://eland.readthedocs.io/en/7.10.1b1/reference/api/eland.ml.MLModel.import_model.html#eland-ml-mlmodel-import-model[MLModel.import_model]
 API documentation contains details on importing a model and the types of models
 we support.


### PR DESCRIPTION
This update will point directly to the eland API which has an example and full list of supported models. This is the right place to document limitations as this is where it's implemented.