### PR TITLE
[DOCS] Add Kibana highlights to Install & Upgrade Guide

### DIFF
--- a/docs/en/install-upgrade/highlights.asciidoc
+++ b/docs/en/install-upgrade/highlights.asciidoc
@@ -49,10 +49,8 @@ coming::[7.11.0]
 
 This list summarizes the most important enhancements in {kib} {minor-version}].
 
-////
 :leveloffset: +1
 
 include::{kib-repo-dir}/user/whats-new.asciidoc[tag=notable-highlights]
 
 :leveloffset: -1
-////


### PR DESCRIPTION
This PR makes the Kibana release highlights visible in the Installation and Upgrade Guide.

Related to https://github.com/elastic/kibana/pull/90238