### PR TITLE
[DOCS] Comment out ES migration guide

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -53,7 +53,7 @@ include::{beats-repo-dir}/release-notes/breaking/breaking-8.0.asciidoc[tag=notab
 This list summarizes the most important breaking changes in {es} {version}. For
 the complete list, go to {ref}/breaking-changes.html[{es} breaking changes].
 
-include::{es-repo-dir}/migration/migrate_8_1.asciidoc[tag=notable-breaking-changes]
+// include::{es-repo-dir}/migration/migrate_8_2.asciidoc[tag=notable-breaking-changes]
 
 [[elasticsearch-hadoop-breaking-changes]]
 === {es} Hadoop breaking changes


### PR DESCRIPTION
Removing this while we get the 8.2 migration guide in place in https://github.com/elastic/elasticsearch/pull/83341