### PR TITLE
[DOCS] Remove index alias anchor for `alias` glossary entry

### DIFF
--- a/docs/en/glossary/glossary.asciidoc
+++ b/docs/en/glossary/glossary.asciidoc
@@ -35,7 +35,6 @@ See {fleet-guide}/agent-policy.html[{agent} policies].
 [[glossary-alias]] alias::
 +
 --
-[[glossary-index-alias]]
 include::{es-repo-dir}/glossary.asciidoc[tag=alias-def]
 --
 


### PR DESCRIPTION
Removes an unneeded anchor from the `alias` glossary entry.

Relates to https://github.com/elastic/elasticsearch/pull/73169.