### PR TITLE
[DOCS] Add deleted pages for reorganized content

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/ml-ad-finding-anomalies.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-ad-finding-anomalies.asciidoc
@@ -138,7 +138,7 @@ administrative tasks by opening or closing multiple jobs at once.
 //TBD Mention impact of model plot config?
 
 [discrete]
-[[ml-datafeeds]]
+[[ml-ad-datafeeds]]
 === {dfeeds-cap}
 
 include::ml-datafeeds.asciidoc[]

--- a/docs/en/stack/ml/anomaly-detection/ml-limitations.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-limitations.asciidoc
@@ -196,7 +196,7 @@ user who created or updated the {dfeed} **at that time**. This means that if the
 roles the user has are changed after they create or update a {dfeed} then the 
 {dfeed} continues to run without change. However, if instead the permissions 
 associated with the roles that are stored with the {dfeed} are changed then this 
-affects the {dfeed}. For more information, see <<ml-datafeeds>>.
+affects the {dfeed}. For more information, see <<ml-ad-datafeeds>>.
 
 
 [discrete]
@@ -272,7 +272,7 @@ single dot. If there are only two data points, they are joined by a line.
 If you create jobs in {kib}, you must use {dfeeds}. If the data that you want to
 analyze is not stored in {es}, you cannot use {dfeeds} and therefore you cannot
 create your jobs in {kib}. You can, however, use the {ml} APIs to create jobs. For more information, see
-<<ml-datafeeds>> and <<ml-api-quickref>>.
+<<ml-ad-datafeeds>> and <<ml-api-quickref>>.
 
 
 [discrete]

--- a/docs/en/stack/ml/get-started/ml-gs-jobs.asciidoc
+++ b/docs/en/stack/ml/get-started/ml-gs-jobs.asciidoc
@@ -38,7 +38,7 @@ value that is seen within a bucket. Others perform some aggregation over the
 length of the bucket. For example, `mean` calculates the mean of all the data
 points seen within the bucket.
 
-For more information, see <<ml-datafeeds>>, <<ml-buckets>>, and <<ml-functions>>.
+For more information, see <<ml-ad-datafeeds>>, <<ml-buckets>>, and <<ml-functions>>.
 ****
 
 If you want to see all of the configuration details for your jobs and {dfeeds},

--- a/docs/en/stack/ml/redirects.asciidoc
+++ b/docs/en/stack/ml/redirects.asciidoc
@@ -114,7 +114,7 @@ This content has moved. See <<ml-ad-model-snapshots>>.
 
 This content has moved. See <<ml-ad-finding-anomalies>>.
 
-[role="exclude",id="ml-ad-overview"]
+[role="exclude",id="xpack-ml"]
 === Anomaly detection
 
 This content has moved. See <<ml-ad-overview>>.

--- a/docs/en/stack/ml/redirects.asciidoc
+++ b/docs/en/stack/ml/redirects.asciidoc
@@ -6,7 +6,12 @@ The following pages have moved or been deleted.
 [role="exclude",id="ml-dfeeds"]
 === Datafeeds
 
-This page has moved. See <<ml-datafeeds>>.
+This page has moved. See <<ml-ad-datafeeds>>.
+
+[role="exclude",id="ml-datafeeds"]
+=== Datafeeds
+
+This page has moved. See <<ml-ad-datafeeds>>.
 
 [role="exclude",id="ml-configuring-pop"]
 === Performing population analysis
@@ -108,3 +113,14 @@ This content has moved. See <<ml-ad-model-snapshots>>.
 === Concepts
 
 This content has moved. See <<ml-ad-finding-anomalies>>.
+
+[role="exclude",id="ml-ad-overview"]
+=== Anomaly detection
+
+This content has moved. See <<ml-ad-overview>>.
+
+[role="exclude",id="ml-overview"]
+=== Anomaly detection overview
+
+This content has moved. See <<ml-ad-overview>>.
+


### PR DESCRIPTION
This PR adds deleted pages for anomaly detection content that has moved in the main branch, so that switching versions from 7.x pages doesn't generate an error.