### PR TITLE
[DOCS] Remove anchor from upgrade docs

### DIFF
--- a/docs/en/install-upgrade/upgrading-stack.asciidoc
+++ b/docs/en/install-upgrade/upgrading-stack.asciidoc
@@ -67,7 +67,6 @@ IMPORTANT: You cannot downgrade {es} nodes after upgrading.
 If you cannot complete the upgrade process, 
 you will need to restore from the snapshot.
 
-[[upgrade-order-elastic-stack]]
 Refer to the upgrade instructions for your environment:
 
 * <<upgrade-elastic-stack-for-elastic-cloud,Upgrade on Elastic Cloud>>


### PR DESCRIPTION
#2024 re-added an anchor to fix some broken links for the 8.0 release. Now that we've updated links using the anchor, we can remove it.

Depends on https://github.com/elastic/cloud-on-k8s/pull/5350