### PR TITLE
[DOCS] Update index pattern definition

### DIFF
--- a/docs/en/glossary/glossary.asciidoc
+++ b/docs/en/glossary/glossary.asciidoc
@@ -629,7 +629,7 @@ each phase. See {ref}/ilm-policy-definition.html[Index lifecycle].
 //Source: Elasticsearch
 
 [[glossary-index-pattern]] index pattern::
-String containing a wildcard (`*`) pattern that can match multiple
+In {es}, a string containing a wildcard (`*`) pattern that can match multiple
 <<glossary-data-stream,data streams>>, <<glossary-index,indices>>, or
 <<glossary-alias,aliases>>. See {ref}/multi-index.html[Multi-target syntax].
 //Source: Elasticsearch


### PR DESCRIPTION
Tweaks the `index pattern` definition to make it clear that it now applies to the Elasticsearch context, not Kibana.

Relates to https://github.com/elastic/stack-docs/pull/1886.