### PR TITLE
[DOCS] Restructures Metrics jobs in table

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-metrics-ui.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-metrics-ui.asciidoc
@@ -1,56 +1,62 @@
 ["appendix",role="exclude",id="ootb-ml-jobs-metrics-ui"]
 = Metrics {anomaly-detect} configurations
 
-// tag::metrics-jobs[]
 These {anomaly-jobs} can be created in the
-{observability-guide}/analyze-metrics.html[{metrics-app}] in {kib}.
+{observability-guide}/analyze-metrics.html[{metrics-app}] in {kib}. For more
+information about their usage, refer to
+{observability-guide}/inspect-metric-anomalies.html[Inspect metric anomalies].
 
-The jobs below detect anomalous memory and network behavior on hosts and 
-Kubernetes pods. For more details, see the {dfeed} and job definitions in the 
-`metrics_ui_*` folders in 
-https://github.com/elastic/kibana/tree/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules[GitHub].
+// tag::metrics-jobs[]
+[discrete]
+[[metrics-ui-hosts]]
+== Metrics hosts
 
+Detect anomalous memory and network behavior on hosts.
 
-hosts_memory_usage::
+|===
+|Name |Description |Job |Datafeed
 
-* For memory usage data about hosts in the {metrics-app}.
-* Models system memory usage.
-* Detects unusual increases in memory usage across hosts.
+|hosts_memory_usage
+|Identify unusual spikes in memory usage across hosts.
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/metrics_ui_hosts/ml/hosts_memory_usage.json[image:images/link.svg[A link icon]]
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/metrics_ui_hosts/ml/datafeed_hosts_memory_usage.json[image:images/link.svg[A link icon]]
 
+|hosts_network_in
+|Identify unusual spikes in inbound traffic across hosts.
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/metrics_ui_hosts/ml/hosts_network_in.json[image:images/link.svg[A link icon]]
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/metrics_ui_hosts/ml/datafeed_hosts_network_in.json[image:images/link.svg[A link icon]]
 
-hosts_network_in::
+|hosts_network_out
+|Identify unusual spikes in outbound traffic across hosts.
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/metrics_ui_hosts/ml/hosts_network_out.json[image:images/link.svg[A link icon]]
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/metrics_ui_hosts/ml/datafeed_hosts_network_out.json[image:images/link.svg[A link icon]]
 
-* For network traffic across hosts in the {metrics-app}.
-* Models inbound network traffic.
-* Detects unusually high inbound traffic across hosts.
+|===
 
+[discrete]
+[[metrics-ui-k8s]]
+== Metrics Kubernetes
 
-hosts_network_out::
+Detect anomalous memory and network behavior on Kubernetes pods.
 
-* For network traffic across hosts in the {metrics-app}. 
-* Models outbound network traffic.
-* Detects unusually high outbound traffic across hosts.
+|===
+|Name |Description |Job |Datafeed
 
+|k8s_memory_usage
+|Identify unusual spikes in memory usage across Kubernetes pods.
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/metrics_ui_k8s/ml/k8s_memory_usage.json[image:images/link.svg[A link icon]]
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/metrics_ui_k8s/ml/datafeed_k8s_memory_usage.json[image:images/link.svg[A link icon]]
 
-k8s_memory_usage::
+|k8s_network_in
+|Identify unusual spikes in inbound traffic across Kubernetes pods.
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/metrics_ui_k8s/ml/k8s_network_in.json[image:images/link.svg[A link icon]]
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/metrics_ui_k8s/ml/datafeed_k8s_network_in.json[image:images/link.svg[A link icon]]
 
-* For memory usage data about Kubernetes pods in the {metrics-app}.
-* Models system memory usage.
-* Detects unusual increases in memory usage across Kubernetes pods.
+|k8s_network_out
+|Identify unusual spikes in outbound traffic across Kubernetes pods.
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/metrics_ui_k8s/ml/k8s_network_out.json[image:images/link.svg[A link icon]]
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/metrics_ui_k8s/ml/datafeed_k8s_network_out.json[image:images/link.svg[A link icon]]
 
+|===
 
-k8s_network_in::
-
-* For network traffic across Kubernetes pods in the {metrics-app}. 
-* Models inbound network traffic.
-* Detects unusually high inbound traffic across Kubernetes pods.
-
-
-k8s_network_out::
-
-* For network traffic across Kubernetes pods in the {metrics-app}. 
-* Models outbound network traffic.
-* Detects unusually high outbound traffic across Kubernetes pods.
-
-  
 // end::metrics-jobs[]


### PR DESCRIPTION
This PR updates the content in https://www.elastic.co/guide/en/machine-learning/master/ootb-ml-jobs-metrics-ui.html to use tables instead of description lists and to link to the appropriate configuration files.