### PR TITLE
[DOCS] Add 7.12 highlights to Installation Upgrade Guide

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -90,7 +90,7 @@ coming::[7.12.0]
 This list summarizes the most important breaking changes in {kib} {version}. For
 the complete list, go to {kibana-ref}/release-notes.html[{kib} breaking changes].
 
-include::{kib-repo-dir}/docs/CHANGELOG.asciidoc[tag=notable-breaking-changes]
+include::{kib-repo-dir}/CHANGELOG.asciidoc[tag=notable-breaking-changes]
 
 [[logstash-breaking-changes]]
 === {ls} breaking changes

--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -61,7 +61,7 @@ coming::[7.12.0]
 This list summarizes the most important breaking changes in {es} {version}. For
 the complete list, go to {ref}/breaking-changes.html[{es} breaking changes].
 
-//include::{es-repo-dir}/migration/migrate_7_12.asciidoc[tag=notable-breaking-changes]
+include::{es-repo-dir}/migration/migrate_7_12.asciidoc[tag=notable-breaking-changes]
 
 [[elasticsearch-hadoop-breaking-changes]]
 === {es} Hadoop breaking changes

--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -90,7 +90,7 @@ coming::[7.12.0]
 This list summarizes the most important breaking changes in {kib} {version}. For
 the complete list, go to {kibana-ref}/release-notes.html[{kib} breaking changes].
 
-//include::{kib-repo-dir}/migration/migrate_7_12.asciidoc[tag=notable-breaking-changes]
+include::{kib-repo-dir}/docs/CHANGELOG.asciidoc[tag=notable-breaking-changes]
 
 [[logstash-breaking-changes]]
 === {ls} breaking changes

--- a/docs/en/install-upgrade/highlights.asciidoc
+++ b/docs/en/install-upgrade/highlights.asciidoc
@@ -32,13 +32,11 @@ coming::[7.12.0]
 This list summarizes the most important enhancements in {es} {minor-version}.
 For the complete list, go to {ref}/release-highlights.html[{es} release highlights].
 
-////
 :leveloffset: +1
 
 include::{es-repo-dir}/release-notes/highlights.asciidoc[tag=notable-highlights]
 
 :leveloffset: -1
-////
 
 [[kibana-higlights]]
 === {kib} highlights
@@ -51,10 +49,8 @@ coming::[7.12.0]
 
 This list summarizes the most important enhancements in {kib} {minor-version}].
 
-////
 :leveloffset: +1
 
 include::{kib-repo-dir}/user/whats-new.asciidoc[tag=notable-highlights]
 
 :leveloffset: -1
-////


### PR DESCRIPTION
This PR must be merged after https://github.com/elastic/kibana/pull/94771 , https://github.com/elastic/kibana/pull/95124, https://github.com/elastic/kibana/pull/94761, https://github.com/elastic/elasticsearch/pull/70533, https://github.com/elastic/elasticsearch/pull/70700

It adds some highlights and breaking changes to the Installation and Upgrade Guide.

### Preview

https://stack-docs_1620.docs-preview.app.elstc.co/guide/en/elastic-stack/7.12/elastic-stack-highlights.html
https://stack-docs_1620.docs-preview.app.elstc.co/guide/en/elastic-stack/7.12/elastic-stack-breaking-changes.html