### PR TITLE
[DOCS] Update 7.x breaking changes in Install Upgrade Guide

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -31,7 +31,7 @@ Upgrade Assistant provides information about which {dfeeds} need to be updated.
 This list summarizes the most important breaking changes in APM.
 For the complete list, go to {apm-server-ref}/breaking-changes.html[APM Server breaking changes].
 
-include::{apm-repo-dir}/apm-breaking-changes.asciidoc[tag=714-bc]
+include::{apm-repo-dir}/apm-breaking-changes.asciidoc[tag=716-bc]
 
 [[beats-breaking-changes]]
 === Beats breaking changes
@@ -42,7 +42,7 @@ include::{apm-repo-dir}/apm-breaking-changes.asciidoc[tag=714-bc]
 This list summarizes the most important breaking changes in Beats. For the
 complete list, go to {beats-ref}/breaking-changes.html[Beats breaking changes].
 
-//include::{beats-repo-dir}/release-notes/breaking/breaking-7.12.asciidoc[tag=notable-breaking-changes]
+//include::{beats-repo-dir}/release-notes/breaking/breaking-7.16.asciidoc[tag=notable-breaking-changes]
 
 
 [[elasticsearch-breaking-changes]]
@@ -55,7 +55,7 @@ complete list, go to {beats-ref}/breaking-changes.html[Beats breaking changes].
 This list summarizes the most important breaking changes in {es} {version}. For
 the complete list, go to {ref}/breaking-changes.html[{es} breaking changes].
 
-//include::{es-repo-dir}/migration/migrate_7_12.asciidoc[tag=notable-breaking-changes]
+include::{es-repo-dir}/migration/migrate_7_16.asciidoc[tag=notable-breaking-changes]
 
 [[elasticsearch-hadoop-breaking-changes]]
 === {es} Hadoop breaking changes
@@ -80,7 +80,7 @@ include::{hadoop-repo-dir}/appendix/breaking.adoc[tag=notable-v7-breaking-change
 This list summarizes the most important breaking changes in {kib} {version}. For
 the complete list, go to {kibana-ref}/breaking-changes.html[{kib} breaking changes].
 
-//include::{kib-repo-dir}/migration/migrate_7_12.asciidoc[tag=notable-breaking-changes]
+include::{kib-repo-dir}/CHANGELOG.asciidoc[tag=notable-breaking-changes]
 
 [[logstash-breaking-changes]]
 === {ls} breaking changes


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch/issues/79486

This PR updates the breaking changes that are pulled into the Installation and Upgrade Guide for 7.x.