### PR TITLE
[7.x] [DOCS] Adds anomaly detection alert config docs to ML book (#1573)

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/anomaly-examples.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/anomaly-examples.asciidoc
@@ -11,12 +11,13 @@ gaining deep insights might require some additional planning and configuration.
 The scenarios in this section describe some best practices for generating useful
 {ml} results and insights from your data.
 
-* <<ml-configuring-url>>
+* <<ml-configuring-alerts>>
 * <<ml-configuring-aggregation>>
 * <<ml-configuring-categories>>
 * <<ml-configuring-detector-custom-rules>>
 * <<ml-configuring-populations>>
 * <<ml-configuring-transform>>
+* <<ml-configuring-url>>
 * <<ml-delayed-data-detection>>
 
 [discrete]

--- a/docs/en/stack/ml/anomaly-detection/index.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/index.asciidoc
@@ -49,7 +49,7 @@ include::{es-repo-dir}/ml/anomaly-detection/functions/ml-time-functions.asciidoc
 
 include::anomaly-examples.asciidoc[leveloffset=+1]
 
-include::{es-repo-dir}/ml/anomaly-detection/ml-configuring-url.asciidoc[leveloffset=+2]
+include::{es-repo-dir}/ml/anomaly-detection/ml-configuring-alerts.asciidoc[leveloffset=+2]
 
 include::{es-repo-dir}/ml/anomaly-detection/ml-configuring-aggregations.asciidoc[leveloffset=+2]
 
@@ -60,6 +60,8 @@ include::{es-repo-dir}/ml/anomaly-detection/ml-configuring-categories.asciidoc[l
 include::{es-repo-dir}/ml/anomaly-detection/ml-configuring-populations.asciidoc[leveloffset=+2]
 
 include::{es-repo-dir}/ml/anomaly-detection/ml-configuring-transform.asciidoc[leveloffset=+2]
+
+include::{es-repo-dir}/ml/anomaly-detection/ml-configuring-url.asciidoc[leveloffset=+2]
 
 include::{es-repo-dir}/ml/anomaly-detection/ml-delayed-data-detection.asciidoc[leveloffset=+2]
 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Adds anomaly detection alert config docs to ML book (#1573)