### PR TITLE
[DOCS] Add legacy header for Stack Overview

### DIFF
--- a/docs/en/stack/page_header.html
+++ b/docs/en/stack/page_header.html
@@ -1,3 +1,3 @@
-<strong>IMPORTANT</strong>This documentation is no longer maintained and might be removed.
+<strong>IMPORTANT</strong> This documentation is no longer maintained and might be removed.
 For the latest information, see the
 <a href="https://www.elastic.co/guide/index.html">current documentation</a>.

--- a/docs/en/stack/page_header.html
+++ b/docs/en/stack/page_header.html
@@ -1,0 +1,3 @@
+<strong>IMPORTANT</strong>This documentation is no longer maintained and might be removed.
+For the latest information, see the
+<a href="https://www.elastic.co/guide/index.html">current documentation</a>.


### PR DESCRIPTION
Related to https://github.com/elastic/stack-docs/issues/1698

This PR adds a warning at the top of pages in the Stack Overview, which indicates that this is legacy documentation.