### PR TITLE
Activate Logstash breaking changes include 8.0

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -135,4 +135,4 @@ This list summarizes the most important breaking changes in {ls} {version}. For
 the complete list, go to
 {logstash-ref}/breaking-changes.html[Logstash breaking changes].
 
-//include::{ls-repo-dir}/static/breaking-changes-80.asciidoc[tag=notable-breaking-changes]
+include::{ls-repo-dir}/static/breaking-changes-80.asciidoc[tag=notable-breaking-changes]


### PR DESCRIPTION
DO NOT MERGE until elastic/logstash#13723 has been merged.

NOTE: Docs CI will fail until then.