### PR TITLE
Revert anomaly detection part to chapter

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/ml-ad-overview.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-ad-overview.asciidoc
@@ -6,8 +6,6 @@
 :description: An introduction to {ml} {anomaly-detect}, which analyzes time \
 series data to identify and predict anomalous patterns in your data.
 
-[partintro]
---
 Use {anomaly-detect} to analyze time series data by creating accurate baselines 
 of normal behavior and identifying anomalous patterns in your data set. Data is 
 pulled from {es} for analysis and anomaly results are displayed in {kib} 
@@ -19,4 +17,3 @@ privileges that are required to use {anomaly-detect}.
 * <<ml-api-quickref>>
 * <<anomaly-examples>>
 * <<ml-ad-resources>>
---


### PR DESCRIPTION
The anomaly detection content in the Machine Learning guide is currently in a docbook "part", which means there are some limitations to what can go in the "partintro" on the first page. It gained us extra layers in the navigation, however those are no longer required.  Therefore, this PR reverts to a chapter format instead of a part format.