### PR TITLE
[DOCS] Add 8.0 ES breaking changes for plugins and SQL JDBC

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -80,8 +80,14 @@ include::{es-repo-dir}/migration/migrate_8_0/packaging-changes.asciidoc[tag=nota
 ==== Painless changes
 include::{es-repo-dir}/migration/migrate_8_0/painless-changes.asciidoc[tag=notable-breaking-changes]
 
+==== Plugin changes
+include::{es-repo-dir}/migration/migrate_8_0/plugin-changes.asciidoc[tag=notable-breaking-changes]
+
 ==== REST API changes
 include::{es-repo-dir}/migration/migrate_8_0/rest-api-changes.asciidoc[tag=notable-breaking-changes]
+
+==== SQL JDBC changes
+include::{es-repo-dir}/migration/migrate_8_0/sql-jdbc-changes.asciidoc[tag=notable-breaking-changes]
 
 ==== System requirement changes
 include::{es-repo-dir}/migration/migrate_8_0/system-req-changes.asciidoc[tag=notable-breaking-changes]


### PR DESCRIPTION
Adds some missing headings to the 8.0 Elasticsearch breaking changes.