### PR TITLE
[DOCS] Uncomments 7.15 release highlights

### DIFF
--- a/docs/en/install-upgrade/highlights.asciidoc
+++ b/docs/en/install-upgrade/highlights.asciidoc
@@ -28,13 +28,11 @@ include::{obs-repo-dir}/whats-new.asciidoc[tag=whats-new]
 This list summarizes the most important enhancements in {es} {minor-version}.
 For the complete list, go to {ref}/release-highlights.html[{es} release highlights].
 
-////
 :leveloffset: +1
 
 include::{es-repo-dir}/release-notes/highlights.asciidoc[tag=notable-highlights]
 
 :leveloffset: -1
-////
 
 [[kibana-higlights]]
 === {kib} highlights


### PR DESCRIPTION
This PR makes the 7.15 Elasticsearch release highlights visible in the Installation and Upgrade Guide.