### PR TITLE
[ML] Adds link to anomaly detection video

### DIFF
--- a/docs/en/stack/ml/get-started/ml-getting-started.asciidoc
+++ b/docs/en/stack/ml/get-started/ml-getting-started.asciidoc
@@ -58,6 +58,21 @@ Ready to take {ml} for a test drive? Follow this tutorial to:
 At the end of this tutorial, you should have a good idea of what {ml} is and
 will hopefully be inspired to use it to detect anomalies in your own data.
 
+The following video provides a quick overview of some of the tasks we'll perform in this tutorial:
+
+++++
+<script type="text/javascript" async src="https://play.vidyard.com/embed/v4.js"></script>
+<img
+  style="width: 100%; margin: auto; display: block;"
+  class="vidyard-player-embed"
+  src="https://play.vidyard.com/eVQoHfHNgGxBeuAZ5rCtXq.jpg"
+  data-uuid="qAiTxhZSXKQVQF5aFMp1s3"
+  data-v="4"
+  data-type="inline"
+/>
+</br>
+++++
+
 Need more context? Check out the
 {ref}/elasticsearch-intro.html[{es} introduction] to learn the lingo and
 understand the basics of how {es} works.


### PR DESCRIPTION
This PR embeds the education video about single metric anomaly detection jobs in the machine learning getting started page. It uses the same method as pages like https://www.elastic.co/guide/en/observability/current/user-experience.html 

### Preview

https://stack-docs_1638.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-getting-started.html#get-started-prereqs