### PR TITLE
[DOCS] Updating Stack getting started for security ON

### DIFF
--- a/docs/en/getting-started/get-started-stack.asciidoc
+++ b/docs/en/getting-started/get-started-stack.asciidoc
@@ -56,7 +56,7 @@ work with your system:
 * <<linux, linux>> for Linux
 * <<win, win>> for Windows
 
-When you start {es} for the first time, the following security configuration
+When you start {es} for the first time, security features such as authentication, authorization and network encryption (TLS) for elasticsearch are enabled by default. The following security configuration
 occurs automatically:
 
 * {ref}/configuring-stack-security.html#stack-security-certificates[Certificates and keys] for TLS are
@@ -406,7 +406,7 @@ https://www.elastic.co/guide/en/kibana/current/index.html[{kib} Reference].
 ==== Access the {kib} web interface
 
 To access the {kib} web interface, point your browser to port `5601`. For example,
-https://127.0.0.1:5601[http://127.0.0.1:5601].
+http://127.0.0.1:5601[http://127.0.0.1:5601].
 
 [float]
 [[install-beats]]

--- a/docs/en/getting-started/get-started-stack.asciidoc
+++ b/docs/en/getting-started/get-started-stack.asciidoc
@@ -1,7 +1,9 @@
 [[get-started-elastic-stack]]
 == Getting started with the {stack}
 
-Looking for an {stack} ("ELK") guide that shows how to quickly install and configure the {stack}? You're in the right place! You can install the {stack} on a single VM, or even on your laptop:
+Looking for a guide that shows how to quickly install and configure the {stack}?
+You're in the right place! You can install the {stack} on a single VM, or even
+on your laptop. Install each component in the following order:
 
 * <<install-elasticsearch,{es}>>
 * <<install-kibana,{kib}>>
@@ -14,11 +16,6 @@ isn't required. To get started with {ls}, see
 After completing the installation process, learn how to implement a system
 monitoring solution that uses {metricbeat} to collect server metrics and ship
 the data to {es}. Then use {kib} to search and visualize the data.
-
-IMPORTANT: Implementing security is a critical step in configuring the {stack}.
-This guide skips security configuration to quickly install a sample installation. Before sending sensitive data across the network,
-{ref}/elasticsearch-security.html[secure the {stack}] and enable
-{ref}/encrypting-communications.html[encrypted communications].
 
 [float]
 [[install-prereqs]]
@@ -43,18 +40,33 @@ data, such as logs or decoded network packets.
 
 [TIP]
 ==========
-You can run Elasticsearch on your own hardware, or use our
-https://www.elastic.co/cloud/elasticsearch-service[hosted Elasticsearch Service]
-on Elastic Cloud. The Elasticsearch Service is available on both AWS and GCP.
+You can run {es} on your own hardware, or use our
+https://www.elastic.co/cloud/elasticsearch-service[hosted {es} Service]
+on Elastic Cloud. The {es} Service is available on both AWS and GCP.
 {ess-trial}[Try out the
-Elasticsearch Service for free].
+{es} Service for free].
 ==========
 
 To download and install {es}, open a terminal window and use the commands that
-work with your system (<<deb, deb>> for Debian/Ubuntu, <<rpm, rpm>> for
-Redhat/Centos/Fedora, <<mac, mac>> or <<brew, brew>> for OS X, <<linux, linux>>
-for Linux, and <<win, win>> for Windows):
+work with your system:
 
+* <<deb, deb>> for Debian/Ubuntu
+* <<rpm, rpm>> for Redhat/Centos/Fedora
+* <<mac, mac>> or <<brew, brew>> for OS X
+* <<linux, linux>> for Linux
+* <<win, win>> for Windows
+
+When you start {es} for the first time, the following security configuration
+occurs automatically:
+
+* {ref}/configuring-stack-security.html#stack-security-certificates[Certificates and keys] for TLS are
+generated for the transport and HTTP layers.
+* The TLS configuration settings are written to `elasticsearch.yml`.
+* A password is generated for the `elastic` user.
+* An enrollment token is generated for {kib}.
+
+You can then start {kib} and enter the enrollment token to securely connect 
+{kib} with {es}. The enrollment token is valid for 30 minutes.
 
 [[deb]]*deb:*
 
@@ -189,8 +201,8 @@ endif::[]
 For other operating systems, go to the
 https://www.elastic.co/downloads/elasticsearch[{es} download] page.
 
-TIP: The default {ref}/cluster.name.html[cluster.name] and
-{ref}/node.name.html[node.name] are `elasticsearch` and your hostname,
+TIP: The default {ref}/important-settings.html#cluster-name[cluster.name] and
+{ref}/important-settings.html#node-name[node.name] are `elasticsearch` and your hostname,
 respectively. If you plan to keep using this cluster or add more nodes, it is a
 good idea to change these default values to unique names. For details about
 changing these and other settings in the `elasticsearch.yml` file, see
@@ -200,16 +212,22 @@ To learn more about installing, configuring, and running {es}, read the
 https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html[{es} Reference].
 
 [float]
-==== Make sure {es} is up and running
+==== Make sure that {es} is up and running
 
-
-To test that the {es} daemon is up and running, try sending an HTTP GET
-request on port 9200.
+Open a new terminal and verify that you can connect to your {es} cluster by
+making an authenticated call. Enter the password for the `elastic` user when
+prompted:
 
 [source,shell]
-----------------------------------------------------------------------
-curl http://127.0.0.1:9200
-----------------------------------------------------------------------
+----
+curl --cacert config/tls_auto_config_<timestamp>/http_ca.crt \
+-u elastic https://localhost:9200 <1>
+----
+// NOTCONSOLE
+<1> Ensure that you use `https` in your call, or the request will fail.
++
+`--cacert`::
+Path to the generated `http_ca.crt` certificate for the HTTP layer.
 
 On Windows, if you don't have cURL installed, point your browser to the URL.
 
@@ -226,11 +244,11 @@ You should see a response similar to this:
     "build_flavor" : "default",
     "build_type" : "tar",
     "build_hash" : "f4d76bd413ecfbd5122c3aa5dc85465960f18afe",
-    "build_date" : "2021-04-23T15:58:28.336786977Z",
+    "build_date" : "2021-10-27T22:47:53.634020433Z",
     "build_snapshot" : false,
-    "lucene_version" : "8.8.2",
-    "minimum_wire_compatibility_version" : "6.8.0",
-    "minimum_index_compatibility_version" : "6.0.0-beta1"
+    "lucene_version" : "9.0.0",
+    "minimum_wire_compatibility_version" : "7.16.0",
+    "minimum_index_compatibility_version" : "7.0.0"
   },
   "tagline" : "You Know, for Search"
 }
@@ -249,20 +267,44 @@ and maps.
 
 [TIP]
 ==========
-Running our hosted Elasticsearch Service on https://www.elastic.co/cloud[Elastic Cloud]?
-Kibana is enabled automatically in most templates,
-or manually with the {cloud}/ec-enable-kibana.html[flick of a switch].
+Running our hosted {es} Service on https://www.elastic.co/cloud[Elastic Cloud]?
+{kib} is enabled automatically in most templates.
 ==========
 
-We recommend that you install {kib} on the same server as {es},
-but it is not required. If you install the products on different servers, you'll
+We recommend that you install {kib} on the same server as {es}, but it's not
+required. If you install the products on different servers, you'll
 need to change the URL (IP:PORT) of the {es} server in the {kib} configuration
 file, `kibana.yml`, before starting {kib}.
 
 To download and install {kib}, open a terminal window and use the commands that
 work with your system:
 
-*deb, rpm, or linux:*
+* <<deb-rpm-linux,deb>> for Debian/Ubuntu/Redhat/Centos/Fedora
+* <<kibana-mac,mac>> or <<kibana-brew, brew>> for OS X
+* <<kibana-win,win>> for Windows
+
+If this is the first time you're starting {kib}, this command generates a 
+unique link in your terminal to enroll your {kib} instance with {es}.
+
+. In your terminal, click the generated link to open {kib} in your browser.
+
+. In your browser, paste the enrollment token that was generated in the terminal 
+when you started {es}, and then click the button to connect your {kib} instance
+with {es}.
+
+. Log in to {kib} as the `elastic` user with the password that was generated
+when you started {es}.
+
+[NOTE]
+====
+If you need to reset the password for the `elastic` user or other
+built-in users, run the {ref}/reset-password.html[`elasticsearch-reset-password`] tool.
+To generate new enrollment tokens for {kib} or {es} nodes, run the
+{ref}/create-enrollment-token.html[`elasticsearch-create-enrollment-token`] tool.
+These tools are available in the {es} `bin` directory.
+====
+
+[[deb-rpm-linux]]*deb, rpm, or linux:*
 
 ifeval::["{release-state}"=="unreleased"]
 
@@ -282,7 +324,7 @@ cd kibana-{kibana_version}-linux-x86_64/
 
 endif::[]
 
-*mac:*
+[[kibana-mac]]*mac:*
 
 ifeval::["{release-state}"=="unreleased"]
 
@@ -302,7 +344,7 @@ cd kibana-{kibana_version}-darwin-x86_64/
 
 endif::[]
 
-*brew:*
+[[kibana-brew]]*brew:*
 
 ifeval::["{release-state}"=="unreleased"]
 
@@ -321,7 +363,7 @@ kibana
 
 endif::[]
 
-*win:*
+[[kibana-win]]*win:*
 
 ifeval::["{release-state}"=="unreleased"]
 
@@ -361,10 +403,10 @@ To learn more about installing, configuring, and running {kib}, read the
 https://www.elastic.co/guide/en/kibana/current/index.html[{kib} Reference].
 
 [float]
-==== Launch the {kib} web interface
+==== Access the {kib} web interface
 
-To launch the {kib} web interface, point your browser to port 5601. For example,
-http://127.0.0.1:5601[http://127.0.0.1:5601].
+To access the {kib} web interface, point your browser to port `5601`. For example,
+https://127.0.0.1:5601[http://127.0.0.1:5601].
 
 [float]
 [[install-beats]]
@@ -657,27 +699,18 @@ TIP: If you don’t see data in {kib}, try changing the date range to a larger
 range. By default, {kib} shows the last 15 minutes. If you see errors, make
 sure {metricbeat} is running, then refresh the page.
 
-[role="screenshot"]
-image::images/metricbeat-system-overview.png[{metricbeat} system overview]
-
 Click *Host Overview* to see detailed metrics about the selected host.
-
-[role="screenshot"]
-image::images/metricbeat-system-host-details.png[{metricbeat} host overview]
 
 [float]
 [[whats_next]]
 ==== What's next?
 
-Congratulations! You've successfully set up the {stack}. You learned how to
-stream system metrics to {es} and visualize the data in {kib}. 
+Congratulations! You've successfully set up the {stack} and securely connected
+{kib} with {es}. You learned how to stream system metrics to {es} and visualize
+the data in {kib}. 
 
-Next, you'll want to set up the {stack} {security-features} and activate your
-trial license so you can unlock the full capabilities of the {stack}. To learn
-how, read:
-
-* {ref}/elasticsearch-security.html[Securing the {stack}]
-* {kibana-ref}/managing-licenses.html[License Management]
+Next, you'll want to {kibana-ref}/managing-licenses.html[activate your trial license]
+to unlock the full capabilities of the {stack}.
 
 Want to get up and running quickly with metrics monitoring and
 centralized log analytics? Try out the Metrics app and the Logs app in {kib}.

--- a/docs/en/getting-started/get-started-stack.asciidoc
+++ b/docs/en/getting-started/get-started-stack.asciidoc
@@ -231,7 +231,7 @@ curl --cacert $ES_PATH_CONF/tls_auto_config_<timestamp>/http_ca.crt \
 -u elastic https://localhost:9200
 ----
 // NOTCONSOLE
-+
+
 `--cacert`::
 Path to the generated `http_ca.crt` certificate for the HTTP layer. This file
 is created in the {es} configuration directory, which is defined by the

--- a/docs/en/getting-started/get-started-stack.asciidoc
+++ b/docs/en/getting-started/get-started-stack.asciidoc
@@ -1,9 +1,9 @@
 [[get-started-elastic-stack]]
 == Getting started with the {stack}
 
-Looking for a guide that shows how to quickly install and configure the {stack}?
-You're in the right place! You can install the {stack} on a single VM, or even
-on your laptop. Install each component in the following order:
+Looking for a guide that shows how to quickly install and configure the {stack}
+("ELK")? You're in the right place! You can install the {stack} on a single VM, 
+or even on your laptop. Install each component in the following order:
 
 * <<install-elasticsearch,{es}>>
 * <<install-kibana,{kib}>>
@@ -67,6 +67,13 @@ generated for the transport and HTTP layers.
 
 You can then start {kib} and enter the enrollment token to securely connect 
 {kib} with {es}. The enrollment token is valid for 30 minutes.
+
+[NOTE]
+====
+On `deb` and `rpm` installations, an enrollment token isn't generated for {kib}
+during installation. To generate an enrollment token for {kib}, use the
+{ref}/create-enrollment-token.html[`elasticsearch-create-enrollment-token`] tool.
+====
 
 [[deb]]*deb:*
 
@@ -220,14 +227,15 @@ prompted:
 
 [source,shell]
 ----
-curl --cacert config/tls_auto_config_<timestamp>/http_ca.crt \
--u elastic https://localhost:9200 <1>
+curl --cacert $ES_PATH_CONF/tls_auto_config_<timestamp>/http_ca.crt \
+-u elastic https://localhost:9200
 ----
 // NOTCONSOLE
-<1> Ensure that you use `https` in your call, or the request will fail.
 +
 `--cacert`::
-Path to the generated `http_ca.crt` certificate for the HTTP layer.
+Path to the generated `http_ca.crt` certificate for the HTTP layer. This file
+is created in the {es} configuration directory, which is defined by the
+`$ES_PATH_CONF` {ref}/settings.html#config-files-location[environment variable].
 
 On Windows, if you don't have cURL installed, point your browser to the URL.
 


### PR DESCRIPTION
Updates the getting started page for the Stack to reflect changes for security ON by default. Also removes old links, updates other links, and fixes some minor issues throughout the page.

Preview link: https://stack-docs_1883.docs-preview.app.elstc.co/guide/en/elastic-stack-get-started/master/get-started-elastic-stack.html