### PR TITLE
[DOCS] Removes classification and regression links from Glossary

### DIFF
--- a/docs/en/glossary/glossary.asciidoc
+++ b/docs/en/glossary/glossary.asciidoc
@@ -306,7 +306,7 @@ See {fleet-guide}/data-streams.html[data stream naming scheme].
 {dfanalytics-jobs-cap} contain the configuration information and metadata
 necessary to perform {ml} analytics tasks on a source index and store the
 outcome in a destination index. See
-{ml-docs}//ml-dfa-overview.html[{dfanalytics-cap} overview] and the
+{ml-docs}/ml-dfa-overview.html[{dfanalytics-cap} overview] and the
 {ref}/put-dfanalytics.html[create {dfanalytics-job} API].
 //Source: X-Pack
 
@@ -440,10 +440,6 @@ point contribute to its outlier behavior.
 [[glossary-feature-importance]] feature importance::
 In supervised {ml} methods such as {regression} and {classification}, feature
 importance indicates the degree to which a specific feature affects a prediction.
-See
-{ml-docs}/dfa-regression.html#dfa-regression-feature-importance[{regression-cap} feature importance]
-and
-{ml-docs}/dfa-classification.html#dfa-classification-feature-importance[{classification-cap} feature importance].
 //Source: X-Pack
 
 [[glossary-field]] field::


### PR DESCRIPTION
## Overview

Related to https://github.com/elastic/stack-docs/pull/1736 and https://github.com/elastic/stack-docs/issues/1725

This PR comments out links that point to classification and regression-related docs. Due to the ML book reorg, these links would break the docs build after merging https://github.com/elastic/stack-docs/pull/1736.