### PR TITLE
[8.1] Remove Homebrew instructions from getting started docs (#2021)

### DIFF
--- a/docs/en/getting-started/get-started-stack.asciidoc
+++ b/docs/en/getting-started/get-started-stack.asciidoc
@@ -55,7 +55,7 @@ work with your system:
 
 * <<deb, deb>> for Debian/Ubuntu
 * <<rpm, rpm>> for Redhat/Centos/Fedora
-* <<mac, mac>> or <<brew, brew>> for OS X
+* <<mac, mac>> for OS X
 * <<linux, linux>> for Linux
 * <<win, win>> for Windows
 
@@ -132,25 +132,6 @@ curl -L -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{e
 tar -xzvf elasticsearch-{elasticsearch_version}-darwin-x86_64.tar.gz
 cd elasticsearch-{elasticsearch_version}
 ./bin/elasticsearch
-----------------------------------------------------------------------
-
-endif::[]
-
-[[brew]]*brew:*
-
-ifeval::["{release-state}"=="unreleased"]
-
-Version {version} of {es} has not yet been released.
-
-endif::[]
-
-ifeval::["{release-state}"!="unreleased"]
-
-["source","sh",subs="attributes,callouts"]
-----------------------------------------------------------------------
-brew tap elastic/tap
-brew install elastic/tap/elasticsearch-full
-elasticsearch
 ----------------------------------------------------------------------
 
 endif::[]
@@ -291,7 +272,7 @@ To download and install {kib}, open a terminal window and use the commands that
 work with your system:
 
 * <<deb-rpm-linux,deb>> for Debian/Ubuntu/Redhat/Centos/Fedora
-* <<kibana-mac,mac>> or <<kibana-brew, brew>> for OS X
+* <<kibana-mac,mac>> for OS X
 * <<kibana-win,win>> for Windows
 
 If this is the first time you're starting {kib}, this command generates a 
@@ -351,25 +332,6 @@ curl -L -O https://artifacts.elastic.co/downloads/kibana/kibana-{kibana_version}
 tar xzvf kibana-{kibana_version}-darwin-x86_64.tar.gz
 cd kibana-{kibana_version}-darwin-x86_64/
 ./bin/kibana
-----------------------------------------------------------------------
-
-endif::[]
-
-[[kibana-brew]]*brew:*
-
-ifeval::["{release-state}"=="unreleased"]
-
-Version {version} of {kib} has not yet been released.
-
-endif::[]
-
-ifeval::["{release-state}"!="unreleased"]
-
-["source","sh",subs="attributes"]
-----------------------------------------------------------------------
-brew tap elastic/tap
-brew install elastic/tap/kibana-full
-kibana
 ----------------------------------------------------------------------
 
 endif::[]
@@ -508,24 +470,6 @@ tar xzvf metricbeat-{version}-darwin-x86_64.tar.gz
 
 endif::[]
 
-*brew:*
-
-ifeval::["{release-state}"=="unreleased"]
-
-Version {version} of {metricbeat} has not yet been released.
-
-endif::[]
-
-ifeval::["{release-state}"!="unreleased"]
-
-["source","sh",subs="attributes"]
-----------------------------------------------------------------------
-brew tap elastic/tap
-brew install elastic/tap/metricbeat-full
-----------------------------------------------------------------------
-
-endif::[]
-
 *linux:*
 
 ifeval::["{release-state}"=="unreleased"]
@@ -617,13 +561,6 @@ sudo metricbeat modules enable system
 ./metricbeat modules enable system
 ----
 +
-*brew:*
-+
-[source,yaml]
-----
-metricbeat modules enable system
-----
-+
 *win:*
 +
 [source,yaml]
@@ -645,13 +582,6 @@ sudo metricbeat setup -e
 [source,yaml]
 ----
 ./metricbeat setup -e
-----
-+
-*brew:*
-+
-[source,yaml]
-----
-metricbeat setup -e
 ----
 +
 *win:*
@@ -679,13 +609,6 @@ sudo service metricbeat start
 [source,yaml]
 ----
 ./metricbeat -e
-----
-+
-*brew:*
-+
-[source,yaml]
-----
-metricbeat -e
 ----
 +
 *win:*


### PR DESCRIPTION
Backports the following commits to 8.1:
 - Remove Homebrew instructions from getting started docs (#2021)