### PR TITLE
[DOCS] Adds custom rules to glossary

### DIFF
--- a/docs/en/glossary/glossary.asciidoc
+++ b/docs/en/glossary/glossary.asciidoc
@@ -259,6 +259,12 @@ include::{es-repo-dir}/glossary.asciidoc[tag=ccr-def]
 include::{es-repo-dir}/glossary.asciidoc[tag=ccs-def]
 --
 
+[[glossary-custom-rules]] custom rules::
+A set of conditions and actions that change the behavior of {anomaly-jobs}. You 
+can also use filters to further limit the scope of the rules. See
+{ml-docs}/ml-rules.html[Custom rules].
+//Source: Machine learning
+
 [discrete]
 [[d-glos]]
 === D


### PR DESCRIPTION
This PR adds "custom rules" to the glossary and links to the following page: https://www.elastic.co/guide/en/machine-learning/current/ml-rules.html