### PR TITLE
[DOCS] Makes limitation item about rolled up indices clearer

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/ml-limitations.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-limitations.asciidoc
@@ -329,11 +329,11 @@ spaces.
 
 [discrete]
 [[ml-rollup-limitations]]
-=== Rollup indices and {data-sources} are not supported in {kib}
+=== Rollup indices are not supported in {kib}
 
-Rollup indices and {data-sources} cannot be used in {anomaly-jobs} or 
-{dfeeds} in {kib}. If you select an index, saved search, or {data-source} that
-uses {ref}/xpack-rollup.html[{rollup-features}], the {anomaly-job} creation
-wizards fail. If you use APIs to create {anomaly-jobs} that use
-{rollup-features}, the job results might not display properly in the
+Rollup indices and {data-sources} with rolled up indices cannot be used in 
+{anomaly-jobs} or {dfeeds} in {kib}. If you try to analyze data that exists in 
+an index that uses {ref}/xpack-rollup.html[{rollup-features}], the 
+{anomaly-job} creation wizards fail. If you use APIs to create {anomaly-jobs} 
+that use {rollup-features}, the job results might not display properly in the
 *Single Metric Viewer* or *Anomaly Explorer* in {kib}.

--- a/docs/en/stack/ml/anomaly-detection/ml-limitations.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-limitations.asciidoc
@@ -333,7 +333,7 @@ spaces.
 
 Rollup indices and {data-sources} with rolled up indices cannot be used in 
 {anomaly-jobs} or {dfeeds} in {kib}. If you try to analyze data that exists in 
-an index that uses {ref}/xpack-rollup.html[{rollup-features}], the 
-{anomaly-job} creation wizards fail. If you use APIs to create {anomaly-jobs} 
-that use {rollup-features}, the job results might not display properly in the
-*Single Metric Viewer* or *Anomaly Explorer* in {kib}.
+an index that uses the experimental {ref}/xpack-rollup.html[{rollup-features}], 
+the {anomaly-job} creation wizards fail. If you use APIs to create 
+{anomaly-jobs} that use {rollup-features}, the job results might not display 
+properly in the *Single Metric Viewer* or *Anomaly Explorer* in {kib}.


### PR DESCRIPTION
## Overview

This PR makes it clearer that data that exists in rolled-up indices cannot be analyzed by anomaly detection jobs.

Related to https://github.com/elastic/ml-team/issues/495#issuecomment-906322444

### Preview

[Rollup indices are not supported in Kibana](https://stack-docs_1821.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-limitations.html#ml-rollup-limitations)
