### PR TITLE
[DOCS] Restore rollup glossary items (#1473)

### DIFF
--- a/docs/en/glossary/glossary.asciidoc
+++ b/docs/en/glossary/glossary.asciidoc
@@ -673,7 +673,7 @@ parsing, and visualization of logs and metrics. Also known as a <<glossary-modul
 {ml-cap} jobs contain the configuration information and metadata
 necessary to perform an analytics task. There are two types:
 <<glossary-anomaly-detection-job,{anomaly-jobs}>> and
-<<glossary-dataframe-job,{dfanalytics-jobs}>>.
+<<glossary-dataframe-job,{dfanalytics-jobs}>>. See also <<glossary-rollup-job>>.
 //Source: X-Pack
 
 [discrete]
@@ -942,6 +942,18 @@ include::{es-repo-dir}/glossary.asciidoc[tag=rollover-def]
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=rollup-def]
+--
+
+[[glossary-rollup-index]] rollup index::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=rollup-index-def]
+--
+
+[[glossary-rollup-job]] {rollup-job}::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=rollup-job-def]
 --
 
 [[glossary-routing]] routing::


### PR DESCRIPTION
We've decided to adopt a new approach to the rollup refactor. This reverts commit a1f8f9cdaf9fe1b0c4a80b220658a3874875bc45 and restores some glossary definition for the current rollup functionality.