### PR TITLE
Provide more context for breaking changes links

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -14,9 +14,7 @@ use and make the necessary changes so your code is compatible with {version}.
 [IMPORTANT]
 ===============================
 * Make sure you check the breaking changes for each point release up to the desired new version.
-* If you are using {ml} {dfeeds} that contain discontinued search or query
-domain specific language (DSL), the upgrade will fail. In 5.6.5 and later, the
-Upgrade Assistant provides information about which {dfeeds} need to be updated.
+* If you are using {ml} {dfeeds} that contain discontinued search or query domain specific language (DSL), the upgrade will fail. The Upgrade Assistant provides information about which {dfeeds} need to be updated.
 
 ===============================
 
@@ -27,7 +25,7 @@ Upgrade Assistant provides information about which {dfeeds} need to be updated.
 ++++
 
 This list summarizes the most important breaking changes in APM. 
-For the complete list, go to {apm-get-started-ref}/apm-breaking-changes.html[APM breaking changes].
+For the complete list, go to {apm-get-started-ref}/apm-breaking-changes.html[APM breaking changes] in the {apm-get-started-ref}[APM Overview].
 
 include::{apm-repo-dir}/apm-breaking-changes.asciidoc[tag=notable-v8-breaking-changes]
 
@@ -38,7 +36,7 @@ include::{apm-repo-dir}/apm-breaking-changes.asciidoc[tag=notable-v8-breaking-ch
 ++++
 
 This list summarizes the most important breaking changes in Beats. 
-For the complete list, go to {beats-ref}/breaking-changes.html[Beats breaking changes].
+For the complete list, go to {beats-ref}/breaking-changes.html[Beats breaking changes] in the {beats-ref}[Beats Platform Reference].
 
 include::{beats-repo-dir}/release-notes/breaking/breaking-8.0.asciidoc[tag=notable-breaking-changes]
 
@@ -51,7 +49,7 @@ include::{beats-repo-dir}/release-notes/breaking/breaking-8.0.asciidoc[tag=notab
 ++++
 
 This list summarizes the most important breaking changes in {es} {version}. For
-the complete list, go to {ref}/breaking-changes.html[{es} breaking changes].
+the complete list, go to {ref}/breaking-changes.html[{es} breaking changes] in the {ref}[Elasticsearch Reference].
 
 include::{es-repo-dir}/migration/migrate_8_0.asciidoc[tag=notable-breaking-changes]
 
@@ -151,7 +149,7 @@ include::{hadoop-repo-dir}/appendix/breaking.adoc[tag=notable-v8-breaking-change
 ++++
 
 This list summarizes the most important breaking changes in {kib} {version}. For
-the complete list, go to {kibana-ref}/breaking-changes.html[{kib} breaking changes].
+the complete list, go to {kibana-ref}/breaking-changes.html[{kib} breaking changes] in the {kibana-ref}[{kib} Guide]. 
 
 include::{kib-repo-dir}/migration/migrate_8_0.asciidoc[tag=notable-breaking-changes]
 
@@ -164,7 +162,7 @@ include::{kib-repo-dir}/migration/migrate_8_0.asciidoc[tag=notable-breaking-chan
 
 This list summarizes the most important breaking changes in {ls} {version}. For
 the complete list, go to
-{logstash-ref}/breaking-changes.html[Logstash breaking changes].
+{logstash-ref}/breaking-changes.html[Logstash breaking changes] in the {logstash-ref}[{ls} Reference].
 
 include::{ls-repo-dir}/static/breaking-changes.asciidoc[tag=notable-breaking-changes]
 


### PR DESCRIPTION
Our breaking changes content in the [Installation and Upgrade Guide](https://www.elastic.co/guide/en/elastic-stack/master/index.html) could use a bit more context around the links.  

<img width="769" alt="Screen Shot 2021-08-13 at 3 25 35 PM" src="https://user-images.githubusercontent.com/35154725/129409166-a833d77c-86b4-4b10-8f3d-20e2850205e6.png">

At first glance, this link appears to be self-referential, when in fact, it's sending the user to the Logstash Reference. I made a proposal for Logstash (and for other books as well) to add a clue that the link will send you to another book.  

#### You get to decide for your deliverables
Like your links they way they are now? Prefer a different approach? Let me know, and we can make the change in this PR, or reverse the change for your docs. 

#### Another thought 
The breaking changes for Logstash are identical between the Installation and Upgrade Guide and the Logstash Reference. Is this statement true for other products?  

I'm considering changing the text to something like "The list of breaking changes is also available in the [Logstash Reference](https://www.elastic.co/guide/en/logstash/current/index.html)" to avoid sending users away for more info when there isn't any additional info.  