### PR TITLE
Adds page about recovering from a failed job to anomaly detection docs

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/index.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/index.asciidoc
@@ -26,6 +26,8 @@ include::job-tips.asciidoc[leveloffset=+3]
 
 include::stopping-ml.asciidoc[leveloffset=+2]
 
+include::ml-recover-failed-jobs.asciidoc[leveloffset=+2]
+
 include::anomaly-detection-scale.asciidoc[leveloffset=+2]
 
 include::ml-api-quickref.asciidoc[leveloffset=+1]

--- a/docs/en/stack/ml/anomaly-detection/index.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/index.asciidoc
@@ -26,7 +26,7 @@ include::job-tips.asciidoc[leveloffset=+3]
 
 include::stopping-ml.asciidoc[leveloffset=+2]
 
-include::ml-recover-failed-jobs.asciidoc[leveloffset=+2]
+include::ml-restart-failed-jobs.asciidoc[leveloffset=+2]
 
 include::anomaly-detection-scale.asciidoc[leveloffset=+2]
 

--- a/docs/en/stack/ml/anomaly-detection/ml-configuration.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-configuration.asciidoc
@@ -18,7 +18,7 @@ you visualize and explore the results.
 
 * <<create-jobs>>
 * <<stopping-ml>>
-* <<ml-recover-failed-jobs>>
+* <<ml-restart-failed-jobs>>
 
 After you learn how to create and stop {anomaly-detect} jobs, you can check the 
 <<anomaly-examples>> for more advanced settings and scenarios.

--- a/docs/en/stack/ml/anomaly-detection/ml-configuration.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-configuration.asciidoc
@@ -18,9 +18,11 @@ you visualize and explore the results.
 
 * <<create-jobs>>
 * <<stopping-ml>>
+* <<ml-recover-failed-jobs>>
 
-After you learn how to create and stop {anomaly-detect} jobs, you can check the 
-<<anomaly-examples>> for more advanced settings and scenarios.
+After you learn how to create and stop {anomaly-detect} jobs, and how to recover 
+from a failed job, you can check the <<anomaly-examples>> for more advanced 
+settings and scenarios.
 
 Consult <<anomaly-detection-scale>> to learn more about the particularities of 
 large {anomaly-jobs}.

--- a/docs/en/stack/ml/anomaly-detection/ml-configuration.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-configuration.asciidoc
@@ -20,9 +20,8 @@ you visualize and explore the results.
 * <<stopping-ml>>
 * <<ml-recover-failed-jobs>>
 
-After you learn how to create and stop {anomaly-detect} jobs, and how to recover 
-from a failed job, you can check the <<anomaly-examples>> for more advanced 
-settings and scenarios.
+After you learn how to create and stop {anomaly-detect} jobs, you can check the 
+<<anomaly-examples>> for more advanced settings and scenarios.
 
 Consult <<anomaly-detection-scale>> to learn more about the particularities of 
 large {anomaly-jobs}.

--- a/docs/en/stack/ml/anomaly-detection/ml-recover-failed-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-recover-failed-jobs.asciidoc
@@ -1,0 +1,47 @@
+[role="xpack"]
+[[ml-recover-failed-jobs]]
+= Recover from a failed {anomaly-job}
+
+When an {anomaly-job} has failed, decide whether you want to investigate the 
+cause of the failure or restart the job without further investigation. If the 
+job failed due to a transient problem, then there is no need to investigate 
+further and you can follow the procedure described below.
+
+If a persistent problem caused the job to fail, find out which node the failed 
+job was running on by checking the job stats on the **Job management** pane in 
+{kib} before the recovery procedure. Then get the logs for that node and look 
+for exceptions and errors where the ID of the {anomaly-job} is in the message to 
+have a better understanding of the issue.
+
+If an {anomaly-job} has failed, do the following to recover from `failed` state: 
+
+. _Force_ stop the corresponding {dfeed} by using the 
+{ref}/ml-stop-datafeed.html[Stop {dfeed} API] with the `force` parameter being 
+`true`. For example, the following request force stops the `my_datafeed` 
+{dfeed}.
++
+--
+[source,console]
+--------------------------------------------------
+POST _ml/datafeeds/my_datafeed/_stop
+{
+  "force": "true"
+}
+--------------------------------------------------
+// TEST[skip]
+--
+
+. _Force_ close the {anomaly-job} by using the 
+{ref}/ml-close-job.html[Close {anomaly-job} API] with the `force` parameter 
+being `true`. For example, the following request force closes the `my_job` 
+{anomaly-job}:
++
+--
+[source,console]
+--------------------------------------------------
+POST _ml/anomaly_detectors/my_job/_close?force=true
+--------------------------------------------------
+// TEST[skip]
+--
+
+. Restart the {anomaly-job} on the **Job management** pane in {kib}. 

--- a/docs/en/stack/ml/anomaly-detection/ml-recover-failed-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-recover-failed-jobs.asciidoc
@@ -2,7 +2,7 @@
 [[ml-recover-failed-jobs]]
 = Recover from a failed {anomaly-job}
 
-When an {anomaly-job} has failed, decide whether you want to investigate the 
+If an {anomaly-job} fails, you must decide whether you want to investigate the 
 cause of the failure or restart the job without further investigation. If the 
 job failed due to a transient problem, then there is no need to investigate 
 further and you can follow the procedure described below.

--- a/docs/en/stack/ml/anomaly-detection/ml-restart-failed-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-restart-failed-jobs.asciidoc
@@ -1,17 +1,16 @@
 [role="xpack"]
-[[ml-recover-failed-jobs]]
-= Recover from a failed {anomaly-job}
+[[ml-restart-failed-jobs]]
+= Restart failed {anomaly-jobs}
 
-If an {anomaly-job} fails, you must decide whether you want to investigate the 
-cause of the failure or restart the job without further investigation. If the 
-job failed due to a transient problem, then there is no need to investigate 
-further and you can follow the procedure described below.
-
-If a persistent problem caused the job to fail, find out which node the failed 
-job was running on by checking the job stats on the **Job management** pane in 
-{kib} before the recovery procedure. Then get the logs for that node and look 
-for exceptions and errors where the ID of the {anomaly-job} is in the message to 
-have a better understanding of the issue.
+If an {anomaly-job} fails, try to restart the job by following the procedure 
+described below. If the restarted job runs as expected, then the problem that 
+caused the job to fail was transient and no further investigation is needed. If 
+the job quickly fails after the restart, then the problem is persistent and 
+needs further investigation. In this case, find out which node the failed job 
+was running on by checking the job stats on the **Job management** pane in 
+{kib}. Then get the logs for that node and look for exceptions and errors where 
+the ID of the {anomaly-job} is in the message to have a better understanding of 
+the issue.
 
 If an {anomaly-job} has failed, do the following to recover from `failed` state: 
 
@@ -45,3 +44,4 @@ POST _ml/anomaly_detectors/my_job/_close?force=true
 --
 
 . Restart the {anomaly-job} on the **Job management** pane in {kib}. 
+


### PR DESCRIPTION
## Overview

This PR adds a new page to the anomaly detection documentation that explains how to recover from a failed job.

### Preview

[Recover from a failed anomaly detection job](https://stack-docs_1667.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-recover-failed-jobs.html)