### PR TITLE
[DOCS] Removes obsolete terms from glossary

### DIFF
--- a/docs/en/glossary/glossary.asciidoc
+++ b/docs/en/glossary/glossary.asciidoc
@@ -25,18 +25,6 @@ ZooKeeper to {es}.
 include::{kib-repo-dir}/glossary.asciidoc[tag=advanced-settings-def]
 --
 
-[[glossary-alert]] alert::
-+
---
-include::{kib-repo-dir}/glossary.asciidoc[tag=alert-def]
---
-
-[[glossary-alerts-and-actions]] Alerts and Actions::
-+
---
-include::{kib-repo-dir}/glossary.asciidoc[tag=alerts-and-actions-def]
---
-
 [[glossary-allocator]] allocator::
 Manages hosts that contain {es} and {kib} nodes. Controls the lifecycle of these
 nodes by creating new <<glossary-container,containers>> and managing the nodes


### PR DESCRIPTION
Related to https://github.com/elastic/kibana/pull/94447

This PR removes the terms "alert" and "Alerts and Actions" from the glossary.