### PR TITLE
[8.0][DOCS] Restructure Apache job list as table with links (#1963)

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-apache.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-apache.asciidoc
@@ -14,38 +14,38 @@ use fields and data types from the Elastic Common Schema (ECS).
 These {anomaly-jobs} find unusual activity in HTTP access logs.
 
 For more details, see the {dfeed} and job definitions in
-https://github.com/elastic/integrations/blob/{branch}/packages/apache/kibana/ml_module/apache-Logs-ml.json[GitHub].
+https://github.com/elastic/integrations/blob/main/packages/apache/kibana/ml_module/apache-Logs-ml.json[GitHub].
 Note that these jobs are available in {kib} only if data exists that matches the
 query specified in the
-https://github.com/elastic/integrations/blob/{branch}/packages/apache/kibana/ml_module/apache-Logs-ml.json#L11[manifest file].
+https://github.com/elastic/integrations/blob/main/packages/apache/kibana/ml_module/apache-Logs-ml.json#L11[manifest file].
 
 |===
 |Name |Description |Job |Datafeed
 
 |low_request_rate_apache
 |Detects low request rates.
-|https://github.com/elastic/integrations/blob/{branch}/packages/apache/kibana/ml_module/apache-Logs-ml.json#L215[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/{branch}/packages/apache/kibana/ml_module/apache-Logs-ml.json#L370[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/apache/kibana/ml_module/apache-Logs-ml.json#L215[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/apache/kibana/ml_module/apache-Logs-ml.json#L370[image:images/link.svg[A link icon]]
 
 |source_ip_request_rate_apache
 |Detects unusual source IPs - high request rates.
-|https://github.com/elastic/integrations/blob/{branch}/packages/apache/kibana/ml_module/apache-Logs-ml.json#L176[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/{branch}/packages/apache/kibana/ml_module/apache-Logs-ml.json#L349[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/apache/kibana/ml_module/apache-Logs-ml.json#L176[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/apache/kibana/ml_module/apache-Logs-ml.json#L349[image:images/link.svg[A link icon]]
 
 |source_ip_url_count_apache
 |Detects unusual source IPs - high distinct count of URLs.
-|https://github.com/elastic/integrations/blob/{branch}/packages/apache/kibana/ml_module/apache-Logs-ml.json#L136[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/{branch}/packages/apache/kibana/ml_module/apache-Logs-ml.json#L328[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/apache/kibana/ml_module/apache-Logs-ml.json#L136[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/apache/kibana/ml_module/apache-Logs-ml.json#L328[image:images/link.svg[A link icon]]
 
 |status_code_rate_apache
 |Detects unusual status code rates.
-|https://github.com/elastic/integrations/blob/{branch}/packages/apache/kibana/ml_module/apache-Logs-ml.json#L90[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/{branch}/packages/apache/kibana/ml_module/apache-Logs-ml.json#L307[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/apache/kibana/ml_module/apache-Logs-ml.json#L90[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/apache/kibana/ml_module/apache-Logs-ml.json#L307[image:images/link.svg[A link icon]]
 
 |visitor_rate_apache
 |Detects unusual visitor rates.
-|https://github.com/elastic/integrations/blob/{branch}/packages/apache/kibana/ml_module/apache-Logs-ml.json#L47[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/{branch}/packages/apache/kibana/ml_module/apache-Logs-ml.json#L260[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/apache/kibana/ml_module/apache-Logs-ml.json#L47[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/apache/kibana/ml_module/apache-Logs-ml.json#L260[image:images/link.svg[A link icon]]
 |===
 
 [discrete]

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-apache.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-apache.asciidoc
@@ -16,66 +16,37 @@ These {anomaly-jobs} find unusual activity in HTTP access logs.
 For more details, see the {dfeed} and job definitions in
 https://github.com/elastic/integrations/blob/{branch}/packages/apache/kibana/ml_module/apache-Logs-ml.json[GitHub].
 Note that these jobs are available in {kib} only if data exists that matches the
-{dfeed} query.
+query specified in the
+https://github.com/elastic/integrations/blob/{branch}/packages/apache/kibana/ml_module/apache-Logs-ml.json#L11[manifest file].
 
-low_request_rate_apache::
-Detects low request rates.
+|===
+|Name |Description |Job |Datafeed
 
-Job details:::
+|low_request_rate_apache
+|Detects low request rates.
+|https://github.com/elastic/integrations/blob/{branch}/packages/apache/kibana/ml_module/apache-Logs-ml.json#L215[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/{branch}/packages/apache/kibana/ml_module/apache-Logs-ml.json#L370[image:images/link.svg[A link icon]]
 
-* Analyzes request rates (using the <<ml-count,`low_count` function>>).
+|source_ip_request_rate_apache
+|Detects unusual source IPs - high request rates.
+|https://github.com/elastic/integrations/blob/{branch}/packages/apache/kibana/ml_module/apache-Logs-ml.json#L176[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/{branch}/packages/apache/kibana/ml_module/apache-Logs-ml.json#L349[image:images/link.svg[A link icon]]
 
-Required {beats} or {agent} integrations:::
+|source_ip_url_count_apache
+|Detects unusual source IPs - high distinct count of URLs.
+|https://github.com/elastic/integrations/blob/{branch}/packages/apache/kibana/ml_module/apache-Logs-ml.json#L136[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/{branch}/packages/apache/kibana/ml_module/apache-Logs-ml.json#L328[image:images/link.svg[A link icon]]
 
-* Apache integration
+|status_code_rate_apache
+|Detects unusual status code rates.
+|https://github.com/elastic/integrations/blob/{branch}/packages/apache/kibana/ml_module/apache-Logs-ml.json#L90[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/{branch}/packages/apache/kibana/ml_module/apache-Logs-ml.json#L307[image:images/link.svg[A link icon]]
 
-source_ip_request_rate_apache::
-Detects unusual source IPs.
-
-Job details:::
-
-* Analyzes request rates (using the <<ml-count,`high_count` function>>)
-relative to all the source IPs (`over_field_name` is `source.address`).
-
-Required {beats} or {agent} integrations:::
-
-* Apache integration
-
-source_ip_url_count_apache::
-Detects unusual source IPs.
-
-Job details:::
-
-* Analyzes distinct counts of URLs (using the
-<<ml-distinct-count,`high_distinct_count` function>> on the `url.original`
-field) relative to all the source IPs (`over_field_name` is `source.address`).
-
-Required {beats} or {agent} integrations:::
-
-* Apache integration
-
-status_code_rate_apache::
-Detects unusual status code rates.
-
-Job details:::
-
-* Analyzes request rates (using the <<ml-count,`count` function>>) split by
-status code (`partition_field_name` is `http.response.status_code`).
-
-Required {beats} or {agent} integrations:::
-
-* Apache integration
-
-visitor_rate_apache::
-Detects unusual visitor rates.
-
-Job details:::
-
-* Analyzes request rates using the <<ml-nonzero-count,`non_zero_count` function>>.
-
-Required {beats} or {agent} integrations:::
-
-* Apache integration
+|visitor_rate_apache
+|Detects unusual visitor rates.
+|https://github.com/elastic/integrations/blob/{branch}/packages/apache/kibana/ml_module/apache-Logs-ml.json#L47[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/{branch}/packages/apache/kibana/ml_module/apache-Logs-ml.json#L260[image:images/link.svg[A link icon]]
+|===
 
 [discrete]
 [[apache-access-logs-filebeat]]
@@ -92,64 +63,33 @@ These configurations are only available if data exists that matches the
 recognizer query specified in the 
 https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/apache_ecs/manifest.json#L8[manifest file].
 
-low_request_rate_ecs::
-Detects low request rates.
+|===
+|Name |Description |Job |Datafeed
 
-Job details:::
+|low_request_rate_ecs
+|Detects low request rates (ECS).
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/apache_ecs/ml/low_request_rate_ecs.json[image:images/link.svg[A link icon]]
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/apache_ecs/ml/datafeed_low_request_rate_ecs.json[image:images/link.svg[A link icon]]
 
-* Analyzes request rates (using the <<ml-count,`low_count` function>>).
+|source_ip_request_rate_ecs
+|Detects unusual source IPs - high request rates (ECS).
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/apache_ecs/ml/source_ip_request_rate_ecs.json[image:images/link.svg[A link icon]]
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/apache_ecs/ml/datafeed_source_ip_request_rate_ecs.json[image:images/link.svg[A link icon]]
 
-Required {beats} or {agent} integrations:::
+|source_ip_url_count_ecs
+|Detect unusual source IPs - high distinct count of URLs (ECS).
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/apache_ecs/ml/source_ip_url_count_ecs.json[image:images/link.svg[A link icon]]
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/apache_ecs/ml/datafeed_source_ip_url_count_ecs.json[image:images/link.svg[A link icon]] 
 
-* {filebeat}  
+|status_code_rate_ecs
+|Detects unusual status code rates (ECS).
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/apache_ecs/ml/status_code_rate_ecs.json[image:images/link.svg[A link icon]]
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/apache_ecs/ml/datafeed_status_code_rate_ecs.json[image:images/link.svg[A link icon]] 
 
-source_ip_request_rate_ecs::
-Detects unusual source IPs.
+|visitor_rate_ecs
+|Detects unusual visitor rates (ECS).
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/apache_ecs/ml/visitor_rate_ecs.json[image:images/link.svg[A link icon]]
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/apache_ecs/ml/datafeed_visitor_rate_ecs.json[image:images/link.svg[A link icon]]
 
-Job details:::
-
-* Analyzes request rates (using the <<ml-count,`high_count` function>>)
-relative to all the source IPs (`over_field_name` is `source.address`).
-  
-Required {beats} or {agent} integrations:::
-
-* {filebeat}
-
-source_ip_url_count_ecs::
-Detects unusual source IPs.
-
-Job details:::
-
-* Analyzes distinct counts of URLs (using the
-<<ml-distinct-count,`high_distinct_count` function>> on the `url.original`
-field) relative to all the source IPs (`over_field_name` is `source.address`).
-
-Required {beats} or {agent} integrations:::
-
-* {filebeat}
-
-status_code_rate_ecs::
-
-Detects unusual status code rates.
-
-Job details:::
-
-* Analyzes request rates (using the <<ml-count,`count` function>>) split by
-status code (`partition_field_name` is `http.response.status_code`).
-
-Required {beats} or {agent} integrations:::
-
-* {filebeat}
-
-visitor_rate_ecs::
-Detects unusual visitor rates.
-
-Job details:::
-
-* Analyzes request rates using the <<ml-nonzero-count,`non_zero_count` function>>.
-  
-Required {beats} or {agent} integrations:::
-
-* {filebeat}
-
+|===
 // end::apache-jobs[]


### PR DESCRIPTION
Backports https://github.com/elastic/stack-docs/pull/1963

### Preview

https://stack-docs_1965.docs-preview.app.elstc.co/guide/en/machine-learning/8.0/ootb-ml-jobs-apache.html