### PR TITLE
[DOCS] Add highlights to Install Upgrade Guide

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -90,7 +90,7 @@ coming::[7.13.0]
 This list summarizes the most important breaking changes in {kib} {version}. For
 the complete list, go to {kibana-ref}/breaking-changes.html[{kib} breaking changes].
 
-//include::{kib-repo-dir}/migration/migrate_7_12.asciidoc[tag=notable-breaking-changes]
+include::{kib-repo-dir}/docs/CHANGELOG.asciidoc[tag=notable-breaking-changes]
 
 [[logstash-breaking-changes]]
 === {ls} breaking changes

--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -90,7 +90,7 @@ coming::[7.13.0]
 This list summarizes the most important breaking changes in {kib} {version}. For
 the complete list, go to {kibana-ref}/breaking-changes.html[{kib} breaking changes].
 
-include::{kib-repo-dir}/docs/CHANGELOG.asciidoc[tag=notable-breaking-changes]
+include::{kib-repo-dir}/CHANGELOG.asciidoc[tag=notable-breaking-changes]
 
 [[logstash-breaking-changes]]
 === {ls} breaking changes

--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -28,7 +28,7 @@ Upgrade Assistant provides information about which {dfeeds} need to be updated.
 <titleabbrev>APM</titleabbrev>
 ++++
 
-coming::[7.12.0]
+coming::[7.13.0]
 
 This list summarizes the most important breaking changes in APM. 
 For the complete list, go to {apm-server-ref}/breaking-changes.html[APM Server breaking changes].
@@ -41,7 +41,7 @@ For the complete list, go to {apm-server-ref}/breaking-changes.html[APM Server b
 <titleabbrev>Beats</titleabbrev>
 ++++
 
-coming::[7.12.0]
+coming::[7.13.0]
 
 This list summarizes the most important breaking changes in Beats. For the
 complete list, go to {beats-ref}/breaking-changes.html[Beats breaking changes].
@@ -56,12 +56,12 @@ complete list, go to {beats-ref}/breaking-changes.html[Beats breaking changes].
 <titleabbrev>{es}</titleabbrev>
 ++++
 
-coming::[7.12.0]
+coming::[7.13.0]
 
 This list summarizes the most important breaking changes in {es} {version}. For
 the complete list, go to {ref}/breaking-changes.html[{es} breaking changes].
 
-//include::{es-repo-dir}/migration/migrate_7_12.asciidoc[tag=notable-breaking-changes]
+include::{es-repo-dir}/migration/migrate_7_13.asciidoc[tag=notable-breaking-changes]
 
 [[elasticsearch-hadoop-breaking-changes]]
 === {es} Hadoop breaking changes
@@ -70,7 +70,7 @@ the complete list, go to {ref}/breaking-changes.html[{es} breaking changes].
 <titleabbrev>{es} Hadoop</titleabbrev>
 ++++
 
-coming::[7.12.0]
+coming::[7.13.0]
 
 This list summarizes the most important breaking changes in {es} Hadoop {version}.
 For the complete list, go to
@@ -85,7 +85,7 @@ include::{hadoop-repo-dir}/appendix/breaking.adoc[tag=notable-v7-breaking-change
 <titleabbrev>{kib}</titleabbrev>
 ++++
 
-coming::[7.12.0]
+coming::[7.13.0]
 
 This list summarizes the most important breaking changes in {kib} {version}. For
 the complete list, go to {kibana-ref}/breaking-changes.html[{kib} breaking changes].
@@ -99,7 +99,7 @@ the complete list, go to {kibana-ref}/breaking-changes.html[{kib} breaking chang
 <titleabbrev>{ls}</titleabbrev>
 ++++
 
-coming::[7.12.0]
+coming::[7.13.0]
 
 This list summarizes the most important breaking changes in {ls} {version}. For
 the complete list, go to

--- a/docs/en/install-upgrade/highlights.asciidoc
+++ b/docs/en/install-upgrade/highlights.asciidoc
@@ -14,7 +14,7 @@ highlights notable new features and enhancements in {minor-version}.
 <titleabbrev>Observability</titleabbrev>
 ++++
 
-coming::[7.12.0]
+coming::[7.13.0]
 
 This list summarizes the most important enhancements in Observability {minor-version}.
 
@@ -27,18 +27,16 @@ include::{obs-repo-dir}/whats-new.asciidoc[tag=whats-new]
 <titleabbrev>{es}</titleabbrev>
 ++++
 
-coming::[7.12.0]
+coming::[7.13.0]
 
 This list summarizes the most important enhancements in {es} {minor-version}.
 For the complete list, go to {ref}/release-highlights.html[{es} release highlights].
 
-////
 :leveloffset: +1
 
 include::{es-repo-dir}/release-notes/highlights.asciidoc[tag=notable-highlights]
 
 :leveloffset: -1
-////
 
 [[kibana-higlights]]
 === {kib} highlights
@@ -47,14 +45,13 @@ include::{es-repo-dir}/release-notes/highlights.asciidoc[tag=notable-highlights]
 <titleabbrev>{kib}</titleabbrev>
 ++++
 
-coming::[7.12.0]
+coming::[7.13.0]
 
 This list summarizes the most important enhancements in {kib} {minor-version}].
 
-////
 :leveloffset: +1
 
 include::{kib-repo-dir}/user/whats-new.asciidoc[tag=notable-highlights]
 
 :leveloffset: -1
-////
+


### PR DESCRIPTION
This PR must be merged *after* https://github.com/elastic/kibana/pull/100081 and https://github.com/elastic/kibana/pull/99978

It uncomments some tagged regions and fixes the "coming" tags in the Install and Upgrade Guide