### PR TITLE
[DOCS] Remove Gold license reference for TLS security

### DIFF
--- a/docs/en/getting-started/get-started-docker.asciidoc
+++ b/docs/en/getting-started/get-started-docker.asciidoc
@@ -57,11 +57,10 @@ volumes by running `docker-compose down -v`.
 [[get-started-docker-tls]]
 === Run in Docker with TLS enabled 
 
-If you have a {subscriptions}[Gold (or higher) subscription] and the
-{security-features} are enabled, you must configure Transport Layer Security
+If {security-features} are enabled, you must configure Transport Layer Security
 (TLS) encryption for the {es} transport layer. While it is possible to use a
 trial license without setting up TLS, we advise securing your stack from the
-start. 
+start.
 
 To get an {es} cluster and {kib} up and running in Docker with security enabled, 
 you can use Docker Compose:


### PR DESCRIPTION
If you use security in production, we recommend setting up TLS, even for the basic license.

Closes https://github.com/elastic/elasticsearch/issues/73800

### Preview
https://stack-docs_1693.docs-preview.app.elstc.co/guide/en/elastic-stack-get-started/master/get-started-docker.html#get-started-docker-tls