### PR TITLE
[DOCS] Add missing ES terms to glossary

### DIFF
--- a/docs/en/glossary/glossary.asciidoc
+++ b/docs/en/glossary/glossary.asciidoc
@@ -189,6 +189,12 @@ include::{es-repo-dir}/glossary.asciidoc[tag=cold-phase-def]
 include::{es-repo-dir}/glossary.asciidoc[tag=cold-tier-def]
 --
 
+[[glossary-component-template]] component template::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=component-template-def]
+--
+
 [[glossary-condition]] condition::
 +
 --
@@ -459,10 +465,34 @@ include::{es-repo-dir}/glossary.asciidoc[tag=flush-def]
 include::{es-repo-dir}/glossary.asciidoc[tag=follower-index-def]
 --
 
+[[glossary-force-merge]] force merge::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=force-merge-def]
+--
+
+[[glossary-freeze]] freeze::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=freeze-def]
+--
+
 [[glossary-frozen-index]] frozen index::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=frozen-index-def]
+--
+
+[[glossary-frozen-phase]] frozen phase::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=frozen-phase-def]
+--
+
+[[glossary-frozen-tier]] frozen tier::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=frozen-tier-def]
 --
 
 [discrete]
@@ -516,7 +546,7 @@ include::{kib-repo-dir}/glossary.asciidoc[tag=grok-debugger-def]
 include::{kib-repo-dir}/glossary.asciidoc[tag=heat-map-def]
 --
 
-[[glossary-hidden-index]] hidden index::
+[[glossary-hidden-index]] hidden data stream or index::
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=hidden-index-def]
@@ -577,6 +607,12 @@ include::{es-repo-dir}/glossary.asciidoc[tag=index-lifecycle-policy-def]
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=index-pattern-def]
+--
+
+[[glossary-index-template]] index template::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=index-template-def]
 --
 
 [[glossary-indexer]] indexer::
@@ -712,6 +748,12 @@ an ordered fashion. Each cluster has a single master node which is chosen
 automatically by the cluster and is replaced if the current master node fails.
 Also see <<glossary-node,node>>.
 //Source: Cloud
+
+[[glossary-merge]] merge::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=merge-def]
+--
 
 [[glossary-message-broker]] message broker::
 Also referred to as a _message buffer_ or _message queue_, a message broker is
@@ -890,6 +932,12 @@ Used when installing {ece} on additional hosts, a roles token helps secure {ece}
 by making sure that only authorized hosts become part of the installation.
 //Source: Cloud
 
+[[glossary-rollover]] rollover::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=rollover-def]
+--
+
 [[glossary-rollup]] rollup::
 +
 --
@@ -920,6 +968,12 @@ based on role definitions. Ensures that containers assigned to it exist and are
 able to run, and creates or recreates the containers if necessary.
 //Source: Cloud
 
+[[glossary-runtime-fields]] runtime field::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=runtime-fields-def]
+--
+
 [discrete]
 [[s-glos]]
 === S
@@ -936,16 +990,34 @@ include::{kib-repo-dir}/glossary.asciidoc[tag=saved-object-def]
 include::{kib-repo-dir}/glossary.asciidoc[tag=saved-search-def]
 --
 
+[[glossary-scripted-field]] scripted field::
++
+--
+include::{kib-repo-dir}/glossary.asciidoc[tag=scripted-field-def]
+--
+
 [[glossary-search-session]] search session::
 +
 --
 include::{kib-repo-dir}/glossary.asciidoc[tag=search-session-def]
 --
 
-[[glossary-scripted-field]] scripted field::
+[[glossary-searchable-snapshot]] searchable snapshot::
 +
 --
-include::{kib-repo-dir}/glossary.asciidoc[tag=scripted-field-def]
+include::{es-repo-dir}/glossary.asciidoc[tag=searchable-snapshot-def]
+--
+
+[[glossary-searchable-snapshot-index]] searchable snapshot index::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=searchable-snapshot-index-def]
+--
+
+[[glossary-segment]] segment::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=segment-def]
 --
 
 [[glossary-services-forwarder]] services forwarder::
@@ -1072,6 +1144,19 @@ include::{kib-repo-dir}/glossary.asciidoc[tag=timelion-def]
 --
 include::{kib-repo-dir}/glossary.asciidoc[tag=time-series-data-def]
 --
+
+[[glossary-token]] token::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=token-def]
+--
+
+[[glossary-tokenization]] tokenization::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=tokenization-def]
+--
+
 
 [[glossary-trace]] trace::
 Defines the amount of time an application spends on a request.


### PR DESCRIPTION
Add some new and missing terms from the Elasticsearch glossary to the Stack glossary.

Relates to https://github.com/elastic/elasticsearch/pull/70516