### PR TITLE
[DOCS] Add migrate_to_java_time.asciidoc to Install and Upgrade Guide

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -91,6 +91,9 @@ include::{es-repo-dir}/migration/migrate_8_0/indices.asciidoc[tag=notable-breaki
 ==== Ingest pipeline changes
 include::{es-repo-dir}/migration/migrate_8_0/ingest.asciidoc[tag=notable-breaking-changes]
 
+==== Java time changes
+include::{es-repo-dir}/migration/migrate_8_0/migrate_to_java_time.asciidoc[tag=notable-breaking-changes]
+
 ==== Java API changes
 include::{es-repo-dir}/migration/migrate_8_0/java.asciidoc[tag=notable-breaking-changes]
 


### PR DESCRIPTION
This PR adds a reference to https://github.com/elastic/elasticsearch/blob/master/docs/reference/migration/migrate_8_0/migrate_to_java_time.asciidoc in the Installation and Upgrade Guide.