### PR TITLE
[DOCS] Refreshes list of data frame analytics APIs

### DIFF
--- a/docs/en/stack/ml/df-analytics/ml-dfanalytics-apis.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfanalytics-apis.asciidoc
@@ -26,19 +26,31 @@ All the trained models endpoints have the following base:
 ----
 // NOTCONSOLE
 
-
-* {ref}/preview-dfanalytics.html[Preview {dfanalytics}]
+// CREATE
 * {ref}/put-dfanalytics.html[Create {dfanalytics-jobs}]
-* {ref}/update-dfanalytics.html[Update {dfanalytics-jobs}]
+* {ref}/put-trained-models-aliases.html[Create trained model aliases]
+* {ref}/put-trained-models.html[Create trained models]
+// DELETE
 * {ref}/delete-dfanalytics.html[Delete {dfanalytics-jobs}]
+* {ref}/delete-trained-models.html[Delete trained models]
+// EVALUATE
+* {ref}/evaluate-dfanalytics.html[Evaluate {dfanalytics}]
+// EXPLAIN
+* {ref}/explain-dfanalytics.html[Explain {dfanalytics}]
+// GET
 * {ref}/get-dfanalytics.html[Get {dfanalytics-jobs} info]
 * {ref}/get-dfanalytics-stats.html[Get {dfanalytics-jobs} statistics]
-* {ref}/start-dfanalytics.html[Start {dfanalytics-jobs}]
-* {ref}/stop-dfanalytics.html[Stop {dfanalytics-jobs}]
-* {ref}/evaluate-dfanalytics.html[Evaluate {dfanalytics}]
-* {ref}/explain-dfanalytics.html[Explain {dfanalytics}]
-* {ref}/put-trained-models.html[Create trained models]
-* {ref}/put-trained-models-aliases.html[Create trained model aliases]
 * {ref}/get-trained-models.html[Get trained models]
 * {ref}/get-trained-models-stats.html[Get trained models statistics]
-* {ref}/delete-trained-models.html[Delete trained models]
+// INFER
+* {ref}//infer-trained-model-deployment.html[Infer trained model deployment]
+// PREVIEW
+* {ref}/preview-dfanalytics.html[Preview {dfanalytics}]
+// START
+* {ref}/start-dfanalytics.html[Start {dfanalytics-jobs}]
+// STOP
+* {ref}/stop-dfanalytics.html[Stop {dfanalytics-jobs}]
+* {ref}/stop-trained-model-deployment.html[Stop trained model deployment]
+// UPDATE
+* {ref}/update-dfanalytics.html[Update {dfanalytics-jobs}]
+


### PR DESCRIPTION
This PR refreshes the list of data frame analytics APIs in https://www.elastic.co/guide/en/machine-learning/master/ml-dfanalytics-apis.html to match https://www.elastic.co/guide/en/elasticsearch/reference/master/ml-df-analytics-apis.html

It also sorts the list alphabetically.