### PR TITLE
[DOCS] Update datafeed details in ML docs

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/geographic-anomalies.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/geographic-anomalies.asciidoc
@@ -92,12 +92,10 @@ PUT _ml/anomaly_detectors/ecommerce-geo <1>
   },
   "data_description" : {
     "time_field": "order_date"
-  }
-}
-
-PUT _ml/datafeeds/datafeed-ecommerce-geo <2>
-{
-    "job_id": "ecommerce-geo",
+  },
+  "datafeed_config":{ <2>
+    "datafeed_id": "datafeed-ecommerce-geo",
+    "indices": ["kibana_sample_data_ecommerce"],
     "query": {
       "bool": {
         "must": [
@@ -106,10 +104,8 @@ PUT _ml/datafeeds/datafeed-ecommerce-geo <2>
           }
         ]
       }
-    },
-    "indices": [
-      "kibana_sample_data_ecommerce"
-    ]
+    }
+  }
 }
 
 POST _ml/anomaly_detectors/ecommerce-geo/_open <3>
@@ -163,12 +159,10 @@ PUT _ml/anomaly_detectors/weblogs-geo <1>
   "data_description" : {
     "time_field": "timestamp",
      "time_format": "epoch_ms"
-  }
-}
-
-PUT _ml/datafeeds/datafeed-weblogs-geo <2>
-{
-    "job_id": "weblogs-geo",
+  },
+  "datafeed_config":{ <2>
+    "datafeed_id": "datafeed-weblogs-geo",
+    "indices": ["kibana_sample_data_logs"],
     "query": {
       "bool": {
         "must": [
@@ -177,10 +171,8 @@ PUT _ml/datafeeds/datafeed-weblogs-geo <2>
           }
         ]
       }
-    },
-    "indices": [
-      "kibana_sample_data_logs"
-    ]
+    }
+  }
 }
 
 POST _ml/anomaly_detectors/weblogs-geo/_open <3>

--- a/docs/en/stack/ml/anomaly-detection/mapping-anomalies.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/mapping-anomalies.asciidoc
@@ -70,12 +70,10 @@ PUT _ml/anomaly_detectors/weblogs-vectors <1>
   },
   "data_description" : {
     "time_field": "timestamp"
-  }
-}
-
-PUT _ml/datafeeds/datafeed-weblogs-vectors <2>
-{
-    "job_id": "weblogs-vectors",
+  },
+  "datafeed_config": { <2>
+    "datafeed_id": "datafeed-weblogs-vectors",
+    "indices": ["kibana_sample_data_logs"],
     "query": {
       "bool": {
         "must": [
@@ -84,10 +82,8 @@ PUT _ml/datafeeds/datafeed-weblogs-vectors <2>
           }
         ]
       }
-    },
-    "indices": [
-      "kibana_sample_data_logs"
-    ]
+    }
+  }
 }
 
 POST _ml/anomaly_detectors/weblogs-vectors/_open <3>

--- a/docs/en/stack/ml/anomaly-detection/stopping-ml.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/stopping-ml.asciidoc
@@ -50,13 +50,9 @@ POST _ml/datafeeds/_all/_stop
 == Closing {anomaly-jobs}
 
 When you close an {anomaly-job}, it cannot receive data or perform analysis
-operations. If a job is associated with a {dfeed}, you must stop the {dfeed}
-before you can close the job. If the {dfeed} has an end date, the job closes
-automatically on that end date.
-
-You can close a job by using the
-{ref}/ml-close-job.html[close {anomaly-job} API]. For 
-example, the following request closes the `job1` job:
+operations. You can close a job by using the
+{ref}/ml-close-job.html[close {anomaly-job} API]. For example, the following
+request closes the `job1` job:
 
 [source,console]
 --------------------------------------------------
@@ -64,14 +60,20 @@ POST _ml/anomaly_detectors/job1/_close
 --------------------------------------------------
 // TEST[skip:setup:server_metrics_openjob]
 
-NOTE: You must have `manage_ml`, or `manage` cluster privileges to stop {dfeeds}.
-For more information, see {ref}/security-privileges.html[Security privileges].
+NOTE: You must have `manage_ml`, or `manage` cluster privileges to stop
+{anomaly-jobs}. For more information, see
+{ref}/security-privileges.html[Security privileges].
+
+If you submit a request to close an {anomaly-job} and its {dfeed} is running,
+the request first tries to stop the {dfeed}. This behavior is equivalent to
+calling the {ref}/ml-stop-datafeed.html[stop {dfeeds} API] with the same
+`timeout` and `force` parameters as the close job request.
 
 {anomaly-jobs-cap} can be opened and closed multiple times throughout their
 lifecycle.
 
 [discrete]
-[[closing-all-ml-datafeeds]]
+[[closing-all-ml-jobs]]
 == Closing all {anomaly-jobs}
 
 If you are upgrading your cluster, you can use the following request to close


### PR DESCRIPTION
Related to #74265 and #74257

This PR updates machine learning documentation to make use of the datafeed_config option in the create anomaly detection jobs API and clarifies some details related to stopping datafeeds when jobs close.

### Preview

* https://stack-docs_1793.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-ad-finding-anomalies.html#closing-ml-jobs
* https://stack-docs_1793.docs-preview.app.elstc.co/guide/en/machine-learning/master/mapping-anomalies.html
* https://stack-docs_1793.docs-preview.app.elstc.co/guide/en/machine-learning/master/geographic-anomalies.html