### PR TITLE
[7.x] Add Fleet and Elastic Agent terminology to glossary (#1637)

### DIFF
--- a/docs/en/glossary/glossary.asciidoc
+++ b/docs/en/glossary/glossary.asciidoc
@@ -1,0 +1,1341 @@
+[[terms]]
+== Terminology
+
+<<a-glos>> | <<b-glos>> | <<c-glos>> | <<d-glos>> | <<e-glos>> | <<f-glos>> | <<g-glos>> | <<h-glos>> | <<i-glos>> | <<j-glos>> | <<k-glos>> | <<l-glos>> | <<m-glos>> | <<n-glos>> | <<o-glos>> | <<p-glos>> | <<q-glos>> | <<r-glos>> | <<s-glos>> | <<t-glos>> | <<u-glos>> | <<v-glos>> | <<w-glos>> | X | Y | <<z-glos>>
+
+[discrete]
+[[a-glos]]
+=== A
+
+[[glossary-action]] action::
++
+--
+include::{kib-repo-dir}/glossary.asciidoc[tag=action-def]
+--
+
+[[glossary-admin-console]] administration console::
+A component of {ece} that provides the API server for the
+<<glossary-cloud-ui,Cloud UI>>. Also syncs cluster and allocator data from
+ZooKeeper to {es}.
+//Source: Cloud
+
+[[glossary-advanced-settings]] Advanced Settings::
++
+--
+include::{kib-repo-dir}/glossary.asciidoc[tag=advanced-settings-def]
+--
+
+[[glossary-agent-policy]] Agent policy::
+A collection of inputs and settings that defines the data to be collected by {agent}.
+An agent policy can be applied to a single agent or shared by a group of agents;
+this makes it easier to manage many agents at scale.
+See {fleet-guide}/agent-policy.html[{agent} policies].
+//Source: Observability
+
+[[glossary-allocator]] allocator::
+Manages hosts that contain {es} and {kib} nodes. Controls the lifecycle of these
+nodes by creating new <<glossary-container,containers>> and managing the nodes
+within these containers when requested. Used to scale the capacity of your {ece}
+installation.
+//Source: Cloud
+
+[[glossary-analysis]] analysis::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=analysis-def]
+--
+
+[[glossary-annotation]] annotation::
++
+--
+include::{kib-repo-dir}/glossary.asciidoc[tag=annotation-def]
+--
+
+[[glossary-anomaly-detection-job]] {anomaly-job}::
+{anomaly-jobs-cap} contain the configuration information and metadata
+necessary to perform an analytics task. See
+{ml-docs}/ml-jobs.html[{ml-jobs-cap}] and the
+{ref}/ml-put-job.html[create {anomaly-job} API].
+//Source: X-Pack
+
+[[glossary-api-key]] API key::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=api-key-def]
+--
+
+[[glossary-apm-agent]] APM agent::
+An open-source library, written in the same language as your service,
+which <<glossary-instrumentation,instruments>> your code and collects performance data
+and errors at runtime.
+//Source: Observability
+
+[[glossary-apm-server]] APM Server::
+An open-source application that receives data from <<glossary-apm-agent,APM agents>> and sends
+it to {es}.
+//Source: Observability
+
+[[glossary-app]] app::
++
+--
+include::{kib-repo-dir}/glossary.asciidoc[tag=app-def]
+--
+
+[[glossary-auto-follow-pattern]] auto-follow pattern::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=auto-follow-pattern-def]
+--
+
+[[glossary-zone]] availability zone::
+Contains resources available to a {ece} installation that are isolated from
+other availability zones to safeguard against failure. Could be a rack, a server
+zone or some other logical constraint that creates a failure boundary. In a
+highly available cluster, the nodes of a cluster are spread across two or three
+availability zones to ensure that the cluster can survive the failure of an
+entire availability zone. Also see
+{ece-ref}/ece-ha.html[Fault Tolerance (High Availability)].
+//Source: Cloud
+
+[discrete]
+[[b-glos]]
+=== B
+
+[[glossary-basemap]] basemap::
++
+--
+include::{kib-repo-dir}/glossary.asciidoc[tag=basemap-def]
+--
+
+[[glossary-beats-runner]] beats runner::
+Used to send {filebeat} and {metricbeat} information to the logging cluster.
+//Source: Cloud
+
+[[glossary-ml-bucket]] bucket::
+. {blank}
++
+--
+include::{kib-repo-dir}/glossary.asciidoc[tag=bucket-def]
+--
+. The {ml-features} also use the concept of a bucket to divide the time series
+into batches for processing. The _bucket span_ is part of the configuration
+information for {anomaly-jobs}. It defines the time interval that is used to
+summarize and model the data. This is typically between 5 minutes to 1 hour and
+it depends on your data characteristics. When you set the bucket span, take into
+account the granularity at which you want to analyze, the frequency of the input
+data, the typical duration of the anomalies, and the frequency at which alerting
+is required.
+
+[[glossary-bucket-aggregation]] bucket aggregation::
++
+--
+include::{kib-repo-dir}/glossary.asciidoc[tag=bucket-aggregation-def]
+--
+
+[discrete]
+[[c-glos]]
+=== C
+
+[[glossary-canvas]] Canvas::
++
+--
+include::{kib-repo-dir}/glossary.asciidoc[tag=canvas-def]
+--
+
+[[glossary-canvas-language]] Canvas expression language::
++
+--
+include::{kib-repo-dir}/glossary.asciidoc[tag=canvas-language-def]
+--
+
+[[glossary-certainty]] certainty::
++
+--
+include::{kib-repo-dir}/glossary.asciidoc[tag=certainty-def]
+--
+
+[[glossary-client-forwarder]] client forwarder::
+Used for secure internal communications between various components of {ece} and
+ZooKeeper.
+//Source: Cloud
+
+[[glossary-cloud-ui]] Cloud UI::
+Provides web-based access to manage your {ece} installation, supported by the
+<<glossary-admin-console,administration console>>.
+//Source: Cloud
+
+[[glossary-cluster]] cluster::
+. {blank}
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=cluster-def]
+--
+. {blank}
++
+--
+include::{kib-repo-dir}/glossary.asciidoc[tag=clusters-def]
+--
+
+[[glossary-codec-plugin]] codec plugin::
+A {ls} <<glossary-plugin,plugin>> that changes the data representation
+of an <<glossary-event,event>>. Codecs are essentially stream filters that
+can operate as part of an input or output. Codecs enable you to separate the
+transport of messages from the serialization process. Popular codecs include
+json, msgpack, and plain (text).
+//Source: Logstash
+
+[[glossary-cold-phase]] cold phase::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=cold-phase-def]
+--
+
+[[glossary-cold-tier]] cold tier::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=cold-tier-def]
+--
+
+[[glossary-component-template]] component template::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=component-template-def]
+--
+
+[[glossary-condition]] condition::
++
+--
+include::{kib-repo-dir}/glossary.asciidoc[tag=condition-def]
+--
+
+[[glossary-conditional]] conditional::
+A control flow that executes certain actions based on whether a statement
+(also called a condition) is true or false. {ls} supports `if`,
+`else if`, and `else` statements. You can use conditional statements to
+apply filters and send events to a specific output based on conditions that
+you specify.
+//Source: Logstash
+
+[[glossary-connector]] connector::
++
+--
+include::{kib-repo-dir}/glossary.asciidoc[tag=connector-def]
+--
+
+[[glossary-console]] Console::
++
+--
+include::{kib-repo-dir}/glossary.asciidoc[tag=console-def]
+--
+
+[[glossary-constructor]] constructor::
+Directs <<glossary-allocator,allocators>> to manage containers of {es} and {kib}
+nodes and maximizes the utilization of allocators. Monitors plan change requests
+from the Cloud UI and determines how to transform the existing cluster. In a
+highly available installation, places cluster nodes within different
+availability zones to ensure that the cluster can survive the failure of an
+entire availability zone.
+//Source: Cloud
+
+[[glossary-container]] container::
+Includes an instance of {ece} software and its dependencies. Used to provision
+similar environments, to assign a guaranteed share of host resources to nodes,
+and to simplify operational effort in {ece}.
+//Source: Cloud
+
+[[glossary-content-tier]] content tier::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=content-tier-def]
+--
+
+[[glossary-coordinator]] coordinator::
+Consists of a logical grouping of some {ece} services and acts as a distributed
+coordination system and resource scheduler.
+//Source: Cloud
+
+[[glossary-ccr]] {ccr} (CCR)::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=ccr-def]
+--
+
+[[glossary-ccs]] {ccs} (CCS)::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=ccs-def]
+--
+
+[[glossary-custom-rules]] custom rules::
+A set of conditions and actions that change the behavior of {anomaly-jobs}. You
+can also use filters to further limit the scope of the rules. See
+{ml-docs}/ml-rules.html[Custom rules]. {kib} refers to custom rules as job
+rules.
+//Source: Machine learning
+
+[discrete]
+[[d-glos]]
+=== D
+
+[[glossary-dashboard]] dashboard::
++
+--
+include::{kib-repo-dir}/glossary.asciidoc[tag=dashboard-def]
+--
+
+[[glossary-ml-datafeed]] datafeed::
+{anomaly-jobs-cap} can analyze either a one-off batch of data or continuously in
+real time. {dfeeds-cap} retrieve data from {es} for analysis.
+//Source: X-Pack
+
+[[glossary-dataset]] dataset::
+A collection of data that has the same structure.
+The name of a dataset typically signifies its source.
+See {fleet-guide}/data-streams.html[data stream naming scheme].
+//Source: Observability
+
+[[glossary-dataframe-job]] {dfanalytics-job}::
+{dfanalytics-jobs-cap} contain the configuration information and metadata
+necessary to perform {ml} analytics tasks on a source index and store the
+outcome in a destination index. See
+{ml-docs}//ml-dfa-overview.html[{dfanalytics-cap} overview] and the
+{ref}/put-dfanalytics.html[create {dfanalytics-job} API].
+//Source: X-Pack
+
+[[glossary-data-source]] data source::
++
+--
+include::{kib-repo-dir}/glossary.asciidoc[tag=data-source-def]
+--
+
+[[glossary-data-stream]] data stream::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=data-stream-def]
+--
+
+[[glossary-data-tier]] data tier::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=data-tier-def]
+--
+
+[[glossary-delete-phase]] delete phase::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=delete-phase-def]
+--
+
+[[glossary-ml-detector]] detector::
+As part of the configuration information that is associated with {anomaly-jobs},
+detectors define the type of analysis that needs to be done. They also specify
+which fields to analyze. You can have more than one detector in a job, which is
+more efficient than running multiple jobs against the same data.
+//Source: X-Pack
+
+[[glossary-director]] director::
+Manages the <<glossary-zookeeper,ZooKeeper>> datastore. This role is often
+shared with the <<glossary-coordinator,coordinator>>, though in production
+deployments it can be separated.
+//Source: Cloud
+
+[[glossary-discover]] Discover::
++
+--
+include::{kib-repo-dir}/glossary.asciidoc[tag=discover-def]
+--
+
+[[glossary-distributed-tracing]] distributed tracing::
+The end-to-end collection of performance data throughout your microservices architecture.
+//Source: Observability
+
+[[glossary-drilldown]] drilldown::
++
+--
+include::{kib-repo-dir}/glossary.asciidoc[tag=drilldown-def]
+--
+
+[[glossary-document]] document::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=document-def]
+--
+
+[discrete]
+[[e-glos]]
+=== E
+
+[[glossary-edge]] edge::
++
+--
+include::{kib-repo-dir}/glossary.asciidoc[tag=edge-def]
+--
+
+[[glossary-{agent}]] {agent}::
+A single, unified agent that you can deploy to hosts or containers to collect data and protect endpoints.
+See {fleet-guide}/fleet-overview.html[{agent} overview].
+//Source: Observability
+
+[[glossary-ecs]] Elastic Common Schema (ECS)::
+A document schema for Elasticsearch, for use cases such as logging and metrics.
+ECS defines a common set of fields, their datatype, and gives guidance on their
+correct usage. ECS is used to improve uniformity of event data coming from
+different sources.
+
+[[glossary-ems]] Elastic Maps Service (EMS)::
++
+--
+include::{kib-repo-dir}/glossary.asciidoc[tag=ems-def]
+--
+
+[[glossary-epr]] Elastic Package Registry (EPR)::
+A service hosted by Elastic that stores Elastic package definitions in a central location.
+See the https://github.com/elastic/package-registry[EPR GitHub repository].
+//Source: Observability
+
+[[glossary-element]] element::
++
+--
+include::{kib-repo-dir}/glossary.asciidoc[tag=element-def]
+--
+
+[[glossary-event]] event::
+A single unit of information, containing a timestamp plus additional data. An
+event arrives via an input, and is subsequently parsed, timestamped, and
+passed through the {ls} <<glossary-pipeline,pipeline>>.
+//Source: Logstash
+
+[[glossary-eql]] Event Query Language (EQL)::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=eql-def]
+--
+
+[discrete]
+[[f-glos]]
+=== F
+
+[[glossary-feature-controls]] Feature Controls::
++
+--
+include::{kib-repo-dir}/glossary.asciidoc[tag=feature-controls-def]
+--
+
+[[glossary-feature-influence]] feature influence::
+In {oldetection}, feature influence scores indicate which features of a data
+point contribute to its outlier behavior. See
+{ml-docs}/dfa-outlier-detection.html#dfa-feature-influence[Feature influence].
+//Source: X-Pack
+
+[[glossary-feature-importance]] feature importance::
+In supervised {ml} methods such as {regression} and {classification}, feature
+importance indicates the degree to which a specific feature affects a prediction.
+See
+{ml-docs}/dfa-regression.html#dfa-regression-feature-importance[{regression-cap} feature importance]
+and
+{ml-docs}/dfa-classification.html#dfa-classification-feature-importance[{classification-cap} feature importance].
+//Source: X-Pack
+
+[[glossary-field]] field::
+. {blank}
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=field-def]
+--
+. {blank}
++
+--
+In {ls}, this term refers to an <<glossary-event,event>> property. For
+example, each event in an apache access log has properties, such as a status
+code (200, 404), request path ("/", "index.html"), HTTP verb (GET, POST), client
+IP address, and so on. {ls} uses the term "fields" to refer to these
+properties.
+//Source: Logstash
+--
+
+[[glossary-field-reference]] field reference::
+A reference to an event <<glossary-field,field>>. This reference may appear in
+an output block or filter block in the {ls} config file. Field references
+are typically wrapped in square (`[]`) brackets, for example `[fieldname]`. If
+you are referring to a top-level field, you can omit the `[]` and simply use
+the field name. To refer to a nested field, you specify the full path to that
+field: `[top-level field][nested field]`.
+//Source: Logstash
+
+[[glossary-filter]] filter::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=filter-def]
+--
+
+[[glossary-filter-plugin]] filter plugin::
+A {ls} <<glossary-plugin,plugin>> that performs intermediary processing on
+an <<glossary-event,event>>. Typically, filters act upon event data after it
+has been ingested via inputs, by mutating, enriching, and/or modifying the
+data according to configuration rules. Filters are often applied conditionally
+depending on the characteristics of the event. Popular filter plugins include
+grok, mutate, drop, clone, and geoip. Filter stages are optional.
+//Source: Logstash
+
+[[glossary-fleet]] Fleet::
+Fleet provides a way to centrally manage {agent}s at scale. There are two parts: The Fleet app in {kib} provides a web-based UI to add and remotely manage agents, while the {fleet-server} provides the backend service that manages agents.
+See {fleet-guide}/fleet-overview.html[{agent} overview].
+//Source: Observability
+
+[[glossary-{fleet-server}]] {fleet-server}::
+{fleet-server} is a component used to centrally manage {agent}s.
+It serves as a control plane for updating agent policies, collecting status information, and coordinating actions across agents.
+//Source: Observability
+
+[[glossary-flush]] flush::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=flush-def]
+--
+
+[[glossary-follower-index]] follower index::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=follower-index-def]
+--
+
+[[glossary-force-merge]] force merge::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=force-merge-def]
+--
+
+[[glossary-freeze]] freeze::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=freeze-def]
+--
+
+[[glossary-frozen-index]] frozen index::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=frozen-index-def]
+--
+
+[[glossary-frozen-phase]] frozen phase::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=frozen-phase-def]
+--
+
+[[glossary-frozen-tier]] frozen tier::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=frozen-tier-def]
+--
+
+[discrete]
+[[g-glos]]
+=== G
+
+[[glossary-gem]] gem::
+A self-contained package of code that's hosted on
+https://rubygems.org[RubyGems.org]. {ls} <<glossary-plugin,plugins>> are
+packaged as Ruby Gems. You can use the {ls}
+<<glossary-plugin-manager,plugin manager>> to manage {ls} gems.
+//Source: Logstash
+
+[[glossary-geojson]] GeoJSON::
++
+--
+include::{kib-repo-dir}/glossary.asciidoc[tag=geojson-def]
+--
+
+[[glossary-geo-point]] geo-point::
++
+--
+include::{kib-repo-dir}/glossary.asciidoc[tag=geo-point-def]
+--
+
+[[glossary-geo-shape]] geo-shape::
++
+--
+include::{kib-repo-dir}/glossary.asciidoc[tag=geo-shape-def]
+--
+
+[[glossary-graph]] graph::
++
+--
+include::{kib-repo-dir}/glossary.asciidoc[tag=graph-def]
+--
+
+[[glossary-grok-debugger]] Grok Debugger::
++
+--
+include::{kib-repo-dir}/glossary.asciidoc[tag=grok-debugger-def]
+--
+
+[discrete]
+[[h-glos]]
+=== H
+
+[[glossary-heat-map]] heat map::
++
+--
+include::{kib-repo-dir}/glossary.asciidoc[tag=heat-map-def]
+--
+
+[[glossary-hidden-index]] hidden data stream or index::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=hidden-index-def]
+--
+
+[[glossary-hot-phase]] hot phase::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=hot-phase-def]
+--
+
+[[glossary-hot-thread]] hot thread::
+A Java thread that has high CPU usage and executes for a longer than normal
+period of time.
+//Source: Logstash
+
+[[glossary-hot-tier]] hot tier::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=hot-tier-def]
+--
+
+[discrete]
+[[i-glos]]
+=== I
+
+[[glossary-id]] ID::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=id-def]
+--
+
+[[glossary-index]] index::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=index-def]
+--
+
+[[glossary-index-alias]] index alias::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=index-alias-def]
+--
+
+[[glossary-index-lifecycle]] index lifecycle::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=index-lifecycle-def]
+--
+
+[[glossary-index-lifecycle-policy]] index lifecycle policy::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=index-lifecycle-policy-def]
+--
+
+[[glossary-index-pattern]] index pattern::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=index-pattern-def]
+--
+
+[[glossary-index-template]] index template::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=index-template-def]
+--
+
+[[glossary-indexer]] indexer::
+A {ls} instance that is tasked with interfacing with an {es} cluster in
+order to index <<glossary-event,event>> data.
+//Source: Logstash
+
+[[glossary-inference]] inference::
+A {ml} feature that enables you to use supervised learning processes – like
+{regression} and {classification} – in a continuous fashion by using
+<<glossary-trained-model,trained models>> against incoming data.
+//Source: Machine learning
+
+[[glossary-inference-aggregation]] inference aggregation::
+A pipeline aggregation that references a <<glossary-trained-model>> in an
+aggregation to infer on the results field of the parent bucket aggregation. It
+enables you to use supervised {ml} at search time.
+//Source: Machine learning
+
+[[glossary-inference-processor]] inference processor::
+A processor specified in an ingest pipeline that uses a
+<<glossary-trained-model>> to infer against the data that is being ingested in
+the pipeline.
+//Source: Machine learning
+
+[[glossary-influencer]] influencer::
+Influencers are entities that might have contributed to an anomaly in a specific
+bucket in an {anomaly-job}. For more information, see
+{ml-docs}/ml-influencers.html[Influencers].
+//Source: X-Pack
+
+[[glossary-ingestion]] ingestion::
+The process of collecting and sending data from various data sources to {es}.
+//Source: Observability
+
+[[glossary-input-plugin]] input plugin::
+A {ls} <<glossary-plugin,plugin>> that reads <<glossary-event,event>> data
+from a specific source. Input plugins are the first stage in the {ls}
+event processing <<glossary-pipeline,pipeline>>. Popular input plugins include
+file, syslog, redis, and beats.
+//Source: Logstash
+
+[[glossary-instrumentation]] instrumentation::
+Extending application code to track where your application is spending time.
+Code is considered instrumented when it collects and reports this performance data to APM.
+//Source: Observability
+
+[[glossary-integration]] integration::
+
+An easy way for external systems to connect to the {stack}.
+Whether it's collecting data or protecting systems from security threats,
+integrations provide out-of-the-box assets to make setup easy--many with just a single click.
+//Source: Observability
+
+[[glossary-integration-policy]] integration policy::
+An instance of an <<glossary-integration,integration>> that is configured for a specific use case,
+such as collecting logs from a specific file.
+//Source: Observability
+
+[discrete]
+[[j-glos]]
+=== J
+
+[[glossary-ml-job]][[glossary-job]] job::
+{ml-cap} jobs contain the configuration information and metadata
+necessary to perform an analytics task. There are two types:
+<<glossary-anomaly-detection-job,{anomaly-jobs}>> and
+<<glossary-dataframe-job,{dfanalytics-jobs}>>. See also <<glossary-rollup-job>>.
+//Source: X-Pack
+
+[discrete]
+[[k-glos]]
+=== K
+
+[[glossary-kibana-privileges]] {kib} privileges::
++
+--
+include::{kib-repo-dir}/glossary.asciidoc[tag=kibana-privileges-def]
+--
+
+[[glossary-kql]] {kib} Query Language (KQL)::
++
+--
+include::{kib-repo-dir}/glossary.asciidoc[tag=kql-def]
+--
+
+[discrete]
+[[l-glos]]
+=== L
+
+[[glossary-leader-index]] leader index::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=leader-index-def]
+--
+
+[[glossary-lens]] Lens::
++
+--
+include::{kib-repo-dir}/glossary.asciidoc[tag=lens-def]
+--
+
+[[glossary-local-cluster]] local cluster::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=local-cluster-def]
+--
+
+[[glossary-lucene]] Lucene query syntax::
++
+--
+include::{kib-repo-dir}/glossary.asciidoc[tag=lucene-def]
+--
+
+[discrete]
+[[m-glos]]
+=== M
+
+[[glossary-ml-nodes]] machine learning node::
+A {ml} node is a node that has `xpack.ml.enabled` set to `true` and `ml` in `node.roles`.
+If you want to use {ml-features}, there must be at least one {ml} node in your
+cluster. See {ref}/modules-node.html#ml-node[Machine learning nodes].
+//Source: X-Pack
+
+[[glossary-map]] map::
++
+--
+include::{kib-repo-dir}/glossary.asciidoc[tag=map-def]
+--
+
+[[glossary-mapping]] mapping::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=mapping-def]
+--
+
+[[glossary-master-node]] master node::
+Handles write requests for the cluster and publishes changes to other nodes in
+an ordered fashion. Each cluster has a single master node which is chosen
+automatically by the cluster and is replaced if the current master node fails.
+Also see <<glossary-node,node>>.
+//Source: Cloud
+
+[[glossary-merge]] merge::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=merge-def]
+--
+
+[[glossary-message-broker]] message broker::
+Also referred to as a _message buffer_ or _message queue_, a message broker is
+external software (such as Redis, Kafka, or RabbitMQ) that stores messages
+from the {ls} shipper instance as an intermediate store, waiting to be
+processed by the {ls} indexer instance.
+//Source: Logstash
+
+[[glossary-metric-aggregation]] metric aggregation::
++
+--
+include::{kib-repo-dir}/glossary.asciidoc[tag=metric-aggregation-def]
+--
+
+[[glossary-metadata]] @metadata::
+A special field for storing content that you don't want to include in output
+<<glossary-event,events>>. For example, the `@metadata` field is useful for
+creating transient fields for use in <<glossary-conditional,conditional>>
+statements.
+//Source: Logstash
+
+[[glossary-module]] module::
+Out-of-the-box configurations for common data sources to simplify the collection,
+parsing, and visualization of logs and metrics.
+//Source: Observability
+
+[[glossary-monitor]] monitor::
+A network endpoint which is monitored to track the performance and availability of
+applications and services.
+//Source: Observability
+
+[discrete]
+[[n-glos]]
+=== N
+
+[[glossary-namespace]] namespace::
+A user-configurable arbitrary data grouping, such as an environment (`dev`, `prod`, or `qa`),
+a team, or a strategic business unit.
+//Source: Observability
+
+[[glossary-node]] node::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=node-def]
+--
+
+[discrete]
+[[o-glos]]
+=== O
+
+[[glossary-observability]] Observability::
+Unifying your logs, metrics, uptime data, and application traces to
+provide granular insights and context into the behavior of services
+running in your environments.
+//Source: Observability
+
+[[glossary-output-plugin]] output plugin::
+A {ls} <<glossary-plugin,plugin>> that writes <<glossary-event,event>> data
+to a specific destination. Outputs are the final stage in the event
+<<glossary-pipeline,pipeline>>. Popular output plugins include elasticsearch,
+file, graphite, and statsd.
+//Source: Logstash
+
+[discrete]
+[[p-glos]]
+=== P
+
+[[glossary-painless-lab]] Painless Lab::
++
+--
+include::{kib-repo-dir}/glossary.asciidoc[tag=painless-lab-def]
+--
+
+[[glossary-panel]] panel::
++
+--
+include::{kib-repo-dir}/glossary.asciidoc[tag=panel-def]
+--
+
+[[glossary-pipeline]] pipeline::
+A term used to describe the flow of <<glossary-event,events>> through the
+{ls} workflow. A pipeline typically consists of a series of input, filter,
+and output stages. <<glossary-input-plugin,Input>> stages get data from a source
+and generate events, <<glossary-filter-plugin,filter>> stages, which are
+optional, modify the event data, and <<glossary-output-plugin,output>> stages
+write the data to a destination. Inputs and outputs support
+<<glossary-codec-plugin,codecs>> that enable you to encode or decode the data as
+it enters or exits the pipeline without having to use a separate filter.
+//Source: Logstash
+
+[[glossary-plan]] plan::
+Specifies the configuration and topology of an {es} or {kib} cluster, such as
+capacity, availability, and {es} version, for example. When changing a plan, the
+<<glossary-constructor,constructor>> determines how to transform the existing
+cluster into the pending plan.
+//Source: Cloud
+
+[[glossary-plugin]] plugin::
+A self-contained software package that implements one of the stages in the
+{ls} event processing <<glossary-pipeline,pipeline>>. The list of available
+plugins includes <<glossary-input-plugin,input plugins>>,
+<<glossary-output-plugin,output plugins>>,
+<<glossary-codec-plugin,codec plugins>>, and
+<<glossary-filter-plugin,filter plugins>>. The plugins are implemented as Ruby
+<<glossary-gem,gems>> and hosted on https://rubygems.org[RubyGems.org]. You
+define the stages of an event processing <<glossary-pipeline,pipeline>>
+by configuring plugins.
+//Source: Logstash
+
+[[glossary-plugin-manager]] plugin manager::
+Accessed via the `bin/logstash-plugin` script, the plugin manager enables
+you to manage the lifecycle of <<glossary-plugin,plugins>> in your {ls}
+deployment. You can install, remove, and upgrade plugins by using the
+plugin manager Command Line Interface (CLI).
+//Source: Logstash
+
+[[glossary-primary-shard]] primary shard::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=primary-shard-def]
+--
+
+[[glossary-proxy]] proxy::
+A highly available, TLS-enabled proxy layer that routes user requests, mapping
+cluster IDs that are passed in request URLs for the container to the cluster
+nodes handling the user requests.
+//Source: Cloud
+
+[discrete]
+[[q-glos]]
+=== Q
+
+[[glossary-query]] query::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=query-def]
+--
+
+[[glossary-query-profiler]] Query Profiler::
++
+--
+include::{kib-repo-dir}/glossary.asciidoc[tag=query-profiler-def]
+--
+
+[discrete]
+[[r-glos]]
+=== R
+
+[[glossary-real-user-monitoring]] Real user monitoring (RUM)::
+Performance monitoring, metrics, and error tracking of web applications.
+//Source: Observability
+
+[[glossary-recovery]] recovery::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=recovery-def]
+--
+
+[[glossary-reindex]] reindex::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=reindex-def]
+--
+
+[[glossary-remote-cluster]] remote cluster::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=remote-cluster-def]
+--
+
+[[glossary-replica-shard]] replica shard::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=replica-shard-def]
+--
+
+[[glossary-roles-token]] roles token::
+Enables a host to join an existing {ece} installation and grants permission to
+hosts to hold certain roles, such as the <<glossary-allocator,allocator>> role.
+Used when installing {ece} on additional hosts, a roles token helps secure {ece}
+by making sure that only authorized hosts become part of the installation.
+//Source: Cloud
+
+[[glossary-rollover]] rollover::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=rollover-def]
+--
+
+[[glossary-rollup]] rollup::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=rollup-def]
+--
+
+[[glossary-rollup-index]] rollup index::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=rollup-index-def]
+--
+
+[[glossary-rollup-job]] {rollup-job}::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=rollup-job-def]
+--
+
+[[glossary-routing]] routing::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=routing-def]
+--
+
+[[glossary-rule]] rule::
++
+--
+include::{kib-repo-dir}/glossary.asciidoc[tag=rule-def]
+--
+
+[[glossary-rules-and-connectors]] Rules and Connectors::
++
+--
+include::{kib-repo-dir}/glossary.asciidoc[tag=rules-and-connectors-def]
+--
+
+[[glossary-runner]] runner::
+A local control agent that runs on all hosts, used to deploy local containers
+based on role definitions. Ensures that containers assigned to it exist and are
+able to run, and creates or recreates the containers if necessary.
+//Source: Cloud
+
+[[glossary-runtime-fields]] runtime field::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=runtime-fields-def]
+--
+
+[discrete]
+[[s-glos]]
+=== S
+
+[[glossary-saved-object]] saved object::
++
+--
+include::{kib-repo-dir}/glossary.asciidoc[tag=saved-object-def]
+--
+
+[[glossary-saved-search]] saved search::
++
+--
+include::{kib-repo-dir}/glossary.asciidoc[tag=saved-search-def]
+--
+
+[[glossary-scripted-field]] scripted field::
++
+--
+include::{kib-repo-dir}/glossary.asciidoc[tag=scripted-field-def]
+--
+
+[[glossary-search-session]] search session::
++
+--
+include::{kib-repo-dir}/glossary.asciidoc[tag=search-session-def]
+--
+
+[[glossary-searchable-snapshot]] searchable snapshot::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=searchable-snapshot-def]
+--
+
+[[glossary-searchable-snapshot-index]] searchable snapshot index::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=searchable-snapshot-index-def]
+--
+
+[[glossary-segment]] segment::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=segment-def]
+--
+
+[[glossary-services-forwarder]] services forwarder::
+Routes data internally in an {ece} installation.
+//Source: Cloud
+
+[[glossary-shard]] shard::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=shard-def]
+--
+
+[[glossary-shareable]] shareable::
++
+--
+include::{kib-repo-dir}/glossary.asciidoc[tag=shareable-def]
+--
+
+[[glossary-shipper]] shipper::
+An instance of {ls} that send events to another instance of {ls}, or
+some other application.
+//Source: Logstash
+
+[[glossary-shrink]] shrink::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=shrink-def]
+--
+
+[[glossary-snapshot]] snapshot::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=snapshot-def]
+--
+
+[[glossary-snapshot-lifecycle-policy]] snapshot lifecycle policy::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=snapshot-lifecycle-policy-def]
+--
+
+[[glossary-snapshot-repository]] snapshot repository::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=snapshot-repository-def]
+--
+
+[[glossary-source_field]] source field::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=source-field-def]
+--
+
+[[glossary-space]] space::
++
+--
+include::{kib-repo-dir}/glossary.asciidoc[tag=space-def]
+--
+
+[[glossary-span]] span::
+Information about the execution of a specific code path.
+{apm-overview-ref-v}/transaction-spans.html[Spans] measure from the start to the end of an activity
+and can have a parent/child relationship with other spans.
+//Source: Observability
+
+[[glossary-split]] split::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=split-def]
+--
+
+[[glossary-standalone]] standalone::
+This mode allows manual configuration and management of {agent}s locally
+on the systems where they are installed.
+See {fleet-guide}/run-elastic-agent-standalone.html[Run {agent} standalone].
+//Source: Observability
+
+[[glossary-stunnel]] stunnel::
+Securely tunnels all traffic in an {ece} installation.
+//Source: Cloud
+
+[[glossary-system-index]] system index::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=system-index-def]
+--
+
+[discrete]
+[[t-glos]]
+=== T
+
+[[glossary-tag]] tag::
++
+--
+include::{kib-repo-dir}/glossary.asciidoc[tag=tag-def]
+--
+
+[[glossary-term]] term::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=term-def]
+--
+
+[[glossary-term-join]] term join::
++
+--
+include::{kib-repo-dir}/glossary.asciidoc[tag=term-join-def]
+--
+
+[[glossary-text]] text::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=text-def]
+--
+
+[[glossary-time-filter]] time filter::
++
+--
+include::{kib-repo-dir}/glossary.asciidoc[tag=time-filter-def]
+--
+
+[[glossary-timelion]] Timelion::
++
+--
+include::{kib-repo-dir}/glossary.asciidoc[tag=timelion-def]
+--
+
+[[glossary-time-series-data]] time series data::
++
+--
+include::{kib-repo-dir}/glossary.asciidoc[tag=time-series-data-def]
+--
+
+[[glossary-token]] token::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=token-def]
+--
+
+[[glossary-tokenization]] tokenization::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=tokenization-def]
+--
+
+
+[[glossary-trace]] trace::
+Defines the amount of time an application spends on a request.
+Traces are made up of a collection of transactions and spans that have a common root.
+//Source: Observability
+
+[[glossary-tracks]] tracks::
++
+--
+include::{kib-repo-dir}/glossary.asciidoc[tag=tracks-def]
+--
+
+[[glossary-trained-model]] trained model::
+A {ml} model that is trained and tested against a labelled data set and can be
+referenced in an ingest pipeline or in a pipeline aggregation to perform
+{classification} or {reganalysis} on new data. See
+{ml-docs}/ml-trained-models.html[Trained models].
+//Source: Machine learning
+
+[[glossary-transaction]] transaction::
+A special kind of <<glossary-span,span>> that has additional attributes associated with it.
+{apm-overview-ref-v}/transactions.html[Transactions] describe an event captured by an
+Elastic <<glossary-apm-agent,APM agent>> instrumenting a service.
+//Source: Observability
+
+[[glossary-tsvb]] TSVB::
++
+--
+include::{kib-repo-dir}/glossary.asciidoc[tag=tsvb-def]
+--
+
+[discrete]
+[[u-glos]]
+=== U
+
+[[glossary-upgrade-assistant]] Upgrade Assistant::
++
+--
+include::{kib-repo-dir}/glossary.asciidoc[tag=upgrade-assistant-def]
+--
+
+[[glossary-uptime]] Uptime::
+A metric of system reliability used to monitor the status of network endpoints
+via HTTP/S, TCP, and ICMP.
+//Source: Observability
+
+[discrete]
+[[v-glos]]
+=== V
+
+[[glossary-vector]] vector data::
++
+--
+include::{kib-repo-dir}/glossary.asciidoc[tag=vector-def]
+--
+
+[[glossary-vega]] Vega::
++
+--
+include::{kib-repo-dir}/glossary.asciidoc[tag=vega-def]
+--
+
+[[glossary-visualization]] visualization::
++
+--
+include::{kib-repo-dir}/glossary.asciidoc[tag=visualization-def]
+--
+
+[discrete]
+[[w-glos]]
+=== W
+
+[[glossary-warm-phase]] warm phase::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=warm-phase-def]
+--
+
+[[glossary-warm-tier]] warm tier::
++
+--
+include::{es-repo-dir}/glossary.asciidoc[tag=warm-tier-def]
+--
+
+[[glossary-watcher]] Watcher::
++
+--
+include::{kib-repo-dir}/glossary.asciidoc[tag=watcher-def]
+--
+
+[[glossary-wms]] Web Map Service (WMS)::
++
+--
+include::{kib-repo-dir}/glossary.asciidoc[tag=wms-def]
+--
+
+[[glossary-worker]] worker::
+The filter thread model used by {ls}, where each worker receives an
+<<glossary-event,event>> and applies all filters, in order, before emitting
+the event to the output queue. This allows scalability across CPUs because
+many filters are CPU intensive.
+//Source: Logstash
+
+[[glossary-workpad]] workpad::
++
+--
+include::{kib-repo-dir}/glossary.asciidoc[tag=workpad-def]
+--
+
+[discrete]
+[[z-glos]]
+=== Z
+
+[[glossary-zookeeper]] ZooKeeper::
+A coordination service for distributed systems used by {ece} to store the state
+of the installation. Responsible for discovery of hosts, resource allocation,
+leader election after failure and high priority notifications.
+//Source: Cloud


### PR DESCRIPTION
Backports the following commits to 7.x:
 - Add Fleet and Elastic Agent terminology to glossary (#1637)