### PR TITLE
[8.1][DOCS] Restructure Apache job list as table with links (#1963)

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-apache.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-apache.asciidoc
@@ -14,38 +14,38 @@ use fields and data types from the Elastic Common Schema (ECS).
 These {anomaly-jobs} find unusual activity in HTTP access logs.
 
 For more details, see the {dfeed} and job definitions in
-https://github.com/elastic/integrations/blob/{branch}/packages/apache/kibana/ml_module/apache-Logs-ml.json[GitHub].
+https://github.com/elastic/integrations/blob/main/packages/apache/kibana/ml_module/apache-Logs-ml.json[GitHub].
 Note that these jobs are available in {kib} only if data exists that matches the
 query specified in the
-https://github.com/elastic/integrations/blob/{branch}/packages/apache/kibana/ml_module/apache-Logs-ml.json#L11[manifest file].
+https://github.com/elastic/integrations/blob/main/packages/apache/kibana/ml_module/apache-Logs-ml.json#L11[manifest file].
 
 |===
 |Name |Description |Job |Datafeed
 
 |low_request_rate_apache
 |Detects low request rates.
-|https://github.com/elastic/integrations/blob/{branch}/packages/apache/kibana/ml_module/apache-Logs-ml.json#L215[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/{branch}/packages/apache/kibana/ml_module/apache-Logs-ml.json#L370[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/apache/kibana/ml_module/apache-Logs-ml.json#L215[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/apache/kibana/ml_module/apache-Logs-ml.json#L370[image:images/link.svg[A link icon]]
 
 |source_ip_request_rate_apache
 |Detects unusual source IPs - high request rates.
-|https://github.com/elastic/integrations/blob/{branch}/packages/apache/kibana/ml_module/apache-Logs-ml.json#L176[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/{branch}/packages/apache/kibana/ml_module/apache-Logs-ml.json#L349[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/apache/kibana/ml_module/apache-Logs-ml.json#L176[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/apache/kibana/ml_module/apache-Logs-ml.json#L349[image:images/link.svg[A link icon]]
 
 |source_ip_url_count_apache
 |Detects unusual source IPs - high distinct count of URLs.
-|https://github.com/elastic/integrations/blob/{branch}/packages/apache/kibana/ml_module/apache-Logs-ml.json#L136[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/{branch}/packages/apache/kibana/ml_module/apache-Logs-ml.json#L328[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/apache/kibana/ml_module/apache-Logs-ml.json#L136[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/apache/kibana/ml_module/apache-Logs-ml.json#L328[image:images/link.svg[A link icon]]
 
 |status_code_rate_apache
 |Detects unusual status code rates.
-|https://github.com/elastic/integrations/blob/{branch}/packages/apache/kibana/ml_module/apache-Logs-ml.json#L90[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/{branch}/packages/apache/kibana/ml_module/apache-Logs-ml.json#L307[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/apache/kibana/ml_module/apache-Logs-ml.json#L90[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/apache/kibana/ml_module/apache-Logs-ml.json#L307[image:images/link.svg[A link icon]]
 
 |visitor_rate_apache
 |Detects unusual visitor rates.
-|https://github.com/elastic/integrations/blob/{branch}/packages/apache/kibana/ml_module/apache-Logs-ml.json#L47[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/{branch}/packages/apache/kibana/ml_module/apache-Logs-ml.json#L260[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/apache/kibana/ml_module/apache-Logs-ml.json#L47[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/apache/kibana/ml_module/apache-Logs-ml.json#L260[image:images/link.svg[A link icon]]
 |===
 
 [discrete]


### PR DESCRIPTION
Backports https://github.com/elastic/stack-docs/pull/1963