### PR TITLE
[DOCS] Adds nested fields related item to DFA limitations

### DIFF
--- a/docs/en/stack/ml/df-analytics/ml-dfa-limitations.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-limitations.asciidoc
@@ -47,6 +47,14 @@ environments.
 {ccs-cap} is not supported for {dfanalytics}.
 
 [discrete]
+[[dfa-nested-fields-limitations]]
+=== Nested fields are not supported
+
+Nested fields are not supported for {dfanalytics-jobs}. These fields are ignored 
+during the analysis. If a nested field is selected as the dependent variable, an 
+error occurs.
+
+[discrete]
 [[dfa-update-limitations]]
 === {dfanalytics-jobs-cap} cannot be updated
 

--- a/docs/en/stack/ml/df-analytics/ml-dfa-limitations.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-limitations.asciidoc
@@ -51,8 +51,8 @@ environments.
 === Nested fields are not supported
 
 Nested fields are not supported for {dfanalytics-jobs}. These fields are ignored 
-during the analysis. If a nested field is selected as the dependent variable, an 
-error occurs.
+during the analysis. If a nested field is selected as the dependent variable for 
+{classification} or {reganalysis}, an error occurs.
 
 [discrete]
 [[dfa-update-limitations]]


### PR DESCRIPTION
## Overview

Adds a new limitation item to the DFA limitations section about nested fields.

### Preview

[DFA limitations – Nested fields are not supported](https://stack-docs_1714.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-dfa-limitations.html#dfa-nested-fields-limitations)