### PR TITLE
Update create-certs.yml with "--keep-ca-key"

### DIFF
--- a/docs/en/getting-started/docker/create-certs.yml
+++ b/docs/en/getting-started/docker/create-certs.yml
@@ -8,7 +8,7 @@ services:
       bash -c '
         yum install -y -q -e 0 unzip;
         if [[ ! -f /certs/bundle.zip ]]; then
-          bin/elasticsearch-certutil cert --silent --pem --in config/certificates/instances.yml -out /certs/bundle.zip;
+          bin/elasticsearch-certutil cert --silent --pem --keep-ca-key --in config/certificates/instances.yml -out /certs/bundle.zip;
           unzip /certs/bundle.zip -d /certs; 
         fi;
         chown -R 1000:0 /certs


### PR DESCRIPTION
"--keep-ca-key" helps the newbies to tackle the stack related problems like adding new host to the stack/scaling the stack/expanding the stack. I wasted weeks in finding this solution.