### PR TITLE
Updates the Beats breaking changes link

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -42,7 +42,7 @@ include::{apm-repo-dir}/apm-breaking.asciidoc[tag=716-bc]
 This list summarizes the most important breaking changes in Beats.
 For the complete list, go to {beats-ref}/breaking-changes.html[Beats breaking changes].
 
-//include::{beats-repo-dir}/release-notes/breaking/breaking-7.16.asciidoc[tag=notable-breaking-changes]
+include::{beats-repo-dir}/release-notes/breaking/breaking-7.16.asciidoc[tag=notable-breaking-changes]
 
 
 [[elasticsearch-breaking-changes]]


### PR DESCRIPTION
Activates the include for beats breaking changes in 7.16.

MERGE AFTER https://github.com/elastic/beats/pull/29300.