### PR TITLE
[DOCS] Add lists for overloaded terms

### DIFF
--- a/docs/en/glossary/glossary.asciidoc
+++ b/docs/en/glossary/glossary.asciidoc
@@ -117,11 +117,12 @@ Used to send {filebeat} and {metricbeat} information to the logging cluster.
 //Source: Cloud
 
 [[glossary-ml-bucket]] bucket::
+. {blank}
 +
 --
 include::{kib-repo-dir}/glossary.asciidoc[tag=bucket-def]
-
-The {ml-features} also use the concept of a bucket to divide the time series
+--
+. The {ml-features} also use the concept of a bucket to divide the time series
 into batches for processing. The _bucket span_ is part of the configuration
 information for {anomaly-jobs}. It defines the time interval that is used to
 summarize and model the data. This is typically between 5 minutes to 1 hour and
@@ -129,7 +130,6 @@ it depends on your data characteristics. When you set the bucket span, take into
 account the granularity at which you want to analyze, the frequency of the input
 data, the typical duration of the anomalies, and the frequency at which alerting
 is required.
---
 
 [[glossary-bucket-aggregation]] bucket aggregation::
 +


### PR DESCRIPTION
For cases where a glossary term has multiple definitions, it can be unclear where one definition begins and another ends. This PR therefore adds ordered lists, which are implemented using the method described here: https://docs.asciidoctor.org/asciidoc/latest/lists/continuation/#dropping-the-principal-text

### Preview

https://stack-docs_1605.docs-preview.app.elstc.co/guide/en/elastic-stack-glossary/master/terms.html#c-glos