### PR TITLE
[7.x] [DOCS] Clarifies that custom rules are called job rules in Kibana. (#1634)

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/ml-rules.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-rules.asciidoc
@@ -8,10 +8,10 @@ and the {ml} models have no awareness of the domain of your data. As a result,
 uninteresting when you know the larger context. Machine learning custom rules
 enable you to customize anomaly detection. 
 
-_Custom rules_ instruct anomaly detectors to change their behavior based on 
-domain-specific knowledge that you provide. When you create a rule, you can  
-specify conditions, scope, and actions. When the conditions of a rule are 
-satisfied, its actions are triggered. 
+_Custom rules_ – or _job rules_ as {kib} refers to them – instruct anomaly 
+detectors to change their behavior based on domain-specific knowledge that you 
+provide. When you create a rule, you can specify conditions, scope, and actions. 
+When the conditions of a rule are satisfied, its actions are triggered. 
 
 For example, if you have an anomaly detector that is analyzing CPU usage, you 
 might decide you are only interested in anomalies where the CPU usage is greater 


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Clarifies that custom rules are called job rules in Kibana. (#1634)