### PR TITLE
[8.0][DOCS] Adds setup page links to sections about ML node setup (#1872)

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/ml-ad-finding-anomalies.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-ad-finding-anomalies.asciidoc
@@ -69,13 +69,9 @@ visualizations that are customized to help you analyze your data.
 [[ml-ad-setup]]
 == 2. Set up the environment
 
-If you want to use {ml-features}, there must be at least one {ml} node in
-your cluster and all master-eligible nodes must have {ml} enabled. For more
-information about these settings, see 
-{ref}/modules-node.html#ml-node[{ml} nodes].
-
-If {stack-security-features} are enabled, you must also ensure your users have
-the necessary privileges. See <<setup>>.
+Before you can use the {stack-ml-features}, there are some configuration
+requirements (such as security privileges) that must be addressed. Refer to
+<<setup>>.
 
 [NOTE]
 ===============================

--- a/docs/en/stack/ml/df-analytics/ml-dfa-classification.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-classification.asciidoc
@@ -40,7 +40,7 @@ previous tree.
 [[dfa-classification-problem]]
 == 1. Define the problem
 
-{classification-cap} can be useful in cases where discerte, categorical values 
+{classification-cap} can be useful in cases where discrete, categorical values 
 needs to be predicted. If your use case requires predicting such values, then 
 {classification} might be the suitable choice for you.
 
@@ -48,14 +48,9 @@ needs to be predicted. If your use case requires predicting such values, then
 [[dfa-classification-environment]]
 == 2. Set up the environment
 
-To use {ml-features}, there must be at least one {ml} node in your cluster and 
-all master-eligible nodes must have {ml} enabled. By default, all nodes are {ml} 
-nodes. For more information about these settings, refer to 
-{ref}/modules-node.html#ml-node[{ml} nodes].
-
-The {stack-security-features} require you to ensure your users also have the 
-necessary security privileges. See <<setup>>.
-
+Before you can use the {stack-ml-features}, there are some configuration
+requirements (such as security privileges) that must be addressed. Refer to
+<<setup>>.
 
 [discrete]
 [[dfa-classification-prepare-data]]

--- a/docs/en/stack/ml/df-analytics/ml-dfa-outlier-detection.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-outlier-detection.asciidoc
@@ -49,7 +49,7 @@ _Density based methods_ are used for mitigating this problem.
 
 The four algorithms don't always agree on which points are outliers. By default, 
 {oldetection} jobs use all these methods, then normalize and combine their 
-results and give every datapoint in the index an {olscore}. The {olscore} ranges 
+results and give every data point in the index an {olscore}. The {olscore} ranges 
 from 0 to 1, where the higher number represents the chance that the data point 
 is an outlier compared to the other data points in the index.
 
@@ -85,13 +85,9 @@ need to provide a training data set.
 [[dfa-outlier-detection-environment]]
 == 2. Set up the environment
 
-If you want to use {ml-features}, there must be at least one {ml} node in your 
-cluster and all master-eligible nodes must have {ml} enabled. By default, all 
-nodes are {ml} nodes. For more information about these settings, see 
-{ref}/modules-node.html#ml-node[{ml} nodes].
-
-If {stack-security-features} are enabled, you must also ensure your users have
-the necessary privileges. See <<setup>>.
+Before you can use the {stack-ml-features}, there are some configuration
+requirements (such as security privileges) that must be addressed. Refer to
+<<setup>>.
 
 
 [discrete]
@@ -129,7 +125,7 @@ has four phases:
 
 * `reindexing`: documents are copied from the source index to the destination 
   index.
-* `loading_data`: the job fatches the necessary data from the destination index.
+* `loading_data`: the job fetches the necessary data from the destination index.
 * `computing_outliers`: the job identifies outliers in the data.
 * `writing_results`: the job matches the results with the data rows in the 
   destination index, merges them, and indexes them back to the destination 
@@ -247,7 +243,7 @@ IP.
 In particular, create a {transform} that calculates the number of occasions when 
 a specific client IP communicated with the network (`@timestamp.value_count`), 
 the sum of the bytes that are exchanged between the network and the client's 
-machine (`bytes.sum`), the maximum excanged bytes during a single occasion 
+machine (`bytes.sum`), the maximum exchanged bytes during a single occasion 
 (`bytes.max`), and the total number of requests (`request.value_count`) 
 initiated by a specific client IP.
 
@@ -478,7 +474,7 @@ In addition to an overall outlier score, each document is annotated with feature
 influence values for each field. These values add up to 1 and indicate which
 fields are the most important in deciding whether an entity is an outlier or
 inlier. For example, the dark shading on the `bytes.sum` field for the client IP 
-`111.237.144.54` indicates that the sum of the excanged bytes was the most
+`111.237.144.54` indicates that the sum of the exchanged bytes was the most
 influential feature in determining that that client IP is an outlier.
 
 If you want to see the exact feature influence values, you can retrieve them

--- a/docs/en/stack/ml/df-analytics/ml-dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-regression.asciidoc
@@ -29,7 +29,7 @@ boost (XGboost) which combines decision trees with gradient boosting
 methodologies.
 
 There are three types of {feature-vars} that you can use with these algorithms: 
-numerical, cathegorical, or Boolean. Arrays are not supported.
+numerical, categorical, or Boolean. Arrays are not supported.
 //end::regression-algorithms[]
 
 [discrete]
@@ -45,14 +45,9 @@ your use case requires predicting continuous, numerical values, then
 [[dfa-regression-environment]]
 == 2. Set up the environment
 
-To use {ml-features}, there must be at least one {ml} node in your cluster and 
-all master-eligible nodes must have {ml} enabled. By default, all nodes are {ml} 
-nodes. For more information about these settings, refer to 
-{ref}/modules-node.html#ml-node[{ml} nodes].
-
-The {stack-security-features} require you to ensure your users also have the 
-necessary security privileges. See <<setup>>.
-
+Before you can use the {stack-ml-features}, there are some configuration
+requirements (such as security privileges) that must be addressed. Refer to
+<<setup>>.
 
 [discrete]
 [[dfa-regression-prepare-data]]
@@ -68,7 +63,7 @@ role in model evaluation.
 You might also need to {ref}/transforms.html[{transform}] your data to create a 
 {dataframe} which can be used as the source for {regression}.
 
-To learn more about how to prepeare your data, refer to 
+To learn more about how to prepare your data, refer to 
 <<prepare-transform-data, the relevant section>> of the supervised learning 
 overview.
 
@@ -163,7 +158,7 @@ transition point between MAE and MSE. Consult the
 
 
 [discrete]
-[[ml-dfanalytics-r-sqared]]
+[[ml-dfanalytics-r-squared]]
 === R-squared
 
 R-squared (R^2^) represents the goodness of fit and measures how much of the 


### PR DESCRIPTION
Backports https://github.com/elastic/stack-docs/pull/1872