### PR TITLE
[DOCS] Adds anomaly detection alert config docs to ML book

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/anomaly-examples.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/anomaly-examples.asciidoc
@@ -18,6 +18,7 @@ The scenarios in this section describe some best practices for generating useful
 * <<ml-configuring-populations>>
 * <<ml-configuring-transform>>
 * <<ml-delayed-data-detection>>
+* <<ml-configuring-alerts>>
 
 [discrete]
 [[anomaly-examples-blog-posts]]

--- a/docs/en/stack/ml/anomaly-detection/anomaly-examples.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/anomaly-examples.asciidoc
@@ -11,14 +11,14 @@ gaining deep insights might require some additional planning and configuration.
 The scenarios in this section describe some best practices for generating useful
 {ml} results and insights from your data.
 
-* <<ml-configuring-url>>
+* <<ml-configuring-alerts>>
 * <<ml-configuring-aggregation>>
 * <<ml-configuring-categories>>
 * <<ml-configuring-detector-custom-rules>>
 * <<ml-configuring-populations>>
 * <<ml-configuring-transform>>
+* <<ml-configuring-url>>
 * <<ml-delayed-data-detection>>
-* <<ml-configuring-alerts>>
 
 [discrete]
 [[anomaly-examples-blog-posts]]

--- a/docs/en/stack/ml/anomaly-detection/index.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/index.asciidoc
@@ -82,6 +82,8 @@ include::{es-repo-dir}/ml/anomaly-detection/ml-configuring-transform.asciidoc[le
 
 include::{es-repo-dir}/ml/anomaly-detection/ml-delayed-data-detection.asciidoc[leveloffset=+2]
 
+include::{es-repo-dir}/ml/anomaly-detection/ml-configuring-alerts.asciidoc[leveloffset=+2]
+
 include::ml-limitations.asciidoc[leveloffset=+1]
 
 //include::ml-troubleshooting.asciidoc[leveloffset=+1]

--- a/docs/en/stack/ml/anomaly-detection/index.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/index.asciidoc
@@ -68,7 +68,7 @@ include::{es-repo-dir}/ml/anomaly-detection/functions/ml-time-functions.asciidoc
 
 include::anomaly-examples.asciidoc[leveloffset=+1]
 
-include::{es-repo-dir}/ml/anomaly-detection/ml-configuring-url.asciidoc[leveloffset=+2]
+include::{es-repo-dir}/ml/anomaly-detection/ml-configuring-alerts.asciidoc[leveloffset=+2]
 
 include::{es-repo-dir}/ml/anomaly-detection/ml-configuring-aggregations.asciidoc[leveloffset=+2]
 
@@ -80,9 +80,9 @@ include::{es-repo-dir}/ml/anomaly-detection/ml-configuring-populations.asciidoc[
 
 include::{es-repo-dir}/ml/anomaly-detection/ml-configuring-transform.asciidoc[leveloffset=+2]
 
-include::{es-repo-dir}/ml/anomaly-detection/ml-delayed-data-detection.asciidoc[leveloffset=+2]
+include::{es-repo-dir}/ml/anomaly-detection/ml-configuring-url.asciidoc[leveloffset=+2]
 
-include::{es-repo-dir}/ml/anomaly-detection/ml-configuring-alerts.asciidoc[leveloffset=+2]
+include::{es-repo-dir}/ml/anomaly-detection/ml-delayed-data-detection.asciidoc[leveloffset=+2]
 
 include::ml-limitations.asciidoc[leveloffset=+1]
 


### PR DESCRIPTION
## Overview

This PR adds the piece about anomaly detection alert type to the Examples section of the Anomaly detection chapter.

### Preview

[Configuring anomaly detection alerts ](https://stack-docs_1573.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-configuring-alerts.html)