### PR TITLE
[DOCS] Add intro; move tutorial

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/anomaly-examples.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/anomaly-examples.asciidoc
@@ -11,6 +11,7 @@ gaining deep insights might require some additional planning and configuration.
 The scenarios in this section describe some best practices for generating useful
 {ml} results and insights from your data.
 
+* <<ml-getting-started>>
 * <<ml-configuring-url>>
 * <<ml-configuring-aggregation>>
 * <<ml-configuring-transform>>

--- a/docs/en/stack/ml/anomaly-detection/index.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/index.asciidoc
@@ -10,6 +10,8 @@ include::ml-api-quickref.asciidoc[leveloffset=+1]
 
 include::anomaly-examples.asciidoc[leveloffset=+1]
 
+include::../get-started/index.asciidoc[leveloffset=+2]
+
 include::{es-repo-dir}/ml/anomaly-detection/ml-configuring-alerts.asciidoc[leveloffset=+2]
 
 include::{es-repo-dir}/ml/anomaly-detection/ml-configuring-aggregations.asciidoc[leveloffset=+2]

--- a/docs/en/stack/ml/anomaly-detection/ml-ad-overview.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-ad-overview.asciidoc
@@ -6,6 +6,8 @@
 :description: An introduction to {ml} {anomaly-detect}, which analyzes time \
 series data to identify and predict anomalous patterns in your data.
 
+[partintro]
+--
 Use {anomaly-detect} to analyze time series data by creating accurate baselines 
 of normal behavior and identifying anomalous patterns in your data set. Data is 
 pulled from {es} for analysis and anomaly results are displayed in {kib} 
@@ -17,3 +19,4 @@ privileges that are required to use {anomaly-detect}.
 * <<ml-api-quickref>>
 * <<anomaly-examples>>
 * <<ml-ad-resources>>
+--

--- a/docs/en/stack/ml/get-started/ml-getting-started.asciidoc
+++ b/docs/en/stack/ml/get-started/ml-getting-started.asciidoc
@@ -1,58 +1,13 @@
 [[ml-getting-started]]
-= Getting started with {ml}
+= Getting started with {anomaly-detect}
+++++
+<titleabbrev>Tutorial: Getting started with {anomaly-detect}</titleabbrev>
+++++
 :keywords: {ml-init}, {stack}, {anomaly-detect}, tutorial
 :description: This tutorial shows you how to create {anomaly-jobs}, \
 interpret the results, and forecast future behavior in {kib}. 
 
-{ml-cap} features analyze your data and generate models for its patterns of
-behavior. The type of analysis that you choose depends on the questions or
-problems you want to address and the type of data you have available.
-
-[discrete]
-[[get-started-unsupervised]]
-== Unsupervised {ml}
-
-There are two types of analysis that can deduce the patterns and relationships
-within your data without training or intervention: _{anomaly-detect}_ and
-_{oldetection}_.
-
-<<ml-ad-overview,{anomaly-detect-cap}>> requires time series data. It constructs a
-probability model and can run continuously to identify unusual events as they
-occur. The model evolves over time; you can use its insights to forecast future
-behavior.
-
-<<ml-dfa-finding-outliers,{oldetection-cap}>> does not require time series data; 
-it identifies unusual points in a data set by analyzing how close each data 
-point is to others and the density of the cluster of points around it. It does 
-not run continuously; it generates a copy of your data set where each data point 
-is annotated with an {olscore}. The score indicates the extent to which a data 
-point is an outlier compared to other data points.
-
-[discrete]
-[[get-started-supervised]]
-== Supervised {ml}
-
-There are two types of analysis that require training data sets:
-_{classification}_ and _{regression}_.
-
-In both cases, the result is a copy of your data set where each data point is
-annotated with predictions and a trained model, which you can deploy to make
-predictions for new data. For more information, refer to
-<<ml-supervised-workflow>>.
-
-<<ml-dfa-classification,{classification-cap}>> learns relationships between your
-data points in order to predict discrete categorical values, such as whether a
-DNS request originates from a malicious or benign domain.
-
-<<ml-dfa-regression,{regression-cap}>> learns relationships between your data
-points in order to predict continuous numerical values, such as the response
-time for a web request.
-
-[discrete]
-[[get-started-prereqs]]
-== Try it out
-
-Ready to take {ml} for a test drive? Follow this tutorial to:
+Ready to take {anomaly-detect} for a test drive? Follow this tutorial to:
 
 * Try out the **{data-viz}**
 * Create {anomaly-jobs} for the {kib} sample data
@@ -79,6 +34,11 @@ The following video provides a quick overview of some of the tasks we'll perform
 Need more context? Check out the
 {ref}/elasticsearch-intro.html[{es} introduction] to learn the lingo and
 understand the basics of how {es} works.
+
+
+[discrete]
+[[get-started-prereqs]]
+== Try it out
 
 . Before you can play with the {ml-features}, you must install {es} and {kib}.
 {es} stores the data and the analysis results. {kib} provides a helpful user 

--- a/docs/en/stack/ml/get-started/ml-gs-forecasts.asciidoc
+++ b/docs/en/stack/ml/get-started/ml-gs-forecasts.asciidoc
@@ -1,5 +1,5 @@
 [role="xpack"]
-[[ml-gs-forecasts]]
+[[sample-data-forecasts]]
 = Create forecasts
 
 In addition to detecting anomalous behavior in your data, you can use the

--- a/docs/en/stack/ml/get-started/ml-gs-jobs.asciidoc
+++ b/docs/en/stack/ml/get-started/ml-gs-jobs.asciidoc
@@ -1,5 +1,5 @@
 [role="xpack"]
-[[ml-gs-jobs]]
+[[sample-data-jobs]]
 = Create sample {anomaly-jobs} in {kib}
 ++++
 <titleabbrev>Create {anomaly-jobs}</titleabbrev>

--- a/docs/en/stack/ml/get-started/ml-gs-next.asciidoc
+++ b/docs/en/stack/ml/get-started/ml-gs-next.asciidoc
@@ -1,5 +1,5 @@
 [role="xpack"]
-[[ml-gs-next]]
+[[sample-data-next]]
 = Next steps
 
 By completing this tutorial, you've learned how you can detect anomalous
@@ -26,7 +26,7 @@ your key performance indicators. After you examine these simple analysis results
 you will have a better idea of what the influencers might be. You can create
 multi-metric jobs and split the data or create more complex analysis functions
 as necessary. For examples of more complicated configuration options, see
-<<ml-configuration>>.
+<<anomaly-examples>>.
 
 If you want to find more sample jobs, see <<ootb-ml-jobs>>. In particular, there
 are sample jobs for <<ootb-ml-jobs-apache,Apache>> and

--- a/docs/en/stack/ml/get-started/ml-gs-results.asciidoc
+++ b/docs/en/stack/ml/get-started/ml-gs-results.asciidoc
@@ -1,5 +1,5 @@
 [role="xpack"]
-[[ml-gs-results]]
+[[sample-data-results]]
 = View {anomaly-detect} results
 
 After the {dfeeds} are started and the {anomaly-jobs} have processed some data,

--- a/docs/en/stack/ml/get-started/ml-gs-visualizer.asciidoc
+++ b/docs/en/stack/ml/get-started/ml-gs-visualizer.asciidoc
@@ -1,5 +1,5 @@
 [role="xpack"]
-[[ml-gs-visualizer]]
+[[sample-data-visualizer]]
 = Explore the data in {kib}
 
 To get the best results from {ml} analytics, you must understand your data. You

--- a/docs/en/stack/ml/index.asciidoc
+++ b/docs/en/stack/ml/index.asciidoc
@@ -10,9 +10,9 @@
 include::{docs-root}/shared/versions/stack/{source_branch}.asciidoc[]
 include::{docs-root}/shared/attributes.asciidoc[]
 
-include::setup.asciidoc[]
+include::machine-learning-intro.asciidoc[]
 
-include::get-started/index.asciidoc[]
+include::setup.asciidoc[]
 
 include::anomaly-detection/index.asciidoc[]
 

--- a/docs/en/stack/ml/machine-learning-intro.asciidoc
+++ b/docs/en/stack/ml/machine-learning-intro.asciidoc
@@ -21,7 +21,7 @@ probability model and can run continuously to identify unusual events as they
 occur. The model evolves over time; you can use its insights to forecast future
 behavior.
 
-<<ml-dfa-finding-outliers,{oldetection-cap}>> does not require time series data; 
+<<ml-dfa-finding-outliers,{oldetection-cap}>> is a type of <<ml-dfanalytics,{dfanalytics}>> that does not require time series data; 
 it identifies unusual points in a data set by analyzing how close each data 
 point is to others and the density of the cluster of points around it. It does 
 not run continuously; it generates a copy of your data set where each data point 

--- a/docs/en/stack/ml/machine-learning-intro.asciidoc
+++ b/docs/en/stack/ml/machine-learning-intro.asciidoc
@@ -16,23 +16,24 @@ There are two types of analysis that can deduce the patterns and relationships
 within your data without training or intervention: _{anomaly-detect}_ and
 _{oldetection}_.
 
-<<ml-ad-overview,{anomaly-detect-cap}>> requires time series data. It constructs a
-probability model and can run continuously to identify unusual events as they
+<<ml-ad-overview,{anomaly-detect-cap}>> requires time series data. It constructs
+a probability model and can run continuously to identify unusual events as they
 occur. The model evolves over time; you can use its insights to forecast future
 behavior.
 
-<<ml-dfa-finding-outliers,{oldetection-cap}>> is a type of <<ml-dfanalytics,{dfanalytics}>> that does not require time series data; 
-it identifies unusual points in a data set by analyzing how close each data 
-point is to others and the density of the cluster of points around it. It does 
-not run continuously; it generates a copy of your data set where each data point 
-is annotated with an {olscore}. The score indicates the extent to which a data 
+<<ml-dfa-finding-outliers,{oldetection-cap}>> is a type of
+<<ml-dfanalytics,{dfanalytics}>> that does not require time series data; it
+identifies unusual points in a data set by analyzing how close each data point
+is to others and the density of the cluster of points around it. It does not run
+continuously; it generates a copy of your data set where each data point is
+annotated with an {olscore}. The score indicates the extent to which a data 
 point is an outlier compared to other data points.
 
 [discrete]
 [[machine-learning-supervised]]
 == Supervised {ml}
 
-There are two types of analysis that require training data sets:
+There are two types of {dfanalytics} that require training data sets:
 _{classification}_ and _{regression}_.
 
 In both cases, the result is a copy of your data set where each data point is

--- a/docs/en/stack/ml/machine-learning-intro.asciidoc
+++ b/docs/en/stack/ml/machine-learning-intro.asciidoc
@@ -21,13 +21,13 @@ a probability model and can run continuously to identify unusual events as they
 occur. The model evolves over time; you can use its insights to forecast future
 behavior.
 
-<<ml-dfa-finding-outliers,{oldetection-cap}>> is a type of
-<<ml-dfanalytics,{dfanalytics}>> that does not require time series data; it
-identifies unusual points in a data set by analyzing how close each data point
-is to others and the density of the cluster of points around it. It does not run
-continuously; it generates a copy of your data set where each data point is
-annotated with an {olscore}. The score indicates the extent to which a data 
-point is an outlier compared to other data points.
+<<ml-dfa-finding-outliers,{oldetection-cap}>> does not require time series data.
+It is a type of {dfanalytics} that identifies unusual points in a data set by
+analyzing how close each data point is to others and the density of the cluster
+of points around it. It does not run continuously; it generates a copy of your
+data set where each data point is annotated with an {olscore}. The score
+indicates the extent to which a data point is an outlier compared to other data
+points.
 
 [discrete]
 [[machine-learning-supervised]]

--- a/docs/en/stack/ml/machine-learning-intro.asciidoc
+++ b/docs/en/stack/ml/machine-learning-intro.asciidoc
@@ -1,0 +1,49 @@
+[chapter,role="xpack"]
+[[machine-learning-intro]]
+= What is Elastic {ml-app}?
+:keywords: {ml-init}, {stack}
+:description: An introduction to the breadth of Elastic {ml-features}.
+
+{ml-cap} features analyze your data and generate models for its patterns of
+behavior. The type of analysis that you choose depends on the questions or
+problems you want to address and the type of data you have available.
+
+[discrete]
+[[machine-learning-unsupervised]]
+== Unsupervised {ml}
+
+There are two types of analysis that can deduce the patterns and relationships
+within your data without training or intervention: _{anomaly-detect}_ and
+_{oldetection}_.
+
+<<ml-ad-overview,{anomaly-detect-cap}>> requires time series data. It constructs a
+probability model and can run continuously to identify unusual events as they
+occur. The model evolves over time; you can use its insights to forecast future
+behavior.
+
+<<ml-dfa-finding-outliers,{oldetection-cap}>> does not require time series data; 
+it identifies unusual points in a data set by analyzing how close each data 
+point is to others and the density of the cluster of points around it. It does 
+not run continuously; it generates a copy of your data set where each data point 
+is annotated with an {olscore}. The score indicates the extent to which a data 
+point is an outlier compared to other data points.
+
+[discrete]
+[[machine-learning-supervised]]
+== Supervised {ml}
+
+There are two types of analysis that require training data sets:
+_{classification}_ and _{regression}_.
+
+In both cases, the result is a copy of your data set where each data point is
+annotated with predictions and a trained model, which you can deploy to make
+predictions for new data. For more information, refer to
+<<ml-supervised-workflow>>.
+
+<<ml-dfa-classification,{classification-cap}>> learns relationships between your
+data points in order to predict discrete categorical values, such as whether a
+DNS request originates from a malicious or benign domain.
+
+<<ml-dfa-regression,{regression-cap}>> learns relationships between your data
+points in order to predict continuous numerical values, such as the response
+time for a web request.

--- a/docs/en/stack/ml/redirects.asciidoc
+++ b/docs/en/stack/ml/redirects.asciidoc
@@ -124,3 +124,27 @@ This content has moved. See <<ml-ad-overview>>.
 
 This content has moved. See <<ml-ad-overview>>.
 
+[role="exclude",id="ml-gs-visualizer"]
+=== Explore the data in {kib}
+
+This content has moved. See <<sample-data-visualizer>>.
+
+[role="exclude",id="ml-gs-jobs"]
+=== Create sample {anomaly-jobs} in {kib}
+
+This content has moved. See <<sample-data-jobs>>.
+
+[role="exclude",id="ml-gs-results"]
+=== View {anomaly-detect} results
+
+This content has moved. See <<sample-data-results>>.
+
+[role="exclude",id="ml-gs-forecasts"]
+=== Create forecasts
+
+This content has moved. See <<sample-data-forecasts>>.
+
+[role="exclude",id="ml-ges-next"]
+=== Next steps
+
+This content has moved. See <<sample-data-next>>.


### PR DESCRIPTION
Moves the "getting started" tutorial under "Anomaly Detection", since it does not cover data frame analytics.  
Moves the introduction from the first page of the tutorial into a new page (aligned with similar "What is...?" pages for [Elasticsearch](https://www.elastic.co/guide/en/elasticsearch/reference/current/elasticsearch-intro.html), [Kibana](https://www.elastic.co/guide/en/kibana/current/introduction.html), [Observability](https://www.elastic.co/guide/en/observability/current/observability-introduction.html), etc).

### Preview

* https://stack-docs_1839.docs-preview.app.elstc.co/guide/en/machine-learning/master/machine-learning-intro.html
* https://stack-docs_1839.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-getting-started.html
