### PR TITLE
Redirects link in Installation & Upgrade

### DIFF
--- a/docs/en/install-upgrade/upgrading-stack.asciidoc
+++ b/docs/en/install-upgrade/upgrading-stack.asciidoc
@@ -58,7 +58,7 @@ on the cluster during the upgrade process. For more information, see
 .. {es} Hadoop: {hadoop-ref}/install.html[install instructions]
 .. {es}: {ref}/setup-upgrade.html[upgrade instructions]
 .. Kibana: {kibana-ref}/upgrade.html[upgrade instructions]
-.. Java High Level REST Client: {java-rest}/java-rest-high-getting-started-maven.html[dependency configuration]
+.. Java API Client: {java-api-client}/installation.html#maven[dependency configuration]
 .. Logstash: {logstash-ref}/upgrading-logstash.html[upgrade instructions]
 .. Beats: {beats-ref}/upgrading.html[upgrade instructions]
 .. APM Server: {apm-server-ref}/upgrading.html[upgrade instructions]


### PR DESCRIPTION
## Overview

This PR redirects a link in the Installation & Upgrade Guide that points to the old Java HLRC. After the PR is merged, the link points to the new client.

Related to https://github.com/elastic/docs/pull/2229

**DO NOT merge before https://github.com/elastic/docs/pull/2236**

### Preview

[Upgrading the Elastic Stack](https://stack-docs_1844.docs-preview.app.elstc.co/guide/en/elastic-stack/master/upgrading-elastic-stack.html)