### PR TITLE
[DOCS] Update ML link for ES #68051

### DIFF
--- a/docs/en/stack/ml/df-analytics/ml-trained-models.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-trained-models.asciidoc
@@ -125,7 +125,7 @@ curl -u username:password \
 --
 * Models exported from the {ref}/get-trained-models.html[get trained models API]
 are limited in size by the
-{ref}/modules-network.html#http-settings[http.max_content_length]
+{ref}/modules-network.html[http.max_content_length]
 global configuration value in Elasticsearch. The default value is `100mb` and
 may need to be increased depending on the size of model being exported.
 

--- a/docs/en/stack/ml/df-analytics/ml-trained-models.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-trained-models.asciidoc
@@ -125,7 +125,7 @@ curl -u username:password \
 --
 * Models exported from the {ref}/get-trained-models.html[get trained models API]
 are limited in size by the
-{ref}/modules-http.html#_http_settings[http.max_content_length]
+{ref}/modules-network.html#http-settings[http.max_content_length]
 global configuration value in Elasticsearch. The default value is `100mb` and
 may need to be increased depending on the size of model being exported.
 


### PR DESCRIPTION
PR [#68051](https://github.com/elastic/elasticsearch/pull/68051) in the Elasticsearch repo is making changes to the networking docs, which impacts the HTTP settings. Specifically, `modules-http` is changing to `modules-network`, with the HTTP settings nested underneath. 

I checked out that PR locally and built the docs, and the resulting URL for the new HTTP section results in `.../guide/modules-network.html#http-settings`. This ML link must be updated for the ES build to pass.