### PR TITLE
[DOCS] Fixes tiny typo

### DIFF
--- a/docs/en/install-upgrade/highlights.asciidoc
+++ b/docs/en/install-upgrade/highlights.asciidoc
@@ -43,7 +43,7 @@ include::{es-repo-dir}/release-notes/highlights.asciidoc[tag=notable-highlights]
 <titleabbrev>{kib}</titleabbrev>
 ++++
 
-This list summarizes the most important enhancements in {kib} {minor-version}].
+This list summarizes the most important enhancements in {kib} {minor-version}.
 
 ////
 :leveloffset: +1

--- a/docs/en/install-upgrade/highlights.asciidoc
+++ b/docs/en/install-upgrade/highlights.asciidoc
@@ -36,7 +36,7 @@ include::{es-repo-dir}/release-notes/highlights.asciidoc[tag=notable-highlights]
 :leveloffset: -1
 ////
 
-[[kibana-higlights]]
+[[kibana-highlights]]
 === {kib} highlights
 [subs="attributes"]
 ++++

--- a/docs/en/install-upgrade/redirects.asciidoc
+++ b/docs/en/install-upgrade/redirects.asciidoc
@@ -14,3 +14,8 @@ See <<observability-highlights>> for a list of what's new in Elastic Observabili
 
 This page no longer exists.
 See <<observability-highlights>> for a list of what's new in Elastic Observability.
+
+[role="exclude",id="kibana-higlights"]
+=== Kibana highlights
+
+See <<kibana-highlights>>.


### PR DESCRIPTION
Removes extraneous `]`