### PR TITLE
[DOCS] Fix CCS cluster compatibility

### DIFF
--- a/docs/en/install-upgrade/upgrading-stack.asciidoc
+++ b/docs/en/install-upgrade/upgrading-stack.asciidoc
@@ -16,7 +16,7 @@ to give you flexibility in scheduling the upgrade.
 .Remote cluster compatibility
 [NOTE]
 ====
-If you use {ccs}, note that {version} can only search remote clusters running 7.17 or later. 
+If you use {ccs}, note that {version} can only search remote clusters running the previous minor version or later. 
 For more information, see {ref}/modules-cross-cluster-search.html[Searching across clusters].
 
 If you use {ccr}, a cluster that contains follower indices must run the same or newer version as the remote cluster. 


### PR DESCRIPTION
Updates the upgrade guide to clarify BWC for CCS. Based on [the CCS docs](https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-cross-cluster-search.html#ccs-supported-configurations), you can only search back one minor version.  This means a local 8.1 cluster can only search remote 8.0+ clusters.

Relates to https://github.com/elastic/kibana/pull/125138 and https://github.com/elastic/stack-docs/pull/1970