### PR TITLE
[DOCS] Adds trained model to glossary

### DIFF
--- a/docs/en/glossary/glossary.asciidoc
+++ b/docs/en/glossary/glossary.asciidoc
@@ -1014,6 +1014,13 @@ Defines the amount of time an application spends on a request.
 Traces are made up of a collection of transactions and spans that have a common root.
 //Source: Observability
 
+[[glossary-trained-model]] trained model::
+A {ml} model that is trained and tested against a labelled data set and can be 
+referenced in an ingest pipeline or in a pipeline aggregation to perform 
+{classification} or {reganalysis} on new data. See 
+{ml-docs}/ml-trained-models.html[Trained models].
+//Source: Machine learning
+
 [[glossary-transaction]] transaction::
 A special kind of <<glossary-span,span>> that has additional attributes associated with it.
 {apm-overview-ref-v}/transactions.html[Transactions] describe an event captured by an


### PR DESCRIPTION
## Overview

This PR adds the short definition of the `trained model` term to the glossary.

### Preview

[Glossary: T](https://stack-docs_1596.docs-preview.app.elstc.co/guide/en/elastic-stack-glossary/master/terms.html#t-glos)