### PR TITLE
[DOCS] Comments out link to outlier detection in glossary

### DIFF
--- a/docs/en/glossary/glossary.asciidoc
+++ b/docs/en/glossary/glossary.asciidoc
@@ -432,8 +432,9 @@ include::{kib-repo-dir}/glossary.asciidoc[tag=feature-controls-def]
 
 [[glossary-feature-influence]] feature influence::
 In {oldetection}, feature influence scores indicate which features of a data
-point contribute to its outlier behavior. See
-{ml-docs}/dfa-outlier-detection.html#dfa-feature-influence[Feature influence].
+point contribute to its outlier behavior.
+// See
+// {ml-docs}/ml-dfa-finding-outliers.html#dfa-feature-influence[Feature influence].
 //Source: X-Pack
 
 [[glossary-feature-importance]] feature importance::


### PR DESCRIPTION
## Overview

Related to https://github.com/elastic/stack-docs/pull/1732 and https://github.com/elastic/stack-docs/issues/1725

This PR comments out a link that points to outlier detection-related docs. Due to the ML book reorg, this link would break the docs build after merging https://github.com/elastic/stack-docs/pull/1732. The PR also changes the URL to point to the proper place. After the changes in [1732](https://github.com/elastic/stack-docs/pull/1732) are applied, it's enough to delete the `//` to make the link work.