### PR TITLE
Amends transforms and regression API config in docs

### DIFF
--- a/docs/en/stack/ml/df-analytics/ml-dfa-outlier-detection.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-outlier-detection.asciidoc
@@ -299,7 +299,7 @@ POST _data_frame/transforms/_preview
       },
       "request.value_count": {
         "value_count": {
-          "field": "request"
+          "field": "request.keyword"
         }
       }
     }

--- a/docs/en/stack/ml/df-analytics/ml-dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-regression.asciidoc
@@ -390,7 +390,8 @@ PUT _ml/data_frame/analytics/model-flight-delays-regression
   "analysis": {
     "regression": {
       "dependent_variable": "FlightDelayMin",
-      "training_percent": 90
+      "training_percent": 90,
+      "num_top_feature_importance_values": 5
     }
   },
   "analyzed_fields": {


### PR DESCRIPTION
## Overview

This PR slightly modifies the transform config in outlier detection docs and the regression DFA config in regression docs.

### Preview

* [Outlier detection](https://stack-docs_1840.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-dfa-finding-outliers.html#weblogs-outliers)
* [Regression](https://stack-docs_1840.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-dfa-regression.html#flightdata-regression-model)