### PR TITLE
Drafts Search and compare section for NLP docs

### DIFF
--- a/docs/en/stack/ml/nlp/index.asciidoc
+++ b/docs/en/stack/ml/nlp/index.asciidoc
@@ -2,5 +2,6 @@ include::ml-nlp.asciidoc[]
 include::ml-nlp-overview.asciidoc[leveloffset=+1]
 include::ml-nlp-extract-info.asciidoc[leveloffset=+2]
 include::ml-nlp-lang-ident.asciidoc[leveloffset=+2]
+include::ml-nlp-search-compare.asciidoc[leveloffset=+2]
 include::ml-nlp-apis.asciidoc[leveloffset=+1]
 

--- a/docs/en/stack/ml/nlp/ml-nlp-overview.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-overview.asciidoc
@@ -38,6 +38,4 @@ language of text.
 * _Zero-shot text classification_ performs classification without requiring a
 specialized model.
 
-Search and compare text::
-* _Text embedding_ turns content into vectors, which enables you to compare text
-by using mathematical functions.
+* <<ml-nlp-search-compare>>

--- a/docs/en/stack/ml/nlp/ml-nlp-search-compare.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-search-compare.asciidoc
@@ -2,16 +2,15 @@
 = Search and compare text
 
 :keywords: {ml-init}, {stack}, {nlp}, text embedding
-:description: NLP tasks that search in unstructured text and compare different \
-pieces of text. 
+:description: NLP tasks that allow you to search in unstructured text or compare difference pieces of text.
 
 
 [discrete]
 [[ml-nlp-text-embedding]]
 == Text embedding
 
-Text embedding is a task which produces a mathematical representation of a text 
-called embedding. The {ml} model turns the text into an array of numerical 
+Text embedding is a task which produces a mathematical representation of text 
+called an embedding. The {ml} model turns the text into an array of numerical 
 values (a vector). Pieces of content with similar meaning have similar 
 representation. This means it is possible to determine whether different pieces 
 of text are either semantically similar, different, or even opposite by using a 

--- a/docs/en/stack/ml/nlp/ml-nlp-search-compare.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-search-compare.asciidoc
@@ -3,8 +3,8 @@
 
 :keywords: {ml-init}, {stack}, {nlp}, text embedding
 
-The {stack-ml-features} can generate embeddings, which you can use to search in unstructured text or
-compare different pieces of text.
+The {stack-ml-features} can generate embeddings, which you can use to search in 
+unstructured text or compare different pieces of text.
 
 
 [discrete]
@@ -13,17 +13,17 @@ compare different pieces of text.
 
 Text embedding is a task which produces a mathematical representation of text 
 called an embedding. The {ml} model turns the text into an array of numerical 
-values (also known as a _vector_). Pieces of content with similar meaning have similar 
-representations. This means it is possible to determine whether different pieces 
-of text are either semantically similar, different, or even opposite by using a 
-mathematical similarity function.
+values (also known as a _vector_). Pieces of content with similar meaning have 
+similar representations. This means it is possible to determine whether 
+different pieces of text are either semantically similar, different, or even 
+opposite by using a mathematical similarity function.
 
 This task is responsible for producing only the embedding. When the 
-embedding is created, it can be stored in a {ref}/dense-vector.html[dense_vector] field and used at 
-search time. Then you can apply the similarity function to an embedding 
-representing a query, and create a semantic search capability. For more 
-information on searching with embeddings, refer to 
-{ref}/knn-search.html[k-nearest neighbour (kNN) search].
+embedding is created, it can be stored in a 
+{ref}/dense-vector.html[dense_vector] field and used at search time. For 
+example, you can use these vectors in a 
+{ref}/knn-search.html[k-nearest neighbour (kNN) search] to achieve semantic 
+search capabilities.
 
 The following is an example of producing a text embedding:
 

--- a/docs/en/stack/ml/nlp/ml-nlp-search-compare.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-search-compare.asciidoc
@@ -2,8 +2,9 @@
 = Search and compare text
 
 :keywords: {ml-init}, {stack}, {nlp}, text embedding
-:description: NLP tasks that allow you to search in unstructured text or \
-compare difference pieces of text.
+
+The {stack-ml-features} can generate embeddings, which you can use to search in unstructured text or
+compare different pieces of text.
 
 
 [discrete]
@@ -12,13 +13,13 @@ compare difference pieces of text.
 
 Text embedding is a task which produces a mathematical representation of text 
 called an embedding. The {ml} model turns the text into an array of numerical 
-values (a vector). Pieces of content with similar meaning have similar 
-representation. This means it is possible to determine whether different pieces 
+values (also known as a _vector_). Pieces of content with similar meaning have similar 
+representations. This means it is possible to determine whether different pieces 
 of text are either semantically similar, different, or even opposite by using a 
 mathematical similarity function.
 
-This task is only responsible for producing the embedding alone. When the 
-embedding is created, it can be stored in a `dense_vector` field and used at 
+This task is responsible for producing only the embedding. When the 
+embedding is created, it can be stored in a {ref}/dense-vector.html[dense_vector] field and used at 
 search time. Then you can apply the similarity function to an embedding 
 representing a query, and create a semantic search capability. For more 
 information on searching with embeddings, refer to 

--- a/docs/en/stack/ml/nlp/ml-nlp-search-compare.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-search-compare.asciidoc
@@ -1,0 +1,48 @@
+[[ml-nlp-search-compare]]
+= Search and compare text
+
+:keywords: {ml-init}, {stack}, {nlp}, text embedding
+:description: NLP tasks that search in unstructured text and compare different \
+pieces of text. 
+
+
+[discrete]
+[[ml-nlp-text-embedding]]
+== Text embedding
+
+Text embedding is a task which produces a mathematical representation of a text 
+called embedding. The {ml} model turns the text into an array of numerical 
+values (a vector). Pieces of content with similar meaning have similar 
+representation. This means it is possible to determine whether different pieces 
+of text are either semantically similar, different, or even opposite by using a 
+mathematical similarity function.
+
+This task is only responsible for producing the embedding alone. When the 
+embedding is created, it can be stored in a `dense_vector` field and used at 
+search time. Then you can apply the similarity function to an embedding 
+representing a query, and create a semantic search capability.
+
+The following is an example of producing a text embedding:
+
+[source,js]
+----------------------------------
+...
+{
+    "input": "The quick brown fox jumps over the lazy dog."
+}
+...
+----------------------------------
+// NOTCONSOLE
+
+
+The task returns the following result:
+
+[source,js]
+----------------------------------
+...
+{
+    "results": [0.293478, -0.23845, ..., 1.34589e2, 0.119376]
+}
+...
+----------------------------------
+// NOTCONSOLE

--- a/docs/en/stack/ml/nlp/ml-nlp-search-compare.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-search-compare.asciidoc
@@ -2,7 +2,8 @@
 = Search and compare text
 
 :keywords: {ml-init}, {stack}, {nlp}, text embedding
-:description: NLP tasks that allow you to search in unstructured text or compare difference pieces of text.
+:description: NLP tasks that allow you to search in unstructured text or \
+compare difference pieces of text.
 
 
 [discrete]
@@ -19,7 +20,9 @@ mathematical similarity function.
 This task is only responsible for producing the embedding alone. When the 
 embedding is created, it can be stored in a `dense_vector` field and used at 
 search time. Then you can apply the similarity function to an embedding 
-representing a query, and create a semantic search capability.
+representing a query, and create a semantic search capability. For more 
+information on searching with embeddings, refer to 
+{ref}/knn-search.html[k-nearest neighbour (kNN) search].
 
 The following is an example of producing a text embedding:
 


### PR DESCRIPTION
## Overview

This PR adds the "Search and compare" page to the NLP docs.
The page contains the conceptual docs for the Text embedding task.

### Preview

[Search and compare](https://stack-docs_1914.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-nlp-search-compare.html)