### PR TITLE
[7.14][DOCS] Adds a note about a workaround if DFA model is too large to fit into JVM

### DIFF
--- a/docs/en/stack/ml/df-analytics/dfa-classification.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-classification.asciidoc
@@ -50,6 +50,10 @@ class), the model might be unaware of them. In general, complex decision
 boundaries between classes are harder to learn and require more data points per 
 class in the training data.
 
+NOTE: When you create a {dfanalytics-job}, the inference step of the process 
+might fail if the model is too large to fit into JVM. For a workaround, refer 
+to https://github.com/elastic/elasticsearch/issues/76093[this GitHub issue].
+
 ////
 It means that you need to supply a labeled training data set that has a {depvar} 
 and some fields that are related to it. The {classification} algorithm learns 

--- a/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/dfa-regression.asciidoc
@@ -68,8 +68,9 @@ usually better than the performance of each individual base learner because the
 individual learners will make different errors. These average out when their 
 predictions are combined.
 
-{regression-cap} works as a batch analysis. If new data comes into your index, 
-you must restart the {dfanalytics-job}.
+NOTE: When you create a {dfanalytics-job}, the inference step of the process 
+might fail if the model is too large to fit into JVM. For a workaround, refer 
+to https://github.com/elastic/elasticsearch/issues/76093[this GitHub issue].
 
 
 [[dfa-regression-algorithm]]

--- a/docs/en/stack/ml/df-analytics/ml-dfa-limitations.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-limitations.asciidoc
@@ -28,12 +28,12 @@ categories:
 [[dfa-scheduling-priority]]
 === CPU scheduling improvements apply to Linux and MacOS only
 
-When there are many {ml} jobs running at the same time and there are insufficient
-CPU resources, the JVM performance must be prioritized so search and indexing
-latency remain acceptable. To that end, when CPU is constrained on Linux and
-MacOS environments, the CPU scheduling priority of native analysis processes is
-reduced to favor the {es} JVM. This improvement does not apply to Windows
-environments.
+When there are many {ml} jobs running at the same time and there are 
+insufficient CPU resources, the JVM performance must be prioritized so search 
+and indexing latency remain acceptable. To that end, when CPU is constrained on 
+Linux and MacOS environments, the CPU scheduling priority of native analysis 
+processes is reduced to favor the {es} JVM. This improvement does not apply to 
+Windows environments.
 
 
 [discrete]
@@ -68,6 +68,11 @@ You cannot update {dfanalytics} configurations. Instead, delete the
 {dfanalytics-cap} can only perform analyses that fit into the memory available 
 for {ml}. Overspill to disk is not currently possible. For general {ml} 
 settings, see {ref}/ml-settings.html[{ml-cap} settings in {es}].
+
+When you create a {dfanalytics-job} and the inference step of the process 
+fails due to the model is too large to fit into JVM, follow the steps in  
+https://github.com/elastic/elasticsearch/issues/76093[this GitHub issue] for a 
+workaround.
 
 [discrete]
 [[dfa-training-docs]]


### PR DESCRIPTION
This PR backports the changes of the following commit to the 7.14 branch:
[DOCS] Adds a note about a workaround if DFA model is too large to fit into JVM #1778
