### PR TITLE
[DOCS] Removes beta qualifiers from prebuilt ML jobs

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-siem.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-siem.asciidoc
@@ -681,7 +681,7 @@ activities (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function])
 
 Required {beats} or {agent} integrations:::
 
-* beta:[] {elastic-endpoint} integration
+* {elastic-endpoint} integration
 * {auditbeat}
 
 Required ECS fields:::
@@ -713,7 +713,7 @@ hosts (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
 
 Required {beats} or {agent} integrations:::
 
-* beta:[] {elastic-endpoint} integration
+* {elastic-endpoint} integration
 * {auditbeat}
 
 Required ECS fields:::
@@ -752,7 +752,7 @@ Job details:::
 
 Required {beats} or {agent} integrations:::
 
-* beta:[] {elastic-endpoint} integration
+* {elastic-endpoint} integration
 * {auditbeat}
 
 Required ECS fields:::
@@ -782,7 +782,7 @@ processes (using the
 
 Required {beats} or {agent} integrations:::
 
-* beta:[] {elastic-endpoint} integration
+* {elastic-endpoint} integration
 * {auditbeat}
 
 Required ECS fields:::
@@ -810,7 +810,7 @@ Job details:::
 
 Required {beats} or {agent} integrations:::
 
-* beta:[] {elastic-endpoint} integration
+* {elastic-endpoint} integration
 * {auditbeat}
 
 Required ECS fields:::
@@ -839,7 +839,7 @@ Job details:::
 
 Required {beats} or {agent} integrations:::
 
-* beta:[] {elastic-endpoint} integration
+* {elastic-endpoint} integration
 * {auditbeat}
 
 Required ECS fields:::
@@ -1078,7 +1078,7 @@ Job details:::
 
 Required {beats} or {agent} integrations:::
 
-* beta:[] {elastic-endpoint} integration
+* {elastic-endpoint} integration
 * {winlogbeat}, colecting data from the Windows System Monitor (Sysmon) or the
 Windows security event log
 +
@@ -1126,7 +1126,7 @@ other processes (using the
 
 Required {beats} or {agent} integrations:::
 
-* beta:[] {elastic-endpoint} integration
+* {elastic-endpoint} integration
 * {winlogbeat}, collecting data from Windows System Monitor (Sysmon)
 
 Required ECS fields:::
@@ -1192,7 +1192,7 @@ Job details:::
 
 Required {beats} or {agent} integrations:::
 
-* beta:[] {elastic-endpoint} integration
+* {elastic-endpoint} integration
 * {winlogbeat}, colecting data from the Windows System Monitor (Sysmon) or from the Windows security event log with process creation auditing enabled.
 +
 TIP: If you collect data from the Windows security event log and you configure
@@ -1236,7 +1236,7 @@ relationships (using the
 
 Required {beats} or {agent} integrations:::
 
-* beta:[] {elastic-endpoint} integration
+* {elastic-endpoint} integration
 * {winlogbeat}, collecting data from the Windows System Monitor (Sysmon) or the 
 Windows security event log
 +
@@ -1281,7 +1281,7 @@ Job details:::
 
 Required {beats} or {agent} integrations:::
 
-* beta:[] {elastic-endpoint} integration
+* {elastic-endpoint} integration
 * {winlogbeat}, collecting data from the Windows System Monitor (Sysmon) or the 
 Windows security event log
 +
@@ -1316,7 +1316,7 @@ processes (using the
 
 Required {beats} or {agent} integrations:::
 
-* beta:[] {elastic-endpoint} integration
+* {elastic-endpoint} integration
 * {winlogbeat}, collecting data from the Windows System Monitor (Sysmon)
 
 Required ECS fields:::
@@ -1342,7 +1342,7 @@ Job details:::
 
 Required {beats} or {agent} integrations:::
 
-* beta:[] {elastic-endpoint} integration
+* {elastic-endpoint} integration
 * {winlogbeat}, collecting data from the Windows System Monitor (Sysmon)
 
 Required ECS fields:::


### PR DESCRIPTION
Related to https://github.com/elastic/security-docs/pull/637

This PR removes the "beta" indicators from within https://www.elastic.co/guide/en/security/master/prebuilt-ml-jobs.html