### PR TITLE
[DOCS] Adds ML document metadata

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/ml-overview.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-overview.asciidoc
@@ -5,7 +5,7 @@
 ++++
 <titleabbrev>Overview</titleabbrev>
 ++++
-:keywords: {ml-init}, {es}, {anomaly-detect}, overview
+:keywords: {ml-init}, {stack}, {anomaly-detect}, overview
 :description: An introduction to {ml} {anomaly-detect}, which analyzes time \
 series data to identify and predict anomalous patterns in your data.
 

--- a/docs/en/stack/ml/anomaly-detection/ml-overview.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-overview.asciidoc
@@ -1,6 +1,13 @@
 [role="xpack"]
 [[ml-overview]]
-= Overview
+= {anomaly-detect-cap} overview
+[subs="attributes"]
+++++
+<titleabbrev>Overview</titleabbrev>
+++++
+:keywords: {ml-init}, {es}, {anomaly-detect}, overview
+:description: An introduction to {ml} {anomaly-detect}, which analyzes time \
+series data to identify and predict anomalous patterns in your data.
 
 [discrete]
 [[ml-analyzing]]

--- a/docs/en/stack/ml/df-analytics/ml-dfa-overview.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-overview.asciidoc
@@ -1,15 +1,22 @@
 [role="xpack"]
 [[ml-dfa-overview]]
-= Overview
-
+= {dfanalytics-cap} overview
+[subs="attributes"]
+++++
+<titleabbrev>Overview</titleabbrev>
+++++
+:keywords: {ml-init}, {es}, {dfanalytics}, overview
+:description: An introduction to {ml} {dfanalytics}, which enables you to  \
+analyze your data using classification, regression, and outlier detection \
+algorithms and to generate trained models for predictions on new data.
 
 {dfanalytics-cap} enable you to perform different analyses of your data and 
 annotate it with the results. By doing this, it provides additional insights 
 into the data. <<dfa-outlier-detection,{oldetection-cap}>> identifies unusual 
-data points in the dataset. <<dfa-regression,{regression-cap}>> makes 
+data points in the data set. <<dfa-regression,{regression-cap}>> makes 
 predictions on your data after it determines certain relationships among your 
 data points. <<dfa-classification,{classification-cap}>> predicts the class or 
-category of a given data point in a dataset. <<ml-inference,{infer-cap}>> 
+category of a given data point in a data set. <<ml-inference,{infer-cap}>> 
 enables you to use trained {ml} models against incoming data in a continuous 
 fashion.
 

--- a/docs/en/stack/ml/df-analytics/ml-dfa-overview.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-overview.asciidoc
@@ -5,7 +5,7 @@
 ++++
 <titleabbrev>Overview</titleabbrev>
 ++++
-:keywords: {ml-init}, {es}, {dfanalytics}, overview
+:keywords: {ml-init}, {stack}, {dfanalytics}, overview
 :description: An introduction to {ml} {dfanalytics}, which enables you to  \
 analyze your data using classification, regression, and outlier detection \
 algorithms and to generate trained models for predictions on new data.

--- a/docs/en/stack/ml/get-started/ml-getting-started.asciidoc
+++ b/docs/en/stack/ml/get-started/ml-getting-started.asciidoc
@@ -1,5 +1,8 @@
 [[ml-getting-started]]
 == Getting started with {ml}
+:keywords: {ml-init}, {es}, {anomaly-detect}, tutorial
+:description: This tutorial shows you how to create {anomaly-jobs}, \
+interpret the results, and forecast future behavior in {kib}. 
 
 {ml-cap} features analyze your data and generate models for its patterns of
 behavior. The type of analysis that you choose depends on the questions or

--- a/docs/en/stack/ml/get-started/ml-getting-started.asciidoc
+++ b/docs/en/stack/ml/get-started/ml-getting-started.asciidoc
@@ -1,6 +1,6 @@
 [[ml-getting-started]]
 == Getting started with {ml}
-:keywords: {ml-init}, {es}, {anomaly-detect}, tutorial
+:keywords: {ml-init}, {stack}, {anomaly-detect}, tutorial
 :description: This tutorial shows you how to create {anomaly-jobs}, \
 interpret the results, and forecast future behavior in {kib}. 
 


### PR DESCRIPTION
This PR adds some metadata to the machine learning overview pages and the getting started tutorial, using the method described in https://docs.asciidoctor.org/asciidoc/latest/document/metadata/

It must be merged *after* https://github.com/elastic/docs/pull/2136

When you "view source" for these pages in a browser, it includes the metadata as follows:

````
<meta name="description" content="An introduction to machine learning data frame analytics, which ...">
<meta name="keywords" content="ML, Elasticsearch, data frame analytics, overview">
````