### PR TITLE
[DOCS] Add 'feature state' definition to glossary

### DIFF
--- a/docs/en/glossary/glossary.asciidoc
+++ b/docs/en/glossary/glossary.asciidoc
@@ -443,8 +443,7 @@ data for an Elastic feature, such as {es} security or {kib}. A feature state
 typically includes one or more <<glossary-system-index,system indices or data
 streams>>. It may also include regular indices and data streams used by the
 feature. You can use <<glossary-snapshot,snapshots>> to back up and restore a
-feature state for a point in time. See
-{ref}/snapshot-restore.html#feature-state[feature states].
+feature states. See {ref}/snapshot-restore.html#feature-state[feature states].
 //Source: Elasticsearch
 
 [[glossary-field]] field::

--- a/docs/en/glossary/glossary.asciidoc
+++ b/docs/en/glossary/glossary.asciidoc
@@ -437,6 +437,16 @@ and
 {ml-docs}/ml-dfa-classification.html#dfa-classification-feature-importance[{classification-cap} feature importance].
 //Source: Machine learning
 
+[[glossary-feature-state]] feature state::
+The indices and data streams used to store configurations, history, and other
+data for an Elastic feature, such as {es} security or {kib}. A feature state
+typically includes one or more <<glossary-system-index,system indices or data
+streams>>. It may also include regular indices and data streams used by the
+feature. You can use <<glossary-snapshot,snapshots>> to back up and restore a
+feature state for a point in time. See
+{ref}/snapshot-restore.html#feature-state[feature states].
+//Source: Elasticsearch
+
 [[glossary-field]] field::
 . Key-value pair in a <<glossary-document,document>>. See
 {ref}/mapping.html[Mapping].

--- a/docs/en/glossary/glossary.asciidoc
+++ b/docs/en/glossary/glossary.asciidoc
@@ -442,7 +442,7 @@ The indices and data streams used to store configurations, history, and other
 data for an Elastic feature, such as {es} security or {kib}. A feature state
 typically includes one or more <<glossary-system-index,system indices or data
 streams>>. It may also include regular indices and data streams used by the
-feature. You can use <<glossary-snapshot,snapshots>> to back up and restore a
+feature. You can use <<glossary-snapshot,snapshots>> to back up and restore
 feature states. See {ref}/snapshot-restore.html#feature-state[feature states].
 //Source: Elasticsearch
 


### PR DESCRIPTION
Closes https://github.com/elastic/elasticsearch/issues/80050

Relates to https://github.com/elastic/elasticsearch/issues/79675, https://github.com/elastic/elasticsearch/pull/79081