### PR TITLE
[8.1] [DOCS] Fix link in Stack Upgrade Guide (#1986)

### DIFF
--- a/docs/en/install-upgrade/upgrading-elasticsearch.asciidoc
+++ b/docs/en/install-upgrade/upgrading-elasticsearch.asciidoc
@@ -356,6 +356,7 @@ upgraded master.
 === Archived settings
 
 If you upgrade an {es} cluster that uses deprecated cluster or index settings
-that are not used in the target version, they are archived and ignored.
+that are not used in the target version, they are archived. We
+recommend you remove any archived settings after upgrading.
 For more information, see 
-{ref}/setup-upgrade.html[Archived settings]. 
+{ref}/archived-settings.html[Archived settings]. 


### PR DESCRIPTION
`8.1` backport for #1986