### PR TITLE
[7.x][DOCS] Adds a note about a workaround if DFA model is too large to fit into JVM

### DIFF
--- a/docs/en/stack/ml/df-analytics/dfa-classification.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-classification.asciidoc
@@ -50,6 +50,10 @@ class), the model might be unaware of them. In general, complex decision
 boundaries between classes are harder to learn and require more data points per 
 class in the training data.
 
+NOTE: When you create a {dfanalytics-job}, the inference step of the process 
+might fail if the model is too large to fit into JVM. For a workaround, refer 
+to https://github.com/elastic/elasticsearch/issues/76093[this GitHub issue].
+
 ////
 It means that you need to supply a labeled training data set that has a {depvar} 
 and some fields that are related to it. The {classification} algorithm learns 

--- a/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
@@ -71,6 +71,10 @@ predictions are combined.
 {regression-cap} works as a batch analysis. If new data comes into your index, 
 you must restart the {dfanalytics-job}.
 
+NOTE: When you create a {dfanalytics-job}, the inference step of the process 
+might fail if the model is too large to fit into JVM. For a workaround, refer 
+to https://github.com/elastic/elasticsearch/issues/76093[this GitHub issue].
+
 
 [[dfa-regression-algorithm]]
 === {regression-cap} algorithms

--- a/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
@@ -68,8 +68,6 @@ usually better than the performance of each individual base learner because the
 individual learners will make different errors. These average out when their 
 predictions are combined.
 
-{regression-cap} works as a batch analysis. If new data comes into your index, 
-you must restart the {dfanalytics-job}.
 
 NOTE: When you create a {dfanalytics-job}, the inference step of the process 
 might fail if the model is too large to fit into JVM. For a workaround, refer 

--- a/docs/en/stack/ml/df-analytics/ml-dfa-limitations.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-limitations.asciidoc
@@ -69,6 +69,11 @@ You cannot update {dfanalytics} configurations. Instead, delete the
 for {ml}. Overspill to disk is not currently possible. For general {ml} 
 settings, see {ref}/ml-settings.html[{ml-cap} settings in {es}].
 
+When you create a {dfanalytics-job} and the inference step of the process 
+fails due to the model is too large to fit into JVM, follow the steps in  
+https://github.com/elastic/elasticsearch/issues/76093[this GitHub issue] for a 
+workaround.
+
 [discrete]
 [[dfa-training-docs]]
 === {dfanalytics-jobs-cap} cannot use more than 2^32^ documents for training


### PR DESCRIPTION
This PR backports the changes of the following commit to the 7.x branch:
[DOCS] Adds a note about a workaround if DFA model is too large to fit into JVM #1778
