### PR TITLE
Update ootb-ml-jobs-siem.asciidoc

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-siem.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-siem.asciidoc
@@ -1154,7 +1154,9 @@ Required ECS fields:::
 
 * `destination.as.organization.name`
 * `destination.geo.country_name`
+* `destination.ip`
 * `event.category`
+* `source.ip`
 
 // end::security-network-jobs[]
 

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-siem.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-siem.asciidoc
@@ -1152,6 +1152,7 @@ Required {beats} or {agent} integrations:::
 
 Required ECS fields:::
 
+* `destination.as.organization.name`
 * `destination.geo.country_name`
 * `event.category`
 


### PR DESCRIPTION
`destination.as.organization.name` ECS field seems bo be also required for `rare_destination_country` prebuilt ML job becasue a user have experienced to fail to start the prebuilt ML job with the following 400 error.

```
{
"error": {
"root_cause": [
{
"type": "status_exception",
"reason": "[datafeed-rare_destination_country] cannot retrieve field [destination.as.organization.name] because it has no mappings"
}
],
"type": "status_exception",
"reason": "[datafeed-rare_destination_country] cannot retrieve field [destination.as.organization.name] because it has no mappings"
},
"status": 400
}
```

Please double check if this PR is approperiate. Thanks much.