### PR TITLE
[7.x] [DOCS] Separates ES and Kibana security info on ML setup page (#1649)

### DIFF
--- a/docs/en/stack/ml/setup.asciidoc
+++ b/docs/en/stack/ml/setup.asciidoc
@@ -5,17 +5,14 @@
 <titleabbrev>Setup and security</titleabbrev>
 ++++
 
-To use the {stack} {ml-features}, you must have the
-{subscriptions}[appropriate subscription] and at least one
+To use the {stack} {ml-features}, you must have the 
+{subscriptions}[appropriate subscription] and at least one 
 <<ml-nodes,{ml} node>> in your cluster.
-
-In {kib}, the {ml-features} must be visible in your
-{kibana-ref}/xpack-spaces.html#spaces-control-feature-visibility[space] and your
-source index patterns must exist in the same space as your {ml} jobs.
 
 If {stack} {security-features} are enabled, you must also ensure your users have
 the <<setup-privileges,necessary privileges>>. If the {operator-feature} is
-enabled, there are some {ml} settings that can be updated only by operator users.
+enabled, there are some {ml} settings that can be updated only by operator 
+users.
 
 TIP: The fastest way to get started with {ml-features} is to
 {ess-trial}[start a free 14-day trial of {ess}] in the cloud.
@@ -37,13 +34,47 @@ information, see {ref}/modules-node.html#ml-node[{ml-cap} nodes] and
 [[setup-privileges]]
 == Security privileges
 
+[discrete]
+[[es-security-privileges]]
+=== {es} security privileges
+
 The {stack-security-features} provide roles and privileges that make it easier
 to control which users can manage or view {ml} objects such as jobs, {dfeeds},
-results, and model snapshots. {kib} also enables you to control access to the
-{ml-features} within each space. You can manage your roles, privileges, and
-spaces in the **{stack-manage-app}** app in {kib}. For more information, see
-{ref}/security-privileges.html[Security privileges] and
+results, and model snapshots.
+
+If you use {ml} APIs, you must have the `machine_learning_admin` or 
+`machine_learning_user` built-in roles or the equivalent cluster privileges and 
+the following index privileges:
+
+For full access:
+
+* [ ] `read` and `view_index_metadata` on source indices
+* [ ] `read`, `manage`, and `index` on destination indices (for 
+  {dfanalytics-jobs} only)
+
+For read-only access:
+
+* [ ] `read` index privileges on source indices
+* [ ] `read` index privileges on destination indices (for {dfanalytics-jobs}
+only)
+
+[discrete]
+[[kib-security-privileges]]
+=== {kib} privileges
+
+In {kib}, the {ml-features} must be visible in your
+{kibana-ref}/xpack-spaces.html#spaces-control-feature-visibility[space] and your
+source index patterns must exist in the same space as your {ml} jobs.
+
+{kib} enables you to control access to the {ml-features} within each space. You 
+can manage your roles, privileges, and spaces in the **{stack-manage-app}** app 
+in {kib}. For more information, see 
+{ref}/security-privileges.html[Security privileges] and 
 {kibana-ref}/kibana-privileges.html[{kib} privileges].
+
+The `machine_learning_admin` and `machine_learning_user` roles grant access to 
+the {ml-features} in all {kib} spaces. Therefore, when you use {kib}, use custom 
+roles instead and set your {kib} privileges appropriately for each space.
 
 For full access to the {ml-features} in {kib}, you must have:
 
@@ -73,11 +104,3 @@ privileges for the index pattern management feature
 IMPORTANT: You cannot limit access to specific {ml} objects in each space. If
 the {ml} feature is visible in your space and you have `read` or `all` {kib}
 privileges for the feature, you have access to *all* {ml} objects in that space.
-
-If you do not use {kib} and instead call {ml} APIs directly, you must have the
-index privileges listed above as well as `machine_learning_admin` or `machine_learning_user` built-in roles.
-
-WARNING: The `machine_learning_admin` and `machine_learning_user` roles grant
-access to the {ml-features} in all {kib} spaces. Therefore, when you use {kib},
-use custom roles instead and set your {kib} privileges appropriately for each
-space.


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Separates ES and Kibana security info on ML setup page (#1649)