### PR TITLE
[DOCS] Removes outdated callout from the ML setup page

### DIFF
--- a/docs/en/stack/ml/setup.asciidoc
+++ b/docs/en/stack/ml/setup.asciidoc
@@ -102,7 +102,3 @@ feature and `all` {kib} privileges for the {ipm-app} feature
 * [ ] `manage_pipeline` or `manage_ingest_pipelines` cluster privileges
 * [ ] `create`, `create_index`, `manage` and `read` index privileges for
 destination indices
-
-IMPORTANT: You cannot limit access to specific {ml} objects in each space. If
-the {ml} feature is visible in your space and you have `read` or `all` {kib}
-privileges for the feature, you have access to *all* {ml} objects in that space.


### PR DESCRIPTION
## Overview

ML jobs are now space-aware, so the callout at the bottom of the page is no longer relevant. This PR deletes the callout.