### PR TITLE
[DOCS] Uncomment 7.14 breaking changes

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -46,7 +46,7 @@ coming::[7.14.0]
 This list summarizes the most important breaking changes in Beats. For the
 complete list, go to {beats-ref}/breaking-changes.html[Beats breaking changes].
 
-//include::{beats-repo-dir}/release-notes/breaking/breaking-7.12.asciidoc[tag=notable-breaking-changes]
+include::{beats-repo-dir}/release-notes/breaking/breaking-7.14.asciidoc[tag=notable-breaking-changes]
 
 
 [[elasticsearch-breaking-changes]]
@@ -61,7 +61,7 @@ coming::[7.14.0]
 This list summarizes the most important breaking changes in {es} {version}. For
 the complete list, go to {ref}/breaking-changes.html[{es} breaking changes].
 
-//include::{es-repo-dir}/migration/migrate_7_12.asciidoc[tag=notable-breaking-changes]
+include::{es-repo-dir}/migration/migrate_7_14.asciidoc[tag=notable-breaking-changes]
 
 [[elasticsearch-hadoop-breaking-changes]]
 === {es} Hadoop breaking changes

--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -90,7 +90,7 @@ coming::[7.14.0]
 This list summarizes the most important breaking changes in {kib} {version}. For
 the complete list, go to {kibana-ref}/breaking-changes.html[{kib} breaking changes].
 
-//include::{kib-repo-dir}/migration/migrate_7_12.asciidoc[tag=notable-breaking-changes]
+include::{kib-repo-dir}/CHANGELOG.asciidoc[tag=notable-breaking-changes]
 
 [[logstash-breaking-changes]]
 === {ls} breaking changes

--- a/docs/en/install-upgrade/highlights.asciidoc
+++ b/docs/en/install-upgrade/highlights.asciidoc
@@ -42,8 +42,6 @@ include::{es-repo-dir}/release-notes/highlights.asciidoc[tag=notable-highlights]
 <titleabbrev>{kib}</titleabbrev>
 ++++
 
-coming::[7.14.0]
-
 This list summarizes the most important enhancements in {kib} {minor-version}.
 
 

--- a/docs/en/install-upgrade/highlights.asciidoc
+++ b/docs/en/install-upgrade/highlights.asciidoc
@@ -48,7 +48,7 @@ include::{es-repo-dir}/release-notes/highlights.asciidoc[tag=notable-highlights]
 
 coming::[7.14.0]
 
-This list summarizes the most important enhancements in {kib} {minor-version}].
+This list summarizes the most important enhancements in {kib} {minor-version}.
 
 
 :leveloffset: +1


### PR DESCRIPTION
This PR uncomments the 7.14 breaking changes in the Installation and Upgrade Guide.

It must be merged after https://github.com/elastic/kibana/pull/107058