### PR TITLE
[8.0] Fix CCS cluster compatibility (#2028)

### DIFF
--- a/docs/en/install-upgrade/upgrading-stack.asciidoc
+++ b/docs/en/install-upgrade/upgrading-stack.asciidoc
@@ -16,7 +16,7 @@ to give you flexibility in scheduling the upgrade.
 .Remote cluster compatibility
 [NOTE]
 ====
-If you use {ccs}, note that {version} can only search remote clusters running 7.17 or later. 
+If you use {ccs}, note that {version} can only search remote clusters running the previous minor version or later. 
 For more information, see {ref}/modules-cross-cluster-search.html[Searching across clusters].
 
 If you use {ccr}, a cluster that contains follower indices must run the same or newer version as the remote cluster. 


### PR DESCRIPTION
# Backport

This is an automatic backport to `8.0` of:
 - #2028

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)