### PR TITLE
[7.13] Update get-started-stack.asciidoc (#1650)

### DIFF
--- a/docs/en/getting-started/get-started-stack.asciidoc
+++ b/docs/en/getting-started/get-started-stack.asciidoc
@@ -220,17 +220,17 @@ You should see a response similar to this:
 {
   "name" : "QtI5dUu",
   "cluster_name" : "elasticsearch",
-  "cluster_uuid" : "DMXhqzzjTGqEtDlkaMOzlA",
+  "cluster_uuid" : "v8OWkR1OQO-rgV8o_lRhEA",
   "version" : {
     "number" : "{elasticsearch_version}",
     "build_flavor" : "default",
     "build_type" : "tar",
-    "build_hash" : "00d8bc1",
-    "build_date" : "2018-06-06T16:48:02.249996Z",
+    "build_hash" : "f4d76bd413ecfbd5122c3aa5dc85465960f18afe",
+    "build_date" : "2021-04-23T15:58:28.336786977Z",
     "build_snapshot" : false,
-    "lucene_version" : "7.3.1",
-    "minimum_wire_compatibility_version" : "5.6.0",
-    "minimum_index_compatibility_version" : "5.0.0"
+    "lucene_version" : "8.8.2",
+    "minimum_wire_compatibility_version" : "6.8.0",
+    "minimum_index_compatibility_version" : "6.0.0-beta1"
   },
   "tagline" : "You Know, for Search"
 }


### PR DESCRIPTION
Backports the following commits to 7.13:
 - Update get-started-stack.asciidoc (#1650)