### PR TITLE
Adds Extract information page to NLP docs

### DIFF
--- a/docs/en/stack/ml/nlp/index.asciidoc
+++ b/docs/en/stack/ml/nlp/index.asciidoc
@@ -1,5 +1,6 @@
 include::ml-nlp.asciidoc[]
 include::ml-nlp-overview.asciidoc[leveloffset=+1]
+include::ml-nlp-extract-info.asciidoc[leveloffset=+2]
 include::ml-nlp-lang-ident.asciidoc[leveloffset=+2]
 include::ml-nlp-apis.asciidoc[leveloffset=+1]
 

--- a/docs/en/stack/ml/nlp/ml-nlp-extract-info.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-extract-info.asciidoc
@@ -72,7 +72,9 @@ The task returns the following result:
 
 The objective of the fill-mask task is to predict a missing word from a text 
 sequence. The model uses the context of the masked word to predict the most 
-likely word to complete the text. 
+likely word to complete the text.
+
+The fill-mask task can be used to quickly and easily test your model.
 
 In the following example, the special word “[MASK]” is used as a placeholder to 
 tell the model which word to predict.

--- a/docs/en/stack/ml/nlp/ml-nlp-extract-info.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-extract-info.asciidoc
@@ -12,7 +12,7 @@ These NLP tasks enable you to extract information from your unstructured text:
 
 [discrete]
 [[ml-nlp-ner]]
-== Named entity recognition (NER)
+== Named entity recognition
 
 The named entity recognition (NER) task can identify and categorize certain 
 entities – typically proper nouns – in your unstructured text. Named entities 

--- a/docs/en/stack/ml/nlp/ml-nlp-extract-info.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-extract-info.asciidoc
@@ -1,0 +1,100 @@
+[[ml-nlp-extract-info]]
+= Extract information
+
+:keywords: {ml-init}, {stack}, {nlp}, named entity recognition, fill mask
+:description: NLP tasks that extract information from unstructured text. 
+
+These NLP tasks enable you to extract information from your unstructured text:
+
+* <<ml-nlp-ner>>
+* <<ml-nlp-mask>>
+
+
+[discrete]
+[[ml-nlp-ner]]
+== Named entity recognition (NER)
+
+The named entity recognition (NER) task can identify and categorize certain 
+entities – typically proper nouns – in your unstructured text. Named entities 
+usually refer to objects in the real world such as persons, locations, 
+organizations, and other miscellaneous entities that are consistently referenced 
+by a proper name.
+
+NER is a useful tool to identify key information, add structure and gain 
+insight on your content while processing and exploring large collections of text 
+such as news articles, wiki pages or websites. It makes it easier to understand 
+the subject of a text and group similar pieces of content together.
+
+In the following example, the short text is analyzed for any named entity and 
+the model extracts not only the individual words that make up the entities, but 
+also phrases, consisting of multiple words.
+
+[source,js]
+----------------------------------
+...
+{
+    "text_field": "Elastic is headquartered in Mountain View, California."
+}
+...
+----------------------------------
+// NOTCONSOLE
+
+
+The task returns the following result:
+
+[source,js]
+----------------------------------
+...
+{
+  "results": [
+    {
+      "entity": "Elastic",
+      "class": "organization"
+    },
+    {
+      "entity": "Mountain View",
+      "class": "location"
+    },
+    {
+      "entity": "California",
+      "class": "location"
+    }
+  ]
+}
+...
+----------------------------------
+// NOTCONSOLE
+
+
+[discrete]
+[[ml-nlp-mask]]
+== Fill-mask
+
+The objective of the Fill-mask task is to predict a missing word from a text 
+sequence. The model uses the context of the masked word to predict the most 
+likely word to complete the text. 
+
+In the following example, the special word “[MASK]” is used as a placeholder to 
+tell the model which word to predict.
+
+[source,js]
+----------------------------------
+...
+{
+    "input": "The capital city of France is [MASK]."
+}
+...
+----------------------------------
+// NOTCONSOLE
+
+The task returns the following result:
+
+[source,js]
+----------------------------------
+...
+{
+  "result": "Paris"
+}
+...
+----------------------------------
+// NOTCONSOLE

--- a/docs/en/stack/ml/nlp/ml-nlp-extract-info.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-extract-info.asciidoc
@@ -70,7 +70,7 @@ The task returns the following result:
 [[ml-nlp-mask]]
 == Fill-mask
 
-The objective of the Fill-mask task is to predict a missing word from a text 
+The objective of the fill-mask task is to predict a missing word from a text 
 sequence. The model uses the context of the masked word to predict the most 
 likely word to complete the text. 
 

--- a/docs/en/stack/ml/nlp/ml-nlp-extract-info.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-extract-info.asciidoc
@@ -21,7 +21,7 @@ organizations, and other miscellaneous entities that are consistently referenced
 by a proper name.
 
 NER is a useful tool to identify key information, add structure and gain 
-insight on your content while processing and exploring large collections of text 
+insight into your content. It's particularly useful while processing and exploring large collections of text 
 such as news articles, wiki pages or websites. It makes it easier to understand 
 the subject of a text and group similar pieces of content together.
 

--- a/docs/en/stack/ml/nlp/ml-nlp-overview.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-overview.asciidoc
@@ -28,9 +28,9 @@ can use it to make predictions (also known as _inference_) against incoming data
 You can perform the following NLP tasks:
 
 Extract information::
-* _Named entity recognition (NER)_ enables you to identify and categorize entities
+* <<ml-nlp-ner>> enables you to identify and categorize entities
 in your text.
-* _Fill masks_ enable you to predict missing words in text sequences.
+* <<ml-nlp-mask>> enable you to predict missing words in text sequences.
 
 Categorize text::
 * <<ml-nlp-lang-ident,Language identification>> enables you to determine the

--- a/docs/en/stack/ml/nlp/ml-nlp-overview.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-overview.asciidoc
@@ -28,8 +28,7 @@ can use it to make predictions (also known as _inference_) against incoming data
 You can perform the following NLP tasks:
 
 Extract information::
-* <<ml-nlp-ner>> enables you to identify and categorize entities
-in your text.
+* <<ml-nlp-ner>> enables you to identify and categorize entities in your text.
 * <<ml-nlp-mask>> enable you to predict missing words in text sequences.
 
 Categorize text::


### PR DESCRIPTION
## Overview

This PR adds the "Extract information" page to the NLP docs.
The page contains the conceptual docs of the following NLP tasks:
* named entity recognition (NER)
* fill-mask

### Preview

[Extract information](https://stack-docs_1908.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-nlp-extract-info.html)