### PR TITLE
[DOCS] Add link to new trained model API

### DIFF
--- a/docs/en/stack/ml/df-analytics/ml-dfanalytics-apis.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfanalytics-apis.asciidoc
@@ -29,6 +29,7 @@ All the trained models endpoints have the following base:
 // CREATE
 * {ref}/put-dfanalytics.html[Create {dfanalytics-jobs}]
 * {ref}/put-trained-models-aliases.html[Create trained model aliases]
+* {ref}/put-trained-model-definition-part.html[Create trained model definition part]
 * {ref}/put-trained-models.html[Create trained models]
 // DELETE
 * {ref}/delete-dfanalytics.html[Delete {dfanalytics-jobs}]


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch/pull/76987

This PR adds a link to https://www.elastic.co/guide/en/elasticsearch/reference/master/put-trained-model-definition-part.html from the Machine Learning Guide