### PR TITLE
[7.15] [DOCS] Makes limitation item about rolled up indices clearer (#1821)

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/ml-limitations.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-limitations.asciidoc
@@ -329,11 +329,11 @@ spaces.
 
 [discrete]
 [[ml-rollup-limitations]]
-=== Rollup indices and index patterns are not supported in {kib}
+=== Rollup indices are not supported in {kib}
 
-Rollup indices and index patterns cannot be used in {anomaly-jobs} or 
-{dfeeds} in {kib}. If you select an index, saved search, or index pattern that
-uses {ref}/xpack-rollup.html[{rollup-features}], the {anomaly-job} creation
-wizards fail. If you use APIs to create {anomaly-jobs} that use
-{rollup-features}, the job results might not display properly in the
-*Single Metric Viewer* or *Anomaly Explorer* in {kib}.
+Rollup indices and {data-sources} with rolled up indices cannot be used in 
+{anomaly-jobs} or {dfeeds} in {kib}. If you try to analyze data that exists in 
+an index that uses the experimental {ref}/xpack-rollup.html[{rollup-features}], 
+the {anomaly-job} creation wizards fail. If you use APIs to create 
+{anomaly-jobs} that use {rollup-features}, the job results might not display 
+properly in the *Single Metric Viewer* or *Anomaly Explorer* in {kib}.

--- a/docs/en/stack/ml/anomaly-detection/ml-limitations.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-limitations.asciidoc
@@ -331,7 +331,7 @@ spaces.
 [[ml-rollup-limitations]]
 === Rollup indices are not supported in {kib}
 
-Rollup indices and {data-sources} with rolled up indices cannot be used in 
+Rollup indices and index patterns with rolled up indices cannot be used in 
 {anomaly-jobs} or {dfeeds} in {kib}. If you try to analyze data that exists in 
 an index that uses the experimental {ref}/xpack-rollup.html[{rollup-features}], 
 the {anomaly-job} creation wizards fail. If you use APIs to create 


### PR DESCRIPTION
Backports the following commits to 7.15:
 - [DOCS] Makes limitation item about rolled up indices clearer (#1821)