### PR TITLE
[8.0] Drafts Classify text page for NLP docs (#1911)

### DIFF
--- a/docs/en/stack/ml/nlp/index.asciidoc
+++ b/docs/en/stack/ml/nlp/index.asciidoc
@@ -1,7 +1,7 @@
 include::ml-nlp.asciidoc[]
 include::ml-nlp-overview.asciidoc[leveloffset=+1]
 include::ml-nlp-extract-info.asciidoc[leveloffset=+2]
-include::ml-nlp-lang-ident.asciidoc[leveloffset=+2]
+include::ml-nlp-classify-text.asciidoc[leveloffset=+2]
 include::ml-nlp-deploy-models.asciidoc[leveloffset=+1]
 include::ml-nlp-apis.asciidoc[leveloffset=+1]
 

--- a/docs/en/stack/ml/nlp/ml-nlp-classify-text.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-classify-text.asciidoc
@@ -1,0 +1,135 @@
+[[ml-nlp-classify-text]]
+= Classify text
+
+:keywords: {ml-init}, {stack}, {nlp}, {lang-ident}, text classification, \
+zero-shot text classification
+
+:description: NLP tasks that classify input text or determine \
+the language of text. 
+
+These NLP tasks enable you to identify the language of text and classify or label 
+unstructured input text:
+
+* <<ml-nlp-lang-ident>>
+* <<ml-nlp-text-classification>>
+* <<ml-nlp-zero-shot>>
+
+include::ml-nlp-lang-ident.asciidoc[]
+
+
+[discrete]
+[[ml-nlp-text-classification]]
+== Text classification
+
+Text classification assigns the input text to one of multiple classes
+ that best describe the text. The classes used depend 
+on the model and the data set that was used to train it. Based on the
+number of classes, two main types of classification exist: binary
+classification, where the number of classes is exactly two, and
+multi-class classification, where the number of classes is more than
+two.
+
+This task can help you analyze text for markers of positive or negative 
+sentiment or classify text into various topics. For example, you might use a 
+trained model to perform sentiment analysis and determine whether the following 
+text is "POSITIVE" or "NEGATIVE":
+
+[source,js]
+----------------------------------
+...
+{
+    "input_text": "This was the best movie I’ve seen in the last decade!"
+}
+...
+----------------------------------
+// NOTCONSOLE
+
+
+Likewise, you might use a trained model to perform multi-class classification 
+and determine whether the following text is a news topic related to "SPORTS", 
+"BUSINESS", "LOCAL", or "ENTERTAINMENT":
+
+[source,js]
+----------------------------------
+...
+{
+    "input_text": "The Blue Jays played their final game in Toronto last night and came out with a win over the Yankees, highlighting just how far the team has come this season."
+}
+...
+----------------------------------
+// NOTCONSOLE
+
+
+[discrete]
+[[ml-nlp-zero-shot]]
+== Zero-shot text classification
+
+The zero-shot classification task offers the ability to classify text without 
+training a model on a specific set of classes. Instead, you provide the classes 
+when you deploy the model or at inference time. It uses a model trained on a 
+large data set that has gained a general language understanding and asks the 
+model how well the labels you provided fit with your text.
+
+This task enables you to analyze and classify your input text even when you 
+don't have sufficient training data to train a text classification model.
+
+For example, you might want to perform multi-class classification and determine 
+whether a news topic is related to "SPORTS", "BUSINESS", "LOCAL", or 
+"ENTERTAINMENT". However, in this case the model is not trained specifically for 
+news classification; instead, the possible labels are provided together with the 
+input text at inference time:
+
+[source,js]
+----------------------------------
+...
+{
+    "input_text": "The S&P 500 gained a meager 12 points in the day’s trading. Trade volumes remain consistent with those of the past week while investors await word from the Fed about possible rate increases.",
+    "labels": ["SPORTS", "BUSINESS", "LOCAL", "ENTERTAINMENT"]
+}
+...
+----------------------------------
+// NOTCONSOLE
+
+
+The task returns the following result:
+
+[source,js]
+----------------------------------
+...
+{
+    "result": "BUSINESS"
+}
+...
+----------------------------------
+// NOTCONSOLE
+
+
+You can use the same model to perform inference with different classes, such as:
+
+[source,js]
+----------------------------------
+...
+{
+    "input_text": "Hello support team. I’m writing to inquire about the possibility of sending my broadband router in for repairs. The internet is really slow and the router keeps rebooting! It’s a big problem because I’m in the middle of binge-watching The Mandalorian!",
+    "labels": ["urgent", "internet", "phone", "cable", "mobile", "tv"]
+}
+...
+----------------------------------
+// NOTCONSOLE
+
+
+The task returns the following result:
+
+[source,js]
+----------------------------------
+...
+{
+    "result": ["urgent", "internet", "tv"]
+}
+...
+----------------------------------
+// NOTCONSOLE
+
+Since you can adjust the labels while you perform inference, this type of task 
+is exceptionally flexible. If you are consistently using the same labels, 
+however, it might be better to use a fine-tuned text classification model.

--- a/docs/en/stack/ml/nlp/ml-nlp-extract-info.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-extract-info.asciidoc
@@ -21,9 +21,10 @@ organizations, and other miscellaneous entities that are consistently referenced
 by a proper name.
 
 NER is a useful tool to identify key information, add structure and gain 
-insight into your content. It's particularly useful while processing and exploring large collections of text 
-such as news articles, wiki pages or websites. It makes it easier to understand 
-the subject of a text and group similar pieces of content together.
+insight into your content. It's particularly useful while processing and 
+exploring large collections of text such as news articles, wiki pages or 
+websites. It makes it easier to understand the subject of a text and group 
+similar pieces of content together.
 
 In the following example, the short text is analyzed for any named entity and 
 the model extracts not only the individual words that make up the entities, but 

--- a/docs/en/stack/ml/nlp/ml-nlp-lang-ident.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-lang-ident.asciidoc
@@ -1,22 +1,19 @@
+[discrete]
 [[ml-nlp-lang-ident]]
-= {lang-ident-cap}
+== {lang-ident-cap}
 
-:keywords: {ml-init}, {stack}, {dfanalytics}, {lang-ident}
-:description: {lang-ident-cap} is a trained model that you can use to \
-determine the language of text. 
+{lang-ident-cap} enables you to determine the language of text.
 
-{lang-ident-cap} is a trained model that you can use to determine the language
-of text. You can reference the {lang-ident} model in an
+A {lang-ident} model is provided in your cluster, which you can use in an
 {ref}/inference-processor.html[{infer} processor] of an ingest pipeline by 
 using its model ID (`lang_ident_model_1`). The input field name is `text`. If 
 you want to run {lang-ident} on a field with a different name, you must map your 
 field name to `text` in the ingest processor settings.
 
 The longer the text passed into the {lang-ident} model, the more accurately the 
-model can identify the language. It is fairly accurate on short samples 
-(for example, 50 character-long streams) in certain languages, but languages 
-that are similar to each other are harder to identify based on a short 
-character stream.
+model can identify the language. It is fairly accurate on short samples (for 
+example, 50 character-long streams) in certain languages, but languages that are 
+similar to each other are harder to identify based on a short character stream.
 
 {lang-ident-cap} takes into account Unicode boundaries when the feature set is 
 built. If the text has diacritical marks, then the model uses that information 
@@ -28,7 +25,7 @@ Unicode input.
 
 [discrete]
 [[ml-lang-ident-supported-languages]]
-== Supported languages
+=== Supported languages
 
 The table below contains the ISO codes and the English names of the languages 
 that {lang-ident} supports. If a language has a 2-letter `ISO 639-1` code, the 
@@ -81,7 +78,7 @@ script.
 
 [discrete]
 [[ml-lang-ident-example]]
-== Example of {lang-ident}
+=== Example of {lang-ident}
 
 In the following example, we feed the {lang-ident} trained model a short 
 Hungarian text that contains diacritics and a couple of English words. The 
@@ -191,6 +188,6 @@ The request returns the following response:
 
 [discrete]
 [[ml-lang-ident-readings]]
-== Further reading
+=== Further reading
 
 * https://www.elastic.co/blog/multilingual-search-using-language-identification-in-elasticsearch[Multilingual search using language identification in {es}]

--- a/docs/en/stack/ml/nlp/ml-nlp-overview.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-overview.asciidoc
@@ -24,19 +24,11 @@ TorchScript representation for use with {stack} {ml} features.
 
 As in the cases of <<ml-dfa-classification,classification>> and
 <<ml-dfa-regression,regression>>, after you deploy a model to your cluster, you
-can use it to make predictions (also known as _inference_) against incoming data.
-You can perform the following NLP tasks:
+can use it to make predictions (also known as _inference_) against incoming 
+data. You can perform the following NLP operations:
 
-Extract information::
-* <<ml-nlp-ner>> enables you to identify and categorize entities in your text.
-* <<ml-nlp-mask>> enable you to predict missing words in text sequences.
-
-Categorize text::
-* <<ml-nlp-lang-ident,Language identification>> enables you to determine the
-language of text.
-* _Text classification_ enables you to classify input text.
-* _Zero-shot text classification_ performs classification without requiring a
-specialized model.
+* <<ml-nlp-extract-info>>
+* <<ml-nlp-classify-text>> 
 
 Search and compare text::
 * _Text embedding_ turns content into vectors, which enables you to compare text


### PR DESCRIPTION
Backports the following commits to 8.0:
 - Drafts Classify text page for NLP docs (#1911)