### PR TITLE
[DOCS] Fix link to Kibana 7.17 release notes

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -74,7 +74,7 @@ No breaking changes.
 ++++
 
 This list summarizes the most important breaking changes in {kib} {version}.
-//For the complete list, go to {kibana-ref}/release-notes-7.16.0.html#breaking-changes-7.16.0[{kib} breaking changes].
+For the complete list, go to {kibana-ref}/release-notes-7.17.0.html#breaking-changes-v7.17.0[{kib} breaking changes].
 
 include::{kib-repo-dir}/CHANGELOG.asciidoc[tag=notable-breaking-changes]
 


### PR DESCRIPTION
This PR must be merged after https://github.com/elastic/kibana/pull/123404, since adds a link in the Installation and Upgrade Guide to the Kibana release notes that are published in that PR.