### PR TITLE
[DOCS] Adds transform breaking changes

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -130,6 +130,9 @@ include::{es-repo-dir}/migration/migrate_8_0/snapshots.asciidoc[tag=notable-brea
 ==== Thread pool changes
 include::{es-repo-dir}/migration/migrate_8_0/threadpool.asciidoc[tag=notable-breaking-changes]
 
+==== {transform-cap} changes
+include::{es-repo-dir}/migration/migrate_8_0/transform.asciidoc[tag=notable-breaking-changes]
+
 ==== Transport changes
 include::{es-repo-dir}/migration/migrate_8_0/transport.asciidoc[tag=notable-breaking-changes]
 


### PR DESCRIPTION
This PR must be merged after https://github.com/elastic/elasticsearch/pull/79531, which adds the new transforms section to the 8.0 breaking changes.