### PR TITLE
[DOCS] Re-add anchor for stack upgrade order

### DIFF
--- a/docs/en/install-upgrade/upgrading-stack.asciidoc
+++ b/docs/en/install-upgrade/upgrading-stack.asciidoc
@@ -67,6 +67,7 @@ IMPORTANT: You cannot downgrade {es} nodes after upgrading.
 If you cannot complete the upgrade process, 
 you will need to restore from the snapshot.
 
+[[upgrade-order-elastic-stack]]
 Refer to the upgrade instructions for your environment:
 
 * <<upgrade-elastic-stack-for-elastic-cloud,Upgrade on Elastic Cloud>>


### PR DESCRIPTION
Re-adds an anchor removed by https://github.com/elastic/stack-docs/pull/1970. This will create a broken link when 8.0 is released.

I'll open a separate PR to remove the anchor once I fix any outstanding references.