### PR TITLE
[DOCS] Adds a note about a workaround if DFA model is too large to fit into JVM

### DIFF
--- a/docs/en/stack/ml/df-analytics/ml-dfa-classification.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-classification.asciidoc
@@ -63,6 +63,8 @@ class), the model might be unaware of them. In general, complex decision
 boundaries between classes are harder to learn and require more data points per 
 class in the training data.
 
+include::ml-dfa-shared.asciidoc[tag=dfa-model-jvm]
+
 ////
 It means that you need to supply a labeled training data set that has a {depvar} 
 and some fields that are related to it. The {classification} algorithm learns 

--- a/docs/en/stack/ml/df-analytics/ml-dfa-limitations.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-limitations.asciidoc
@@ -28,12 +28,12 @@ categories:
 [[dfa-scheduling-priority]]
 === CPU scheduling improvements apply to Linux and MacOS only
 
-When there are many {ml} jobs running at the same time and there are insufficient
-CPU resources, the JVM performance must be prioritized so search and indexing
-latency remain acceptable. To that end, when CPU is constrained on Linux and
-MacOS environments, the CPU scheduling priority of native analysis processes is
-reduced to favor the {es} JVM. This improvement does not apply to Windows
-environments.
+When there are many {ml} jobs running at the same time and there are 
+insufficient CPU resources, the JVM performance must be prioritized so search 
+and indexing latency remain acceptable. To that end, when CPU is constrained on 
+Linux and MacOS environments, the CPU scheduling priority of native analysis 
+processes is reduced to favor the {es} JVM. This improvement does not apply to 
+Windows environments.
 
 
 [discrete]
@@ -68,6 +68,11 @@ You cannot update {dfanalytics} configurations. Instead, delete the
 {dfanalytics-cap} can only perform analyses that fit into the memory available 
 for {ml}. Overspill to disk is not currently possible. For general {ml} 
 settings, see {ref}/ml-settings.html[{ml-cap} settings in {es}].
+
+When you create a {dfanalytics-job} and the inference step of the process 
+fails due to the model is too large to fit into JVM, follow the steps in  
+https://github.com/elastic/elasticsearch/issues/76093[this GitHub issue] for a 
+workaround.
 
 [discrete]
 [[dfa-training-docs]]

--- a/docs/en/stack/ml/df-analytics/ml-dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-regression.asciidoc
@@ -85,8 +85,7 @@ usually better than the performance of each individual base learner because the
 individual learners will make different errors. These average out when their 
 predictions are combined.
 
-{regression-cap} works as a batch analysis. If new data comes into your index, 
-you must restart the {dfanalytics-job}.
+include::ml-dfa-shared.asciidoc[tag=dfa-model-jvm]
 
 
 [discrete]

--- a/docs/en/stack/ml/df-analytics/ml-dfa-shared.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-shared.asciidoc
@@ -68,3 +68,9 @@ Reassign the alias you used to a new trained model ID by using the
 The new trained model needs to use the same type of {dfanalytics} as the old 
 one.
 end::dfa-inference-aggregation[]
+
+tag::dfa-model-jvm[]
+NOTE: When you create a {dfanalytics-job}, the inference step of the process 
+might fail if the model is too large to fit into JVM. For a work around, refer 
+to https://github.com/elastic/elasticsearch/issues/76093[this GitHub issue].
+end::dfa-model-jvm[]

--- a/docs/en/stack/ml/df-analytics/ml-dfa-shared.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-shared.asciidoc
@@ -71,6 +71,6 @@ end::dfa-inference-aggregation[]
 
 tag::dfa-model-jvm[]
 NOTE: When you create a {dfanalytics-job}, the inference step of the process 
-might fail if the model is too large to fit into JVM. For a work around, refer 
+might fail if the model is too large to fit into JVM. For a workaround, refer 
 to https://github.com/elastic/elasticsearch/issues/76093[this GitHub issue].
 end::dfa-model-jvm[]


### PR DESCRIPTION
## Overview

This PR adds a note to the classification/regression sections about a workaround if the DFA model is too large to fit into JVM. Also expands the DFA memory limitation item with this information.

Related issue: https://github.com/elastic/elasticsearch/issues/76093

### Preview

* [Classification](https://stack-docs_1778.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-dfa-classification.html#dfa-classification-supervised)
* [Regression](https://stack-docs_1778.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-dfa-regression.html#dfa-regression-supervised)
* [Limitation](https://stack-docs_1778.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-dfa-limitations.html#dfa-dataframe-size-limitations)