### PR TITLE
Remove frozen index glossary terms

### DIFF
--- a/docs/en/glossary/glossary.asciidoc
+++ b/docs/en/glossary/glossary.asciidoc
@@ -505,18 +505,6 @@ include::{es-repo-dir}/glossary.asciidoc[tag=follower-index-def]
 include::{es-repo-dir}/glossary.asciidoc[tag=force-merge-def]
 --
 
-[[glossary-freeze]] freeze::
-+
---
-include::{es-repo-dir}/glossary.asciidoc[tag=freeze-def]
---
-
-[[glossary-frozen-index]] frozen index::
-+
---
-include::{es-repo-dir}/glossary.asciidoc[tag=frozen-index-def]
---
-
 [[glossary-frozen-phase]] frozen phase::
 +
 --


### PR DESCRIPTION
https://github.com/elastic/elasticsearch/pull/72946 marks the freeze API as deprecated. This removes a couple of glossary terms related to frozen indices.

Relates to https://github.com/elastic/elasticsearch/pull/72990 and https://github.com/elastic/elasticsearch/issues/70192.