### PR TITLE
[DOCS] Add missing breaking change sections

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -60,27 +60,80 @@ This list summarizes the most important breaking changes in {es} {version}. For
 the complete list, go to {ref}/breaking-changes.html[{es} breaking changes].
 
 include::{es-repo-dir}/migration/migrate_8_0.asciidoc[tag=notable-breaking-changes]
+
+==== Aggregations changes
 include::{es-repo-dir}/migration/migrate_8_0/aggregations.asciidoc[tag=notable-breaking-changes]
+
+==== Allocation changes
 include::{es-repo-dir}/migration/migrate_8_0/allocation.asciidoc[tag=notable-breaking-changes]
+
+==== Analysis changes
 include::{es-repo-dir}/migration/migrate_8_0/analysis.asciidoc[tag=notable-breaking-changes]
-include::{es-repo-dir}/migration/migrate_8_0/api.asciidoc[tag=notable-breaking-changes]
+
+==== Circuit breaker changes
 include::{es-repo-dir}/migration/migrate_8_0/breaker.asciidoc[tag=notable-breaking-changes]
+
+==== Cross cluster replication changes
+include::{es-repo-dir}/migration/migrate_8_0/ccr.asciidoc[tag=notable-breaking-changes]
+
+==== Cluster changes
+include::{es-repo-dir}/migration/migrate_8_0/cluster.asciidoc[tag=notable-breaking-changes]
+
+==== Discovery changes
 include::{es-repo-dir}/migration/migrate_8_0/discovery.asciidoc[tag=notable-breaking-changes]
+
+==== EQL changes
+include::{es-repo-dir}/migration/migrate_8_0/eql.asciidoc[tag=notable-breaking-changes]
+
+==== HTTP changes
 include::{es-repo-dir}/migration/migrate_8_0/http.asciidoc[tag=notable-breaking-changes]
+
+==== Index lifecycle management changes
 include::{es-repo-dir}/migration/migrate_8_0/ilm.asciidoc[tag=notable-breaking-changes]
+
+==== Indices changes
 include::{es-repo-dir}/migration/migrate_8_0/indices.asciidoc[tag=notable-breaking-changes]
+
+==== Java API changes
 include::{es-repo-dir}/migration/migrate_8_0/java.asciidoc[tag=notable-breaking-changes]
+
+==== Mapping changes
 include::{es-repo-dir}/migration/migrate_8_0/mappings.asciidoc[tag=notable-breaking-changes]
+
+==== Network changes
 include::{es-repo-dir}/migration/migrate_8_0/network.asciidoc[tag=notable-breaking-changes]
+
+==== Node changes
 include::{es-repo-dir}/migration/migrate_8_0/node.asciidoc[tag=notable-breaking-changes]
+
+==== Packaging changes
 include::{es-repo-dir}/migration/migrate_8_0/packaging.asciidoc[tag=notable-breaking-changes]
+
+==== Reindex changes
 include::{es-repo-dir}/migration/migrate_8_0/reindex.asciidoc[tag=notable-breaking-changes]
+
+==== REST API changes
+include::{es-repo-dir}/migration/migrate_8_0/api.asciidoc[tag=notable-breaking-changes]
+
+==== Rollup changes
 include::{es-repo-dir}/migration/migrate_8_0/rollup.asciidoc[tag=notable-breaking-changes]
+
+==== Search changes
 include::{es-repo-dir}/migration/migrate_8_0/search.asciidoc[tag=notable-breaking-changes]
+
+==== Security changes
 include::{es-repo-dir}/migration/migrate_8_0/security.asciidoc[tag=notable-breaking-changes]
+
+==== Settings changes
 include::{es-repo-dir}/migration/migrate_8_0/settings.asciidoc[tag=notable-breaking-changes]
+
+==== Snapshot and restore changes
 include::{es-repo-dir}/migration/migrate_8_0/snapshots.asciidoc[tag=notable-breaking-changes]
+
+==== Thread pool changes
 include::{es-repo-dir}/migration/migrate_8_0/threadpool.asciidoc[tag=notable-breaking-changes]
+
+==== Transport changes
 include::{es-repo-dir}/migration/migrate_8_0/transport.asciidoc[tag=notable-breaking-changes]
 
 [[elasticsearch-hadoop-breaking-changes]]


### PR DESCRIPTION
This PR adds missing sections to the Installation and Upgrade Guide from the Elasticsearch breaking changes (https://www.elastic.co/guide/en/elasticsearch/reference/master/migrating-8.0.html)