### PR TITLE
[DOCS] Link to trained model aliases API

### DIFF
--- a/docs/en/stack/ml/df-analytics/ml-dfanalytics-apis.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfanalytics-apis.asciidoc
@@ -37,6 +37,7 @@ All the trained models endpoints have the following base:
 * {ref}/evaluate-dfanalytics.html[Evaluate {dfanalytics}]
 * {ref}/explain-dfanalytics.html[Explain {dfanalytics}]
 * {ref}/put-trained-models.html[Create trained models]
+* {ref}/put-trained-models-aliases.html[Create trained model aliases]
 * {ref}/get-trained-models.html[Get trained models]
 * {ref}/get-trained-models-stats.html[Get trained models statistics]
 * {ref}/delete-trained-models.html[Delete trained models]


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/68922

This PR adds a link to the new create trained model aliases API