### PR TITLE
[DOCS] Remove coming tags from breaking changes + release highlights

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -28,8 +28,6 @@ Upgrade Assistant provides information about which {dfeeds} need to be updated.
 <titleabbrev>APM</titleabbrev>
 ++++
 
-coming::[7.14.0]
-
 This list summarizes the most important breaking changes in APM.
 For the complete list, go to {apm-server-ref}/breaking-changes.html[APM Server breaking changes].
 
@@ -40,8 +38,6 @@ include::{apm-repo-dir}/apm-breaking-changes.asciidoc[tag=714-bc]
 ++++
 <titleabbrev>Beats</titleabbrev>
 ++++
-
-coming::[7.14.0]
 
 This list summarizes the most important breaking changes in Beats. For the
 complete list, go to {beats-ref}/breaking-changes.html[Beats breaking changes].
@@ -56,8 +52,6 @@ complete list, go to {beats-ref}/breaking-changes.html[Beats breaking changes].
 <titleabbrev>{es}</titleabbrev>
 ++++
 
-coming::[7.14.0]
-
 This list summarizes the most important breaking changes in {es} {version}. For
 the complete list, go to {ref}/breaking-changes.html[{es} breaking changes].
 
@@ -69,8 +63,6 @@ the complete list, go to {ref}/breaking-changes.html[{es} breaking changes].
 ++++
 <titleabbrev>{es} Hadoop</titleabbrev>
 ++++
-
-coming::[7.14.0]
 
 This list summarizes the most important breaking changes in {es} Hadoop {version}.
 For the complete list, go to
@@ -85,8 +77,6 @@ include::{hadoop-repo-dir}/appendix/breaking.adoc[tag=notable-v7-breaking-change
 <titleabbrev>{kib}</titleabbrev>
 ++++
 
-coming::[7.14.0]
-
 This list summarizes the most important breaking changes in {kib} {version}. For
 the complete list, go to {kibana-ref}/breaking-changes.html[{kib} breaking changes].
 
@@ -98,8 +88,6 @@ the complete list, go to {kibana-ref}/breaking-changes.html[{kib} breaking chang
 ++++
 <titleabbrev>{ls}</titleabbrev>
 ++++
-
-coming::[7.14.0]
 
 This list summarizes the most important breaking changes in {ls} {version}. For
 the complete list, go to

--- a/docs/en/install-upgrade/highlights.asciidoc
+++ b/docs/en/install-upgrade/highlights.asciidoc
@@ -14,8 +14,6 @@ highlights notable new features and enhancements in {minor-version}.
 <titleabbrev>Observability</titleabbrev>
 ++++
 
-coming::[7.14.0]
-
 This list summarizes the most important enhancements in Observability {minor-version}.
 
 include::{obs-repo-dir}/whats-new.asciidoc[tag=whats-new]
@@ -26,8 +24,6 @@ include::{obs-repo-dir}/whats-new.asciidoc[tag=whats-new]
 ++++
 <titleabbrev>{es}</titleabbrev>
 ++++
-
-coming::[7.14.0]
 
 This list summarizes the most important enhancements in {es} {minor-version}.
 For the complete list, go to {ref}/release-highlights.html[{es} release highlights].
@@ -46,8 +42,6 @@ include::{es-repo-dir}/release-notes/highlights.asciidoc[tag=notable-highlights]
 ++++
 <titleabbrev>{kib}</titleabbrev>
 ++++
-
-coming::[7.14.0]
 
 This list summarizes the most important enhancements in {kib} {minor-version}].
 


### PR DESCRIPTION
This PR removes coming tags from breaking changes and release highlights in the 7.x Installation and Upgrade Guide. I plan to do the same for our 8.x branch.

As @chriscressman recently pointed out, our 7.x and 8.x docs already have a "preliminary docs" advisory until they're released:

<img width="744" alt="Screen Shot 2021-08-03 at 11 01 37 AM" src="https://user-images.githubusercontent.com/40268737/128038574-32058d6f-4e63-484f-ab79-1d7ffc820dad.PNG">

These coming tags duplicate that message. Removing them creates an unneeded chore at release.