### PR TITLE
[7.x] [DOCS] Remove Gold license reference for TLS security (#1693)

### DIFF
--- a/docs/en/getting-started/get-started-docker.asciidoc
+++ b/docs/en/getting-started/get-started-docker.asciidoc
@@ -57,11 +57,10 @@ volumes by running `docker-compose down -v`.
 [[get-started-docker-tls]]
 === Run in Docker with TLS enabled 
 
-If you have a {subscriptions}[Gold (or higher) subscription] and the
-{security-features} are enabled, you must configure Transport Layer Security
+If {security-features} are enabled, you must configure Transport Layer Security
 (TLS) encryption for the {es} transport layer. While it is possible to use a
 trial license without setting up TLS, we advise securing your stack from the
-start. 
+start.
 
 To get an {es} cluster and {kib} up and running in Docker with security enabled, 
 you can use Docker Compose:


### PR DESCRIPTION
Backports the following commits to 7.x:
 - [DOCS] Remove Gold license reference for TLS security (#1693)