### PR TITLE
[7.x] [DOCS] Adds link of Jupyter notebook about class assignment objective to classification docs (#1563)

### DIFF
--- a/docs/en/stack/ml/df-analytics/dfa-classification.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-classification.asciidoc
@@ -144,8 +144,8 @@ the actual and predicted labels are both `true` (also known as a true positive
 [role="screenshot"]
 image::images/confusion-matrix-binary-accuracy.jpg[alt="A confusion matrix with the correct predictions highlighted",width="75%"]
 
-TIP: If there is an imbalanced distribution of classes in your training data set,
-focusing on accuracy can decrease your model's sensitivity to incorrect
+TIP: If there is an imbalanced distribution of classes in your training data 
+set, focusing on accuracy can decrease your model's sensitivity to incorrect
 predictions in the classes that are under-represented in your data.
 
 By default, {classanalysis} jobs accept a slight degradation of the overall
@@ -164,6 +164,10 @@ percentage in each cell of the confusion matrix. The class scores are then
 weighted to favor predictions that result in the highest recall values across
 the training data. This objective typically performs better than accuracy when
 you have highly imbalanced data.
+
+To learn more about choosing the class assignment objective that fits your goal, 
+refer to this 
+https://github.com/elastic/examples/blob/master/Machine%20Learning/Class%20Assigment%20Objectives/classification-class-assignment-objective.ipynb[Jupyter notebook].
 
 [[dfa-classification-feature-importance]]
 === {feat-imp-cap}


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Adds link of Jupyter notebook about class assignment objective to classification docs (#1563)