### PR TITLE
[7.15][DOCS] Adds setup page links to sections about ML node setup (#1872)

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/ml-configuration.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-configuration.asciidoc
@@ -2,10 +2,9 @@
 [[ml-configuration]]
 = Configure {anomaly-detect}
 
-If you want to use {ml-features}, there must be at least one {ml} node in
-your cluster and all master-eligible nodes must have {ml} enabled. By default,
-all nodes are {ml} nodes. For more information about these settings, see 
-{ref}/modules-node.html#ml-node[{ml} nodes].
+Before you can use the {stack-ml-features}, there are some configuration
+requirements (such as security privileges) that must be addressed. Refer to
+<<setup>>.
 
 To use the {ml-features} to analyze your data, you can create an {anomaly-job}
 and send your data to that job.


### PR DESCRIPTION
Backports https://github.com/elastic/stack-docs/pull/1872