### PR TITLE
[DOCS] Add redirects for broken links

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/job-tips.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/job-tips.asciidoc
@@ -4,7 +4,7 @@ suggestions, you can create jobs that are more likely to produce insightful {ml}
 results.
 
 [discrete]
-[[bucket-span]]
+[[ml-ad-bucket-span]]
 == Bucket span
 
 The bucket span is the time interval that {ml} analytics use to summarize and
@@ -19,7 +19,7 @@ than the estimated value, you receive an informational message. For more
 information about choosing an appropriate bucket span, see <<ml-buckets>>.
 
 [discrete]
-[[cardinality]]
+[[ml-ad-cardinality]]
 == Cardinality
 
 If there are logical groupings of related entities in your data, {ml} analytics
@@ -37,7 +37,7 @@ Likewise if you are performing population analysis and the cardinality of the
 field to use. For more information, see <<ml-configuring-populations>>.
 
 [discrete]
-[[detectors]]
+[[ml-ad-detectors]]
 == Detectors
 
 Each {anomaly-job} must have one or more _detectors_. A detector applies an
@@ -50,14 +50,14 @@ duplicates if they have the same `function`, `field_name`, `by_field_name`,
 `over_field_name` and `partition_field_name`. 
 
 [discrete]
-[[influencers]]
+[[ml-ad-influencers]]
 == Influencers
 
 See <<ml-influencers>>.
 
 
 [discrete]
-[[model-memory-limits]]
+[[ml-ad-model-memory-limits]]
 == Model memory limits
 
 For each {anomaly-job}, you can optionally specify a `model_memory_limit`, which
@@ -100,7 +100,7 @@ cannot increase `model_memory_limit` for your {ml} jobs, the solution is to
 increase the size of the {ml} nodes in your cluster.
 
 [discrete]
-[[dedicated-indices]]
+[[ml-ad-dedicated-indices]]
 == Dedicated indices
 
 For each {anomaly-job}, you can optionally specify a dedicated index to store 

--- a/docs/en/stack/ml/redirects.asciidoc
+++ b/docs/en/stack/ml/redirects.asciidoc
@@ -28,6 +28,32 @@ This content has moved. See <<ml-ad-close-job>>.
 
 This content has moved. See <<ml-ad-create-job>>.
 
+[[bucket-span]]
+==== Bucket span
+
+This content has moved.
+
+[[cardinality]]
+==== Cardinality
+
+This content has moved.
+
+[[detectors]]
+==== Detectors
+
+This content has moved.
+
+[[job-tips]]
+==== Job tips
+
+This content has moved.
+
+[[model-memory-limits]]
+==== Model memory limits
+
+This content has moved.
+
+
 [role="exclude",id="ml-restart-failed-jobs"]
 === Restart failed {anomaly-jobs}
 


### PR DESCRIPTION
Related to https://github.com/elastic/stack-docs/pull/1747

This PR addresses the following broken links:

> 18:39:00 INFO:build_docs:  Kibana [master]: src/core/public/doc_links/doc_links_service.ts contains broken links to:
18:39:00 INFO:build_docs:   - en/machine-learning/master/create-jobs.html#bucket-span
18:39:00 INFO:build_docs:   - en/machine-learning/master/create-jobs.html#cardinality
18:39:00 INFO:build_docs:   - en/machine-learning/master/create-jobs.html#detectors
18:39:00 INFO:build_docs:   - en/machine-learning/master/create-jobs.html#job-tips
18:39:00 INFO:build_docs:   - en/machine-learning/master/create-jobs.html#model-memory-limits