### PR TITLE
[DOCS] Removes coming tags from highlights and breaking changes

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -28,8 +28,6 @@ Upgrade Assistant provides information about which {dfeeds} need to be updated.
 <titleabbrev>APM</titleabbrev>
 ++++
 
-coming::[7.12.0]
-
 This list summarizes the most important breaking changes in APM.
 For the complete list, go to {apm-server-ref}/breaking-changes.html[APM Server breaking changes].
 
@@ -51,8 +49,6 @@ include::{beats-repo-dir}/release-notes/breaking/breaking-7.12.asciidoc[tag=nota
 <titleabbrev>{es}</titleabbrev>
 ++++
 
-coming::[7.12.0]
-
 This list summarizes the most important breaking changes in {es} {version}. For
 the complete list, go to {ref}/breaking-changes.html[{es} breaking changes].
 
@@ -64,8 +60,6 @@ include::{es-repo-dir}/migration/migrate_7_12.asciidoc[tag=notable-breaking-chan
 ++++
 <titleabbrev>{es} Hadoop</titleabbrev>
 ++++
-
-coming::[7.12.0]
 
 This list summarizes the most important breaking changes in {es} Hadoop {version}.
 For the complete list, go to
@@ -80,8 +74,6 @@ include::{hadoop-repo-dir}/appendix/breaking.adoc[tag=notable-v7-breaking-change
 <titleabbrev>{kib}</titleabbrev>
 ++++
 
-coming::[7.12.0]
-
 This list summarizes the most important breaking changes in {kib} {version}. For
 the complete list, go to {kibana-ref}/release-notes.html[{kib} breaking changes].
 
@@ -93,8 +85,6 @@ include::{kib-repo-dir}/CHANGELOG.asciidoc[tag=notable-breaking-changes]
 ++++
 <titleabbrev>{ls}</titleabbrev>
 ++++
-
-coming::[7.12.0]
 
 This list summarizes the most important breaking changes in {ls} {version}. For
 the complete list, go to

--- a/docs/en/install-upgrade/highlights.asciidoc
+++ b/docs/en/install-upgrade/highlights.asciidoc
@@ -25,8 +25,6 @@ include::{obs-repo-dir}/whats-new.asciidoc[tag=whats-new]
 <titleabbrev>{es}</titleabbrev>
 ++++
 
-coming::[7.12.0]
-
 This list summarizes the most important enhancements in {es} {minor-version}.
 For the complete list, go to {ref}/release-highlights.html[{es} release highlights].
 
@@ -43,9 +41,7 @@ include::{es-repo-dir}/release-notes/highlights.asciidoc[tag=notable-highlights]
 <titleabbrev>{kib}</titleabbrev>
 ++++
 
-coming::[7.12.0]
-
-This list summarizes the most important enhancements in {kib} {minor-version}].
+This list summarizes the most important enhancements in {kib} {minor-version}.
 
 :leveloffset: +1
 


### PR DESCRIPTION
This PR removes "coming" tags now that 7.12.0 documentation is available.