### PR TITLE
[DOCS] Link to preview data frame analytics API

### DIFF
--- a/docs/en/stack/ml/df-analytics/ml-dfanalytics-apis.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfanalytics-apis.asciidoc
@@ -27,6 +27,7 @@ All the trained models endpoints have the following base:
 // NOTCONSOLE
 
 
+* {ref}/preview-dfanalytics.html[Preview {dfanalytics}]
 * {ref}/put-dfanalytics.html[Create {dfanalytics-jobs}]
 * {ref}/update-dfanalytics.html[Update {dfanalytics-jobs}]
 * {ref}/delete-dfanalytics.html[Delete {dfanalytics-jobs}]


### PR DESCRIPTION
This PR must be merged after https://github.com/elastic/elasticsearch/pull/69453
It adds a link in the Machine Learning Guide to the new preview data frame analytics API.