### PR TITLE
[7.11][DOCS] Clarifies machine learning rollup limitation

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/ml-limitations.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-limitations.asciidoc
@@ -70,16 +70,16 @@ You cannot use the following field names in the `by_field_name` or
 `over_field_name` properties in a job: `by`; `count`; `over`. This limitation
 also applies to those properties when you create advanced jobs in {kib}.
 
-
 [discrete]
-=== Rollup indices and index patterns are not supported
+[[ml-rollup-limitations]]
+=== Rollup indices and index patterns are not supported in {kib}
 
-Rollup indices and index patterns cannot be used in machine learning jobs or 
-{dfeeds}. This limitation applies irrespective of whether you create the jobs in 
-{kib} or by using APIs. In {kib}, if you select an index, saved search, or index 
-pattern that uses the Rollup feature, the {ml} job creation wizards fail. 
-
-See {ref}/xpack-rollup.html[Rolling up historical data].
+Rollup indices and index patterns cannot be used in {anomaly-jobs} or 
+{dfeeds} in {kib}. If you select an index, saved search, or index pattern that
+uses {ref}/xpack-rollup.html[{rollup-features}], the {anomaly-job} creation
+wizards fail. If you use APIs to create {anomaly-jobs} that use
+{rollup-features}, the job results might not display properly in the
+*Single Metric Viewer* or *Anomaly Explorer* in {kib}.
 
 
 [discrete]
@@ -155,7 +155,6 @@ you send to the job must use the JSON format.
 
 For more information about this API, see
 {ref}/ml-post-data.html[Post Data to Jobs].
-
 
 [discrete]
 === Misleading high missing field counts

--- a/docs/en/stack/ml/anomaly-detection/ml-limitations.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-limitations.asciidoc
@@ -71,18 +71,6 @@ You cannot use the following field names in the `by_field_name` or
 also applies to those properties when you create advanced jobs in {kib}.
 
 [discrete]
-[[ml-rollup-limitations]]
-=== Rollup indices and index patterns are not supported in {kib}
-
-Rollup indices and index patterns cannot be used in {anomaly-jobs} or 
-{dfeeds} in {kib}. If you select an index, saved search, or index pattern that
-uses {ref}/xpack-rollup.html[{rollup-features}], the {anomaly-job} creation
-wizards fail. If you use APIs to create {anomaly-jobs} that use
-{rollup-features}, the job results might not display properly in the
-*Single Metric Viewer* or *Anomaly Explorer* in {kib}.
-
-
-[discrete]
 [[ml-frozen-limitations]]
 === Frozen indices are not supported
 
@@ -300,7 +288,6 @@ To avoid this behavior, make sure that the aggregation interval in the {dfeed}
 configuration and the bucket span in the {anomaly-job} configuration have the 
 same values.
 
-
 [discrete]
 [[ml-space-limitations]]
 === Calendars and filters are visible in all {kib} spaces
@@ -310,3 +297,14 @@ same values.
 that belong to your space. However, this limited scope does not apply to 
 <<ml-calendars,calendars>> and <<ml-rules,filters>>; they are visible in all
 spaces.
+
+[discrete]
+[[ml-rollup-limitations]]
+=== Rollup indices and index patterns are not supported in {kib}
+
+Rollup indices and index patterns cannot be used in {anomaly-jobs} or 
+{dfeeds} in {kib}. If you select an index, saved search, or index pattern that
+uses {ref}/xpack-rollup.html[{rollup-features}], the {anomaly-job} creation
+wizards fail. If you use APIs to create {anomaly-jobs} that use
+{rollup-features}, the job results might not display properly in the
+*Single Metric Viewer* or *Anomaly Explorer* in {kib}.


### PR DESCRIPTION
Backports https://github.com/elastic/stack-docs/pull/962