### PR TITLE
[DOCS] Adds chapter, removes part from ML guide

### DIFF
--- a/docs/en/stack/ml/get-started/ml-getting-started.asciidoc
+++ b/docs/en/stack/ml/get-started/ml-getting-started.asciidoc
@@ -1,5 +1,5 @@
 [[ml-getting-started]]
-== Getting started with {ml}
+= Getting started with {ml}
 :keywords: {ml-init}, {stack}, {anomaly-detect}, tutorial
 :description: This tutorial shows you how to create {anomaly-jobs}, \
 interpret the results, and forecast future behavior in {kib}. 
@@ -10,13 +10,13 @@ problems you want to address and the type of data you have available.
 
 [discrete]
 [[get-started-unsupervised]]
-=== Unsupervised {ml}
+== Unsupervised {ml}
 
 There are two types of analysis that can deduce the patterns and relationships
 within your data without training or intervention: _{anomaly-detect}_ and
 _{oldetection}_.
 
-<<xpack-ml,{anomaly-detect-cap}>> requires time series data. It constructs a
+<<ml-overview,{anomaly-detect-cap}>> requires time series data. It constructs a
 probability model and can run continuously to identify unusual events as they
 occur. The model evolves over time; you can use its insights to forecast future
 behavior.
@@ -30,7 +30,7 @@ point is an outlier compared to other data points.
 
 [discrete]
 [[get-started-supervised]]
-=== Supervised {ml}
+== Supervised {ml}
 
 There are two types of analysis that require training data sets:
 _{classification}_ and _{regression}_.
@@ -50,7 +50,7 @@ time for a web request.
 
 [discrete]
 [[get-started-prereqs]]
-=== Try it out
+== Try it out
 
 Ready to take {ml} for a test drive? Follow this tutorial to:
 

--- a/docs/en/stack/ml/get-started/ml-gs-forecasts.asciidoc
+++ b/docs/en/stack/ml/get-started/ml-gs-forecasts.asciidoc
@@ -1,6 +1,6 @@
 [role="xpack"]
 [[ml-gs-forecasts]]
-== Create forecasts
+= Create forecasts
 
 In addition to detecting anomalous behavior in your data, you can use the
 {ml-features} to predict future behavior.

--- a/docs/en/stack/ml/get-started/ml-gs-jobs.asciidoc
+++ b/docs/en/stack/ml/get-started/ml-gs-jobs.asciidoc
@@ -1,6 +1,6 @@
 [role="xpack"]
 [[ml-gs-jobs]]
-== Create sample {anomaly-jobs} in {kib}
+= Create sample {anomaly-jobs} in {kib}
 ++++
 <titleabbrev>Create {anomaly-jobs}</titleabbrev>
 ++++

--- a/docs/en/stack/ml/get-started/ml-gs-next.asciidoc
+++ b/docs/en/stack/ml/get-started/ml-gs-next.asciidoc
@@ -1,6 +1,6 @@
 [role="xpack"]
 [[ml-gs-next]]
-== Next steps
+= Next steps
 
 By completing this tutorial, you've learned how you can detect anomalous
 behavior in a simple set of sample data. You created {anomaly-jobs} in {kib},

--- a/docs/en/stack/ml/get-started/ml-gs-results.asciidoc
+++ b/docs/en/stack/ml/get-started/ml-gs-results.asciidoc
@@ -1,6 +1,6 @@
 [role="xpack"]
 [[ml-gs-results]]
-== View {anomaly-detect} results
+= View {anomaly-detect} results
 
 After the {dfeeds} are started and the {anomaly-jobs} have processed some data,
 you can view the results in {kib}.
@@ -24,7 +24,7 @@ job selection to examine a different subset of {anomaly-jobs}.
 
 [discrete]
 [[ml-gs-results-smv]]
-=== Single metric job results
+== Single metric job results
 
 One of the sample jobs (`low_request_rate`), is a _single metric {anomaly-job}_.
 It has a single detector that uses the `low_count` function and limited job
@@ -104,7 +104,7 @@ layering additional jobs or creating multi-metric jobs.
 
 [discrete]
 [[ml-gs-results-ae]]
-=== Advanced or multi-metric job results
+== Advanced or multi-metric job results
 
 Conceptually, you can think of _multi-metric {anomaly-jobs}_ as running multiple
 independent single metric jobs. By bundling them together in a multi-metric job,
@@ -205,7 +205,7 @@ scores. The list of anomalies uses the record-level anomaly scores.
 
 [discrete]
 [[ml-gs-results-population]]
-=== Population job results
+== Population job results
 
 The final sample job (`url_scanning`) is a _population {anomaly-job}_. As we
 saw in the `response_code_rates` job results, there are some clients that seem

--- a/docs/en/stack/ml/get-started/ml-gs-visualizer.asciidoc
+++ b/docs/en/stack/ml/get-started/ml-gs-visualizer.asciidoc
@@ -1,6 +1,6 @@
 [role="xpack"]
 [[ml-gs-visualizer]]
-== Explore the data in {kib}
+= Explore the data in {kib}
 
 To get the best results from {ml} analytics, you must understand your data. You
 must know its data types and the range and distribution of values. The

--- a/docs/en/stack/ml/index.asciidoc
+++ b/docs/en/stack/ml/index.asciidoc
@@ -10,7 +10,7 @@
 include::{docs-root}/shared/versions/stack/{source_branch}.asciidoc[]
 include::{docs-root}/shared/attributes.asciidoc[]
 
-include::setup.asciidoc[leveloffset=+1]
+include::setup.asciidoc[]
 
 include::get-started/index.asciidoc[]
 

--- a/docs/en/stack/ml/setup.asciidoc
+++ b/docs/en/stack/ml/setup.asciidoc
@@ -1,4 +1,4 @@
-[role="xpack"]
+[chapter,role="xpack"]
 [[setup]]
 = Set up {ml-features}
 ++++


### PR DESCRIPTION
This PR simplifies the structure of the "setup and security" and "getting started with machine learning" sections fo the Machine Learning Guide by removing the use of docbook "parts", without losing the desired levels in the table of contents.