### PR TITLE
Activate include for beats breaking changes

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -41,12 +41,7 @@ include::{apm-repo-dir}/apm-breaking-changes.asciidoc[tag=712-bc]
 <titleabbrev>Beats</titleabbrev>
 ++++
 
-coming::[7.12.0]
-
-This list summarizes the most important breaking changes in Beats. For the
-complete list, go to {beats-ref}/breaking-changes.html[Beats breaking changes].
-
-//include::{beats-repo-dir}/release-notes/breaking/breaking-7.12.asciidoc[tag=notable-breaking-changes]
+include::{beats-repo-dir}/release-notes/breaking/breaking-7.12.asciidoc[tag=notable-breaking-changes]
 
 
 [[elasticsearch-breaking-changes]]


### PR DESCRIPTION
Activates the include for Beats BCs.  Doc build will fail until  https://github.com/elastic/beats/pull/24646 is merged and backported.

@lcawl In situations where there are no breaking changes, I don't think we should send users down the rabbit hole, so I've removed the para that begins "This list summarizes the most important breaking changes..." WDYT? Good idea? Bad idea?

This approach only works if there really are *no* changes (even in the changelog). I think that's the case for Beats in 7.12 (I'll know for sure when 24646 is reviewed.)


