### PR TITLE
[DOCS] Update xrefs to time units section in ES guide

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/job-tips.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/job-tips.asciidoc
@@ -19,7 +19,7 @@ model data for your job. When you create an {anomaly-job} in {kib}, you can
 choose to estimate a bucket span value based on your data characteristics. 
 
 NOTE: The bucket span must contain a valid time interval. See
-{ref}/common-options.html#time-units[Time units].
+{time-units}[Time units].
 
 If you choose a value that is larger than one day or is significantly different 
 than the estimated value, you receive an informational message. For more 

--- a/docs/en/stack/ml/get-started/ml-gs-forecasts.asciidoc
+++ b/docs/en/stack/ml/get-started/ml-gs-forecasts.asciidoc
@@ -20,7 +20,7 @@ image::images/ml-gs-forecast.png["Create a forecast from the Single Metric Viewe
 
 . Specify a duration for your forecast. This value indicates how far to
 extrapolate beyond the last record that was processed. You must use
-{ref}/common-options.html#time-units[time units]. In this example, the duration
+{time-units}[time units]. In this example, the duration
 is one week (`1w`): +
 +
 --


### PR DESCRIPTION
Update to use attributes so https://github.com/elastic/elasticsearch/pull/74529 can be merged.