### PR TITLE
[7.14] Add APM placeholder for 7.14

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -33,7 +33,7 @@ coming::[7.14.0]
 This list summarizes the most important breaking changes in APM.
 For the complete list, go to {apm-server-ref}/breaking-changes.html[APM Server breaking changes].
 
-//include::{apm-repo-dir}/apm-breaking-changes.asciidoc[tag=714-bc]
+include::{apm-repo-dir}/apm-breaking-changes.asciidoc[tag=714-bc]
 
 [[beats-breaking-changes]]
 === Beats breaking changes

--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -2,7 +2,7 @@
 == Breaking changes
 
 Before you upgrade, you must review the breaking changes for each product you
-use and make the necessary changes so your code is compatible with {version}. 
+use and make the necessary changes so your code is compatible with {version}.
 
 ** <<apm-breaking-changes,APM {version} breaking changes>>
 ** <<beats-breaking-changes,Beats {version} breaking changes>>
@@ -28,12 +28,12 @@ Upgrade Assistant provides information about which {dfeeds} need to be updated.
 <titleabbrev>APM</titleabbrev>
 ++++
 
-coming::[7.12.0]
+coming::[7.14.0]
 
-This list summarizes the most important breaking changes in APM. 
+This list summarizes the most important breaking changes in APM.
 For the complete list, go to {apm-server-ref}/breaking-changes.html[APM Server breaking changes].
 
-//include::{apm-repo-dir}/apm-breaking-changes.asciidoc[tag=notable-v7-breaking-changes]
+//include::{apm-repo-dir}/apm-breaking-changes.asciidoc[tag=714-bc]
 
 [[beats-breaking-changes]]
 === Beats breaking changes
@@ -41,7 +41,7 @@ For the complete list, go to {apm-server-ref}/breaking-changes.html[APM Server b
 <titleabbrev>Beats</titleabbrev>
 ++++
 
-coming::[7.12.0]
+coming::[7.14.0]
 
 This list summarizes the most important breaking changes in Beats. For the
 complete list, go to {beats-ref}/breaking-changes.html[Beats breaking changes].
@@ -56,7 +56,7 @@ complete list, go to {beats-ref}/breaking-changes.html[Beats breaking changes].
 <titleabbrev>{es}</titleabbrev>
 ++++
 
-coming::[7.12.0]
+coming::[7.14.0]
 
 This list summarizes the most important breaking changes in {es} {version}. For
 the complete list, go to {ref}/breaking-changes.html[{es} breaking changes].
@@ -70,7 +70,7 @@ the complete list, go to {ref}/breaking-changes.html[{es} breaking changes].
 <titleabbrev>{es} Hadoop</titleabbrev>
 ++++
 
-coming::[7.12.0]
+coming::[7.14.0]
 
 This list summarizes the most important breaking changes in {es} Hadoop {version}.
 For the complete list, go to
@@ -85,7 +85,7 @@ include::{hadoop-repo-dir}/appendix/breaking.adoc[tag=notable-v7-breaking-change
 <titleabbrev>{kib}</titleabbrev>
 ++++
 
-coming::[7.12.0]
+coming::[7.14.0]
 
 This list summarizes the most important breaking changes in {kib} {version}. For
 the complete list, go to {kibana-ref}/breaking-changes.html[{kib} breaking changes].
@@ -99,11 +99,10 @@ the complete list, go to {kibana-ref}/breaking-changes.html[{kib} breaking chang
 <titleabbrev>{ls}</titleabbrev>
 ++++
 
-coming::[7.12.0]
+coming::[7.14.0]
 
 This list summarizes the most important breaking changes in {ls} {version}. For
 the complete list, go to
 {logstash-ref}/breaking-changes.html[Logstash breaking changes].
 
 include::{ls-repo-dir}/static/breaking-changes.asciidoc[tag=notable-breaking-changes]
-

--- a/docs/en/install-upgrade/highlights.asciidoc
+++ b/docs/en/install-upgrade/highlights.asciidoc
@@ -14,7 +14,7 @@ highlights notable new features and enhancements in {minor-version}.
 <titleabbrev>Observability</titleabbrev>
 ++++
 
-coming::[7.12.0]
+coming::[7.14.0]
 
 This list summarizes the most important enhancements in Observability {minor-version}.
 
@@ -27,7 +27,7 @@ include::{obs-repo-dir}/whats-new.asciidoc[tag=whats-new]
 <titleabbrev>{es}</titleabbrev>
 ++++
 
-coming::[7.12.0]
+coming::[7.14.0]
 
 This list summarizes the most important enhancements in {es} {minor-version}.
 For the complete list, go to {ref}/release-highlights.html[{es} release highlights].
@@ -47,7 +47,7 @@ include::{es-repo-dir}/release-notes/highlights.asciidoc[tag=notable-highlights]
 <titleabbrev>{kib}</titleabbrev>
 ++++
 
-coming::[7.12.0]
+coming::[7.14.0]
 
 This list summarizes the most important enhancements in {kib} {minor-version}].
 


### PR DESCRIPTION
* Adds a placeholder for 7.14 APM content
* Updates coming tags to 7.14

Blocked by https://github.com/elastic/apm-server/pull/5281.