### PR TITLE
Update glossary.asciidoc

### DIFF
--- a/docs/en/glossary/glossary.asciidoc
+++ b/docs/en/glossary/glossary.asciidoc
@@ -482,7 +482,7 @@ Fleet provides a way to centrally manage {agent}s at scale. There are two parts:
 See {fleet-guide}/fleet-overview.html[{agent} overview].
 //Source: Observability
 
-[[glossary-{fleet-server}]] {fleet-server}::
+[[glossary-fleet-server]] {fleet-server}::
 {fleet-server} is a component used to centrally manage {agent}s.
 It serves as a control plane for updating agent policies, collecting status information, and coordinating actions across agents.
 //Source: Observability


### PR DESCRIPTION
A different syntax is required to use attributes in IDs. I think it's OK to hard code.