### PR TITLE
[DOCS] Remove deprecated env variables in kibana

### DIFF
--- a/docs/en/getting-started/docker/docker-compose.yml
+++ b/docs/en/getting-started/docker/docker-compose.yml
@@ -65,7 +65,6 @@ services:
     ports:
       - 5601:5601
     environment:
-      ELASTICSEARCH_URL: http://es01:9200
       ELASTICSEARCH_HOSTS: '["http://es01:9200","http://es02:9200","http://es03:9200"]'
     networks:
       - elastic

--- a/docs/en/getting-started/docker/elastic-docker-tls.yml
+++ b/docs/en/getting-started/docker/elastic-docker-tls.yml
@@ -109,7 +109,6 @@ services:
       - 5601:5601    
     environment:
       SERVERNAME: localhost
-      ELASTICSEARCH_URL: https://es01:9200
       ELASTICSEARCH_HOSTS: https://es01:9200
       ELASTICSEARCH_USERNAME: kibana_system
       ELASTICSEARCH_PASSWORD: CHANGEME

--- a/docs/en/getting-started/get-started-docker.asciidoc
+++ b/docs/en/getting-started/get-started-docker.asciidoc
@@ -184,7 +184,6 @@ ifeval::["{release-state}"!="unreleased"]
       - 5601:5601
     environment:
       SERVERNAME: localhost
-      ELASTICSEARCH_URL: https://es01:9200
       ELASTICSEARCH_HOSTS: https://es01:9200
       ELASTICSEARCH_USERNAME: kibana_system
       **ELASTICSEARCH_PASSWORD: CHANGEME**


### PR DESCRIPTION
Remove deprecated variable `elasticsearch.url` for kibana in docker-compose examples (deprecated since 6.6.0). 

source : https://www.elastic.co/guide/en/kibana/6.8/settings.html
