### PR TITLE
[DOCS] Restructures log jobs in table

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-logs-ui.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-logs-ui.asciidoc
@@ -2,8 +2,9 @@
 = Logs {anomaly-detect} configurations
 
 These {anomaly-jobs} appear by default in the
-{observability-guide}/monitor-logs.html[{logs-app}] in {kib}. For more details, 
-see {observability-guide}/categorize-logs.html[Categorize log entries] and
+{observability-guide}/monitor-logs.html[{logs-app}] in {kib}. For more
+information about their usage, refer to
+{observability-guide}/categorize-logs.html[Categorize log entries] and
 {observability-guide}/inspect-log-anomalies.html[Inspect log anomalies].
 
 // tag::logs-jobs[]

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-logs-ui.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-logs-ui.asciidoc
@@ -1,22 +1,42 @@
 ["appendix",role="exclude",id="ootb-ml-jobs-logs-ui"]
 = Logs {anomaly-detect} configurations
 
-// tag::logs-jobs[]
 These {anomaly-jobs} appear by default in the
 {observability-guide}/monitor-logs.html[{logs-app}] in {kib}. For more details, 
-see the {dfeed} and job definitions in the `logs_ui_*` folders in
-https://github.com/elastic/kibana/tree/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules[GitHub].
+see {observability-guide}/categorize-logs.html[Categorize log entries] and
+{observability-guide}/inspect-log-anomalies.html[Inspect log anomalies].
 
-log_entry_categories_count::
+// tag::logs-jobs[]
+[discrete]
+[[logs-ui-analysis]]
+== Log analysis
 
-* For log entry categories via the Logs UI.
-* Models the occurrences of log events.
-* Detects anomalies in the count of log entries by category.
+Detect anomalies in log entries via the Logs UI.
 
-log_entry_rate::
+|===
+|Name |Description |Job |Datafeed
 
-* For log entries via the Logs UI.
-* Models ingestion rates. 
-* Detects anomalies in the log entry ingestion rate.
-  
+|log_entry_rate
+|Detects anomalies in the log entry ingestion rate
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/logs_ui_analysis/ml/log_entry_rate.json[image:images/link.svg[A link icon]]
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/logs_ui_analysis/ml/datafeed_log_entry_rate.json[image:images/link.svg[A link icon]]
+
+|===
+
+[discrete]
+[[logs-ui-categories]]
+== Log entry categories
+
+Detect anomalies in count of log entries by category.
+
+|===
+|Name |Description |Job |Datafeed
+
+|log_entry_categories_count
+|Detects anomalies in count of log entries by category
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/logs_ui_categories/ml/log_entry_categories_count.json[image:images/link.svg[A link icon]]
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/logs_ui_categories/ml/datafeed_log_entry_categories_count.json[image:images/link.svg[A link icon]]
+
+|===
+
 // end::logs-jobs[]


### PR DESCRIPTION
This PR updates the content in https://www.elastic.co/guide/en/machine-learning/master/ootb-ml-jobs-logs-ui.html to use tables instead of description lists, to link to the appropriate configuration files, and to link to the corresponding pages in the Observability Guide.