### PR TITLE
[DOCS] Link to the 7.17 upgrade assistant docs

### DIFF
--- a/docs/en/glossary/glossary.asciidoc
+++ b/docs/en/glossary/glossary.asciidoc
@@ -1260,7 +1260,7 @@ aggregations to display complex data. See {kibana-ref}/dashboard.html[TSVB].
 A tool that helps you prepare for an upgrade to the next major version of {es}.
 The assistant identifies the deprecated settings in your cluster and indices and
 guides you through resolving issues, including reindexing. See
-{kibana-ref}/upgrade-assistant.html[Upgrade Assistant].
+{kibana-ref-all}/{prev-major-last}/upgrade-assistant.html[Upgrade Assistant].
 //Source: Kibana
 
 [[glossary-uptime]] Uptime::

--- a/docs/en/install-upgrade/upgrading-stack-cloud.asciidoc
+++ b/docs/en/install-upgrade/upgrading-stack-cloud.asciidoc
@@ -22,7 +22,7 @@ and test against the new version before upgrading your production deployment.
 //To learn more about the upgrade process on Elastic Cloud, see {cloud}/ec-upgrade-deployment.html[Upgrade versions].
 
 Upgrade Assistant::
-Prior to upgrading, Elastic Cloud checks the deprecation API to retrieve information about the cluster, node, and index-level settings that need to be removed or changed. If there are any issues that would prevent a successful upgrade, the upgrade is blocked. Use the {kibana-ref}/upgrade-assistant.html[Upgrade Assistant] in {prev-major-last} to identify and resolve issues and reindex any indices created before 7.0. 
+Prior to upgrading, Elastic Cloud checks the deprecation API to retrieve information about the cluster, node, and index-level settings that need to be removed or changed. If there are any issues that would prevent a successful upgrade, the upgrade is blocked. Use the {kibana-ref-all}/{prev-major-last}/upgrade-assistant.html[Upgrade Assistant] in {prev-major-last} to identify and resolve issues and reindex any indices created before 7.0. 
 
 Snapshots::
 To keep your data safe during the upgrade process, a snapshot is taken automatically 

--- a/docs/en/install-upgrade/upgrading-stack.asciidoc
+++ b/docs/en/install-upgrade/upgrading-stack.asciidoc
@@ -29,7 +29,7 @@ You can view your remote clusters from **Stack Management > Remote Clusters**.
 [[prepare-to-upgrade]]
 === Prepare to upgrade
 
-. Use the {kibana-ref}/upgrade-assistant.html[Upgrade Assistant] 
+. Use the {kibana-ref-all}/{prev-major-last}/upgrade-assistant.html[Upgrade Assistant] 
 to prepare for your upgrade from {prev-major-last} to {version}.
 The **Upgrade Assistant** identifies deprecated settings and guides
 you through resolving issues and reindexing indices created before 7.0.


### PR DESCRIPTION
The 8.0 upgrade assistant is only available in 7.17. This updates our docs to link to the 7.17 version of the related Kibana docs page.