### PR TITLE
[DOCS] Add `alias` glossary term

### DIFF
--- a/docs/en/glossary/glossary.asciidoc
+++ b/docs/en/glossary/glossary.asciidoc
@@ -32,6 +32,13 @@ this makes it easier to manage many agents at scale.
 See {fleet-guide}/agent-policy.html[{agent} policies].
 //Source: Observability
 
+[[glossary-alias]] alias::
++
+--
+[[glossary-index-alias]]
+include::{es-repo-dir}/glossary.asciidoc[tag=alias-def]
+--
+
 [[glossary-allocator]] allocator::
 Manages hosts that contain {es} and {kib} nodes. Controls the lifecycle of these
 nodes by creating new <<glossary-container,containers>> and managing the nodes
@@ -605,12 +612,6 @@ include::{es-repo-dir}/glossary.asciidoc[tag=id-def]
 +
 --
 include::{es-repo-dir}/glossary.asciidoc[tag=index-def]
---
-
-[[glossary-index-alias]] index alias::
-+
---
-include::{es-repo-dir}/glossary.asciidoc[tag=index-alias-def]
 --
 
 [[glossary-index-lifecycle]] index lifecycle::


### PR DESCRIPTION
Adds the `alias` glossary term. Removes the `index alias` term.

Depends on https://github.com/elastic/elasticsearch/pull/73065