### PR TITLE
[DOCS] Add beats breaking changes

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -43,7 +43,10 @@ include::{apm-repo-dir}/apm-breaking-changes.asciidoc[tag=715-bc]
 <titleabbrev>Beats</titleabbrev>
 ++++
 
-For the complete list, go to {beats-ref}/release-notes-7.15.0.html#_breaking_changes[Beats breaking changes].
+This list summarizes the most important breaking changes in Beats. For the
+complete list, go to {beats-ref}/breaking-changes.html[Beats breaking changes].
+
+include::{beats-repo-dir}/release-notes/breaking/breaking-7.15.asciidoc[tag=notable-breaking-changes]
 
 
 [[elasticsearch-breaking-changes]]


### PR DESCRIPTION
This PR adds the Beats 7.15.0 breaking changes to the Installation and Upgrade Guide.

It must be merged only after https://github.com/elastic/beats/pull/28079 is merged.