### PR TITLE
[DOCS] Updates breaking changes in Install Upgrade Guidie

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -31,7 +31,7 @@ Upgrade Assistant provides information about which {dfeeds} need to be updated.
 This list summarizes the most important breaking changes in APM.
 For the complete list, go to {apm-guide-ref}/apm-breaking.html[APM breaking changes].
 
-include::{apm-repo-dir}/apm-breaking.asciidoc[tag=716-bc]
+include::{apm-repo-dir}/apm-breaking.asciidoc[tag=717-bc]
 
 [[beats-breaking-changes]]
 === Beats breaking changes
@@ -42,7 +42,7 @@ include::{apm-repo-dir}/apm-breaking.asciidoc[tag=716-bc]
 This list summarizes the most important breaking changes in Beats.
 For the complete list, go to {beats-ref}/breaking-changes.html[Beats breaking changes].
 
-include::{beats-repo-dir}/release-notes/breaking/breaking-7.16.asciidoc[tag=notable-breaking-changes]
+//include::{beats-repo-dir}/release-notes/breaking/breaking-7.17.asciidoc[tag=notable-breaking-changes]
 
 
 [[elasticsearch-breaking-changes]]
@@ -55,7 +55,7 @@ include::{beats-repo-dir}/release-notes/breaking/breaking-7.16.asciidoc[tag=nota
 This list summarizes the most important breaking changes in {es} {version}. For
 the complete list, go to {ref}/breaking-changes.html[{es} breaking changes].
 
-include::{es-repo-dir}/migration/migrate_7_16.asciidoc[tag=notable-breaking-changes]
+include::{es-repo-dir}/migration/migrate_7_17.asciidoc[tag=notable-breaking-changes]
 
 [[elasticsearch-hadoop-breaking-changes]]
 === {es} Hadoop breaking changes
@@ -73,8 +73,8 @@ No breaking changes.
 <titleabbrev>{kib}</titleabbrev>
 ++++
 
-This list summarizes the most important breaking changes in {kib} {version}. For
-the complete list, go to {kibana-ref}/release-notes-7.16.0.html#breaking-changes-7.16.0[{kib} breaking changes].
+This list summarizes the most important breaking changes in {kib} {version}.
+//For the complete list, go to {kibana-ref}/release-notes-7.16.0.html#breaking-changes-7.16.0[{kib} breaking changes].
 
 include::{kib-repo-dir}/CHANGELOG.asciidoc[tag=notable-breaking-changes]
 


### PR DESCRIPTION
This PR addresses the following broken link in https://github.com/elastic/kibana/pull/123404

> 12:26:47 INFO:build_docs:Bad cross-document links:
12:26:47 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elastic-stack/7.17/kibana-breaking-changes.html contains broken links to:
12:26:47 INFO:build_docs:   - en/kibana/7.17/release-notes-7.16.0.html

It also updates other out-dated references to 7.16 breaking changes.