### PR TITLE
Remove ES `type` definition

### DIFF
--- a/docs/en/glossary/glossary.asciidoc
+++ b/docs/en/glossary/glossary.asciidoc
@@ -1103,12 +1103,6 @@ Elastic <<glossary-apm-agent,APM agent>> instrumenting a service.
 include::{kib-repo-dir}/glossary.asciidoc[tag=tsvb-def]
 --
 
-[[glossary-type]] type::
-+
---
-include::{es-repo-dir}/glossary.asciidoc[tag=type-def]
---
-
 [discrete]
 [[u-glos]]
 === U


### PR DESCRIPTION
Types were deprecated in 6.x and will not be supported in 8.x.
This removes the `type` definition from the Stack glossary.
Relates to https://github.com/elastic/elasticsearch/pull/70516