### PR TITLE
[DOCS] Fix link in Stack Upgrade Guide

### DIFF
--- a/docs/en/install-upgrade/upgrading-elasticsearch.asciidoc
+++ b/docs/en/install-upgrade/upgrading-elasticsearch.asciidoc
@@ -356,6 +356,7 @@ upgraded master.
 === Archived settings
 
 If you upgrade an {es} cluster that uses deprecated cluster or index settings
-that are not used in the target version, they are archived and ignored.
+that are not used in the target version, they are archived. We
+recommend you remove any archived settings after upgrading.
 For more information, see 
 {ref}/archived-settings.html[Archived settings]. 

--- a/docs/en/install-upgrade/upgrading-elasticsearch.asciidoc
+++ b/docs/en/install-upgrade/upgrading-elasticsearch.asciidoc
@@ -358,4 +358,4 @@ upgraded master.
 If you upgrade an {es} cluster that uses deprecated cluster or index settings
 that are not used in the target version, they are archived and ignored.
 For more information, see 
-{ref}/setup-upgrade.html[Archived settings]. 
+{ref}/archived-settings.html[Archived settings]. 


### PR DESCRIPTION
The link from the [Archived settings](https://www.elastic.co/guide/en/elastic-stack/master/upgrading-elasticsearch.html#archived-settings) section of the Stack Upgrade Guide points to the [Elasticsearch Upgrade Guide](https://www.elastic.co/guide/en/elasticsearch/reference/master/setup-upgrade.html). This link should instead point to the child page for [Archived settings](https://www.elastic.co/guide/en/elasticsearch/reference/master/archived-settings.html).

Preview link: https://stack-docs_1986.docs-preview.app.elstc.co/guide/en/elastic-stack/master/upgrading-elasticsearch.html#archived-settings