### PR TITLE
[7.16] Remove links and references to journalbeat (#1893)

### DIFF
--- a/docs/en/getting-started/get-started-stack.asciidoc
+++ b/docs/en/getting-started/get-started-stack.asciidoc
@@ -388,7 +388,6 @@ Started documentation:
 |{filebeat-ref}/filebeat-installation-configuration.html[{filebeat}] |Log files
 |{functionbeat-ref}/functionbeat-installation-configuration.html[{functionbeat}] |Cloud data
 |{heartbeat-ref}/heartbeat-installation-configuration.html[{heartbeat}] |Availability monitoring
-|{journalbeat-ref}/journalbeat-installation-configuration.html[{journalbeat}] |Systemd journals
 |{metricbeat-ref}/metricbeat-installation-configuration.html[{metricbeat}] |Metrics
 |{packetbeat-ref}/packetbeat-installation-configuration.html[{packetbeat}] |Network traffic
 |{winlogbeat-ref}/winlogbeat-installation-configuration.html[{winlogbeat}] |Windows event logs


### PR DESCRIPTION
Backports the following commits to 7.16:
 - Remove links and references to journalbeat (#1893)