### PR TITLE
[DOCS] Fixes links to Kibana sample data documentation

### DIFF
--- a/docs/en/stack/ml/df-analytics/flightdata-classification.asciidoc
+++ b/docs/en/stack/ml/df-analytics/flightdata-classification.asciidoc
@@ -5,7 +5,7 @@
 
 
 Let's try to predict whether a flight will be delayed or not by using the 
-{kibana-ref}/add-sample-data.html[sample flight data]. The data set contains 
+{kibana-ref}/get-started.html#gs-get-data-into-kibana[sample flight data]. The data set contains 
 information such as weather conditions, carrier, flight distance, origin,
 destination, and whether or not the flight was delayed. When you create a
 {dfanalytics-job} for {classanalysis}, it learns the relationships between the

--- a/docs/en/stack/ml/df-analytics/flightdata-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/flightdata-regression.asciidoc
@@ -5,7 +5,7 @@
 
 
 Let's try to predict flight delays by using the 
-{kibana-ref}/add-sample-data.html[sample flight data]. The data set contains
+{kibana-ref}/get-started.html#gs-get-data-into-kibana[sample flight data]. The data set contains
 information such as weather conditions, flight destinations and origins, flight 
 distances, carriers, and the number of minutes each flight was delayed. When you
 create a {dfanalytics-job} for {reganalysis}, it learns the relationships

--- a/docs/en/stack/ml/df-analytics/ml-dfa-outlier-detection.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-outlier-detection.asciidoc
@@ -201,7 +201,7 @@ the algorithm performance by using these values.
 
 The goal of <<dfa-outlier-detection,{oldetection}>> is to find the most unusual
 documents in an index. Let's try to detect unusual customer behavior in the 
-{kibana-ref}/add-sample-data.html[eCommerce sample data set]. 
+{kibana-ref}/get-started.html#gs-get-data-into-kibana[eCommerce sample data set]. 
 
 . Verify that your environment is set up properly to use {ml-features}. 
 If the {es} {security-features} are enabled, you need a user that has authority


### PR DESCRIPTION
This PR fixes links to https://www.elastic.co/guide/en/kibana/master/add-sample-data.html, which are now redirected to the [Quickstart](https://www.elastic.co/guide/en/kibana/master/get-started.html)