### PR TITLE
[DOCS] Separates ES and Kibana security info on ML setup page

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-siem.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-siem.asciidoc
@@ -681,7 +681,7 @@ activities (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function])
 
 Required {beats} or {agent} integrations:::
 
-* beta:[] {elastic-endpoint} integration
+* {elastic-endpoint} integration
 * {auditbeat}
 
 Required ECS fields:::
@@ -713,7 +713,7 @@ hosts (using the {ml-docs}/ml-rare-functions.html#ml-rare[`rare` function]).
 
 Required {beats} or {agent} integrations:::
 
-* beta:[] {elastic-endpoint} integration
+* {elastic-endpoint} integration
 * {auditbeat}
 
 Required ECS fields:::
@@ -752,7 +752,7 @@ Job details:::
 
 Required {beats} or {agent} integrations:::
 
-* beta:[] {elastic-endpoint} integration
+* {elastic-endpoint} integration
 * {auditbeat}
 
 Required ECS fields:::
@@ -782,7 +782,7 @@ processes (using the
 
 Required {beats} or {agent} integrations:::
 
-* beta:[] {elastic-endpoint} integration
+* {elastic-endpoint} integration
 * {auditbeat}
 
 Required ECS fields:::
@@ -810,7 +810,7 @@ Job details:::
 
 Required {beats} or {agent} integrations:::
 
-* beta:[] {elastic-endpoint} integration
+* {elastic-endpoint} integration
 * {auditbeat}
 
 Required ECS fields:::
@@ -839,7 +839,7 @@ Job details:::
 
 Required {beats} or {agent} integrations:::
 
-* beta:[] {elastic-endpoint} integration
+* {elastic-endpoint} integration
 * {auditbeat}
 
 Required ECS fields:::
@@ -1078,7 +1078,7 @@ Job details:::
 
 Required {beats} or {agent} integrations:::
 
-* beta:[] {elastic-endpoint} integration
+* {elastic-endpoint} integration
 * {winlogbeat}, colecting data from the Windows System Monitor (Sysmon) or the
 Windows security event log
 +
@@ -1126,7 +1126,7 @@ other processes (using the
 
 Required {beats} or {agent} integrations:::
 
-* beta:[] {elastic-endpoint} integration
+* {elastic-endpoint} integration
 * {winlogbeat}, collecting data from Windows System Monitor (Sysmon)
 
 Required ECS fields:::
@@ -1192,7 +1192,7 @@ Job details:::
 
 Required {beats} or {agent} integrations:::
 
-* beta:[] {elastic-endpoint} integration
+* {elastic-endpoint} integration
 * {winlogbeat}, colecting data from the Windows System Monitor (Sysmon) or from the Windows security event log with process creation auditing enabled.
 +
 TIP: If you collect data from the Windows security event log and you configure
@@ -1236,7 +1236,7 @@ relationships (using the
 
 Required {beats} or {agent} integrations:::
 
-* beta:[] {elastic-endpoint} integration
+* {elastic-endpoint} integration
 * {winlogbeat}, collecting data from the Windows System Monitor (Sysmon) or the 
 Windows security event log
 +
@@ -1281,7 +1281,7 @@ Job details:::
 
 Required {beats} or {agent} integrations:::
 
-* beta:[] {elastic-endpoint} integration
+* {elastic-endpoint} integration
 * {winlogbeat}, collecting data from the Windows System Monitor (Sysmon) or the 
 Windows security event log
 +
@@ -1316,7 +1316,7 @@ processes (using the
 
 Required {beats} or {agent} integrations:::
 
-* beta:[] {elastic-endpoint} integration
+* {elastic-endpoint} integration
 * {winlogbeat}, collecting data from the Windows System Monitor (Sysmon)
 
 Required ECS fields:::
@@ -1342,7 +1342,7 @@ Job details:::
 
 Required {beats} or {agent} integrations:::
 
-* beta:[] {elastic-endpoint} integration
+* {elastic-endpoint} integration
 * {winlogbeat}, collecting data from the Windows System Monitor (Sysmon)
 
 Required ECS fields:::

--- a/docs/en/stack/ml/setup.asciidoc
+++ b/docs/en/stack/ml/setup.asciidoc
@@ -9,10 +9,6 @@ To use the {stack} {ml-features}, you must have the
 {subscriptions}[appropriate subscription] and at least one 
 <<ml-nodes,{ml} node>> in your cluster.
 
-In {kib}, the {ml-features} must be visible in your
-{kibana-ref}/xpack-spaces.html#spaces-control-feature-visibility[space] and your
-source index patterns must exist in the same space as your {ml} jobs.
-
 If {stack} {security-features} are enabled, you must also ensure your users have
 the <<setup-privileges,necessary privileges>>. If the {operator-feature} is
 enabled, there are some {ml} settings that can be updated only by operator 
@@ -66,9 +62,13 @@ only)
 [[kib-security-privileges]]
 === {kib} privileges
 
-{kib} also enables you to control access to the {ml-features} within each space. 
-You can manage your roles, privileges, and spaces in the **{stack-manage-app}** 
-app in {kib}. For more information, see 
+In {kib}, the {ml-features} must be visible in your
+{kibana-ref}/xpack-spaces.html#spaces-control-feature-visibility[space] and your
+source index patterns must exist in the same space as your {ml} jobs.
+
+{kib} enables you to control access to the {ml-features} within each space. You 
+can manage your roles, privileges, and spaces in the **{stack-manage-app}** app 
+in {kib}. For more information, see 
 {ref}/security-privileges.html[Security privileges] and 
 {kibana-ref}/kibana-privileges.html[{kib} privileges].
 

--- a/docs/en/stack/ml/setup.asciidoc
+++ b/docs/en/stack/ml/setup.asciidoc
@@ -5,8 +5,8 @@
 <titleabbrev>Setup and security</titleabbrev>
 ++++
 
-To use the {stack} {ml-features}, you must have the
-{subscriptions}[appropriate subscription] and at least one
+To use the {stack} {ml-features}, you must have the 
+{subscriptions}[appropriate subscription] and at least one 
 <<ml-nodes,{ml} node>> in your cluster.
 
 In {kib}, the {ml-features} must be visible in your
@@ -37,12 +37,39 @@ information, see {ref}/modules-node.html#ml-node[{ml-cap} nodes] and
 [[setup-privileges]]
 == Security privileges
 
+[discrete]
+[[es-security-privileges]]
+=== {es} security privileges
+
 The {stack-security-features} provide roles and privileges that make it easier
 to control which users can manage or view {ml} objects such as jobs, {dfeeds},
-results, and model snapshots. {kib} also enables you to control access to the
-{ml-features} within each space. You can manage your roles, privileges, and
-spaces in the **{stack-manage-app}** app in {kib}. For more information, see
-{ref}/security-privileges.html[Security privileges] and
+results, and model snapshots.
+
+
+If you use {ml} APIs, you must have the `machine_learning_admin` or 
+`machine_learning_user` built-in roles or the equivalent cluster privileges and 
+the following index privileges:
+
+For full access:
+
+* [ ] `read` and `view_index_metadata` on source indices
+* [ ] `read`, `manage`, and `index` on destination indices (for 
+  {dfanalytics-jobs} only)
+
+For read-only access:
+
+* [ ] `read` index privileges on source indices
+* [ ] `read` index privileges on destination indices (for {dfanalytics-jobs}
+only)
+
+[discrete]
+[[kib-security-privileges]]
+=== {kib} privileges
+
+{kib} also enables you to control access to the {ml-features} within each space. 
+You can manage your roles, privileges, and spaces in the **{stack-manage-app}** 
+app in {kib}. For more information, see 
+{ref}/security-privileges.html[Security privileges] and 
 {kibana-ref}/kibana-privileges.html[{kib} privileges].
 
 For full access to the {ml-features} in {kib}, you must have:
@@ -73,9 +100,6 @@ privileges for the index pattern management feature
 IMPORTANT: You cannot limit access to specific {ml} objects in each space. If
 the {ml} feature is visible in your space and you have `read` or `all` {kib}
 privileges for the feature, you have access to *all* {ml} objects in that space.
-
-If you do not use {kib} and instead call {ml} APIs directly, you must have the
-index privileges listed above as well as `machine_learning_admin` or `machine_learning_user` built-in roles.
 
 WARNING: The `machine_learning_admin` and `machine_learning_user` roles grant
 access to the {ml-features} in all {kib} spaces. Therefore, when you use {kib},

--- a/docs/en/stack/ml/setup.asciidoc
+++ b/docs/en/stack/ml/setup.asciidoc
@@ -46,7 +46,6 @@ The {stack-security-features} provide roles and privileges that make it easier
 to control which users can manage or view {ml} objects such as jobs, {dfeeds},
 results, and model snapshots.
 
-
 If you use {ml} APIs, you must have the `machine_learning_admin` or 
 `machine_learning_user` built-in roles or the equivalent cluster privileges and 
 the following index privileges:

--- a/docs/en/stack/ml/setup.asciidoc
+++ b/docs/en/stack/ml/setup.asciidoc
@@ -15,7 +15,8 @@ source index patterns must exist in the same space as your {ml} jobs.
 
 If {stack} {security-features} are enabled, you must also ensure your users have
 the <<setup-privileges,necessary privileges>>. If the {operator-feature} is
-enabled, there are some {ml} settings that can be updated only by operator users.
+enabled, there are some {ml} settings that can be updated only by operator 
+users.
 
 TIP: The fastest way to get started with {ml-features} is to
 {ess-trial}[start a free 14-day trial of {ess}] in the cloud.
@@ -72,6 +73,10 @@ app in {kib}. For more information, see
 {ref}/security-privileges.html[Security privileges] and 
 {kibana-ref}/kibana-privileges.html[{kib} privileges].
 
+The `machine_learning_admin` and `machine_learning_user` roles grant access to 
+the {ml-features} in all {kib} spaces. Therefore, when you use {kib}, use custom 
+roles instead and set your {kib} privileges appropriately for each space.
+
 For full access to the {ml-features} in {kib}, you must have:
 
 [%interactive]
@@ -100,8 +105,3 @@ privileges for the index pattern management feature
 IMPORTANT: You cannot limit access to specific {ml} objects in each space. If
 the {ml} feature is visible in your space and you have `read` or `all` {kib}
 privileges for the feature, you have access to *all* {ml} objects in that space.
-
-WARNING: The `machine_learning_admin` and `machine_learning_user` roles grant
-access to the {ml-features} in all {kib} spaces. Therefore, when you use {kib},
-use custom roles instead and set your {kib} privileges appropriately for each
-space.


### PR DESCRIPTION
## Overview

This PR adds an ES- and a Kibana-related subsection to the security info on the ML setup page. It also adds the warning about built-in roles in Kibana to the beginning of the section for better visibility.

Related to https://github.com/elastic/ml-team/issues/525

### Preview

[ML setup](https://stack-docs_1649.docs-preview.app.elstc.co/guide/en/machine-learning/master/setup.html)