### PR TITLE
Remove coming tags for 7.11

### DIFF
--- a/docs/en/install-upgrade/highlights.asciidoc
+++ b/docs/en/install-upgrade/highlights.asciidoc
@@ -2,7 +2,7 @@
 == Highlights
 
 Each release brings new features and product improvements. This section
-highlights notable new features and enhancements in {minor-version}].
+highlights notable new features and enhancements in {minor-version}.
 
 ** <<observability-highlights,Observability>>
 ** <<elasticsearch-highlights,{es}>>
@@ -14,8 +14,6 @@ highlights notable new features and enhancements in {minor-version}].
 <titleabbrev>Observability</titleabbrev>
 ++++
 
-coming::[7.11.0]
-
 This list summarizes the most important enhancements in Observability {minor-version}.
 
 include::{obs-repo-dir}/whats-new.asciidoc[tag=whats-new]
@@ -26,8 +24,6 @@ include::{obs-repo-dir}/whats-new.asciidoc[tag=whats-new]
 ++++
 <titleabbrev>{es}</titleabbrev>
 ++++
-
-coming::[7.11.0]
 
 This list summarizes the most important enhancements in {es} {minor-version}.
 For the complete list, go to {ref}/release-highlights.html[{es} release highlights].
@@ -44,8 +40,6 @@ include::{es-repo-dir}/release-notes/highlights.asciidoc[tag=notable-highlights]
 ++++
 <titleabbrev>{kib}</titleabbrev>
 ++++
-
-coming::[7.11.0]
 
 This list summarizes the most important enhancements in {kib} {minor-version}.
 


### PR DESCRIPTION
* Removes coming tags from Release Highlights
* Removes stray `]` in "Highlights" intro. (I'll fix this in master, too)