### PR TITLE
[DOCS] Edits custom rules entry in Glossary

### DIFF
--- a/docs/en/glossary/glossary.asciidoc
+++ b/docs/en/glossary/glossary.asciidoc
@@ -262,7 +262,8 @@ include::{es-repo-dir}/glossary.asciidoc[tag=ccs-def]
 [[glossary-custom-rules]] custom rules::
 A set of conditions and actions that change the behavior of {anomaly-jobs}. You 
 can also use filters to further limit the scope of the rules. See
-{ml-docs}/ml-rules.html[Custom rules].
+{ml-docs}/ml-rules.html[Custom rules]. {kib} refers to custom rules as job 
+rules.
 //Source: Machine learning
 
 [discrete]


### PR DESCRIPTION
## Overview

This PR expands the glossary entry about custom rules by mentioning that they are referred to as job rules in Kibana.


### Preview

[Glossary - C](https://stack-docs_1636.docs-preview.app.elstc.co/guide/en/elastic-stack-glossary/master/terms.html#c-glos)