### PR TITLE
Use ess-leadin-short shared attr

### DIFF
--- a/docs/en/install-upgrade/installing-stack.asciidoc
+++ b/docs/en/install-upgrade/installing-stack.asciidoc
@@ -28,18 +28,14 @@ on are in place.
 [[install-elastic-stack-for-elastic-cloud]]
 === Installing on {ecloud}
 
-The https://www.elastic.co/cloud/elasticsearch-service[{ess}] on {ecloud} is the
-official hosted {es} and {kib} offering from Elastic. The {ess} is available on
-both AWS and GCP.
+{ess-leadin-short}
 
 Installing on {ecloud} is easy: a single click creates an {es} cluster
 configured to the size you want, with or without high availability. The
 subscription features are always installed, so you automatically have the
-ability to secure and monitor your cluster. {kib} can be enabled on a cluster
-with a click, and a number of popular plugins are readily available.
+ability to secure and monitor your cluster. {kib} is enabled automatically,
+and a number of popular plugins are readily available.
 
 Some {ecloud} features can be used only with a specific subscription. For more
 information, see https://www.elastic.co/pricing/.
 
-You can {ess-trial}[try out the {ess} for free]. For more information, see
-{cloud}/ec-getting-started.html[Getting Started with {ecloud}].


### PR DESCRIPTION
Azure was missing from the list of Elastic Cloud providers, switched existing test to use the shared attributes, and removed closing line as it is covered in the first line of the section.