### PR TITLE
[7.11] [DOCS] Adds blog post links to DFA examples page. (#1574)

### DIFF
--- a/docs/en/stack/ml/df-analytics/dfanalytics-examples.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfanalytics-examples.asciidoc
@@ -31,4 +31,7 @@ The blog posts listed below show how to get the most out of Elastic {ml}
 * https://www.elastic.co/blog/multilingual-search-using-language-identification-in-elasticsearch[Multilingual search using language identification in {es}]
 * https://www.elastic.co/blog/benchmarking-binary-classification-results-in-elastic-machine-learning[Benchmarking binary {classification} results in Elastic {ml}]
 * https://www.elastic.co/blog/using-elastic-supervised-machine-learning-for-binary-classification[Using Elastic supervised {ml} for binary {classification}]
-* https://www.elastic.co/blog/machine-learning-in-cybersecurity-training-supervised-models-to-detect-dga-activity[{ml-cap} in cybersecurity: Training supervised models to detect DGA activity]
+* https://www.elastic.co/blog/machine-learning-in-cybersecurity-training-supervised-models-to-detect-dga-activity[{ml-cap} in cybersecurity – part 1: Training supervised models to detect DGA activity]
+* https://www.elastic.co/blog/machine-learning-in-cybersecurity-detecting-dga-activity-in-network-data[{ml-cap} in cybersecurity – part 2: Detecting DGA activity in network data]
+* https://www.elastic.co/blog/supervised-and-unsupervised-machine-learning-for-dga-detection[Combining supervised and unsupervised machine learning for DGA detection]
+* https://www.elastic.co/blog/train-evaluate-monitor-infer-end-to-end-machine-learning-in-elastic[Train, evaluate, monitor, infer: End-to-end machine learning in Elastic]


### PR DESCRIPTION
Backports the following commits to 7.11:
 - [DOCS] Adds blog post links to DFA examples page. (#1574)