### PR TITLE
[DOCS] Adds operator privileges to ML setup

### DIFF
--- a/docs/en/stack/ml/setup.asciidoc
+++ b/docs/en/stack/ml/setup.asciidoc
@@ -14,7 +14,8 @@ In {kib}, the {ml-features} must be visible in your
 source index patterns must exist in the same space as your {ml} jobs.
 
 If {stack} {security-features} are enabled, you must also ensure your users have
-the <<setup-privileges,necessary privileges>>.
+the <<setup-privileges,necessary privileges>>. If the {operator-feature} is
+enabled, there are some {ml} settings that can be updated only by operator users.
 
 TIP: The fastest way to get started with {ml-features} is to
 {ess-trial}[start a free 14-day trial of {ess}] in the cloud.


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/pull/69766 and https://github.com/elastic/elasticsearch/pull/68964

This PR updates the setup page in the Machine Learning Guide to indicate that some machine learning settings are affected by operator privileges.