### PR TITLE
Amends regression API config in docs

### DIFF
--- a/docs/en/stack/ml/df-analytics/flightdata-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/flightdata-regression.asciidoc
@@ -171,7 +171,8 @@ PUT _ml/data_frame/analytics/model-flight-delays-regression
   "analysis": {
     "regression": {
       "dependent_variable": "FlightDelayMin",
-      "training_percent": 90
+      "training_percent": 90,
+      "num_top_feature_importance_values": 5
     }
   },
   "analyzed_fields": {


### PR DESCRIPTION
## Overview

This PR slightly modifies the regression DFA config in regression docs.

Related to https://github.com/elastic/stack-docs/pull/1840

### Preview

* [Regression](https://stack-docs_1841.docs-preview.app.elstc.co/guide/en/machine-learning/7.x/flightdata-regression.html#flightdata-regression-model)