### PR TITLE
fix: minor typos on get-started-stack.asciidoc

### DIFF
--- a/docs/en/getting-started/get-started-stack.asciidoc
+++ b/docs/en/getting-started/get-started-stack.asciidoc
@@ -2,7 +2,7 @@
 == Getting started with the {stack}
 
 Looking for an {stack} ("ELK") guide that shows how to set up the {stack} and 
-get up and running quickly? You're on the right place! First you install the 
+get up and running quickly? You're in the right place! First you install the 
 core products:
 
 * <<install-elasticsearch,{es}>>
@@ -441,7 +441,7 @@ data visualizations, in about 5 minutes.
 In this section, you learn how to run the `system` module to collect metrics
 from the operating system and services running on your server. The system module
 collects system-level metrics, such as CPU usage, memory, file system, disk IO,
-and network IO statistics, as well as top-like statistics for every process
+and network IO statistics, as well as top-line statistics for every process
 running on your system.
 
 *Before you begin*: Verify that {es} and {kib} are running and that {es} is

--- a/docs/en/getting-started/get-started-stack.asciidoc
+++ b/docs/en/getting-started/get-started-stack.asciidoc
@@ -441,7 +441,7 @@ data visualizations, in about 5 minutes.
 In this section, you learn how to run the `system` module to collect metrics
 from the operating system and services running on your server. The system module
 collects system-level metrics, such as CPU usage, memory, file system, disk IO,
-and network IO statistics, as well as top-line statistics for every process
+and network IO statistics, as well as statistics for every process
 running on your system.
 
 *Before you begin*: Verify that {es} and {kib} are running and that {es} is


### PR DESCRIPTION
Nothing dramatic - just two typos.