### PR TITLE
[DOCS] Omit link to logging config changes

### DIFF
--- a/docs/en/install-upgrade/upgrading-kibana.asciidoc
+++ b/docs/en/install-upgrade/upgrading-kibana.asciidoc
@@ -47,4 +47,5 @@ IMPORTANT: If you use {monitor-features}, you must re-use the data directory whe
 . Start {kib}.
 
 IMPORTANT: {kib} has a new logging system in 8.0 and the log formats have changed. 
-For additional information, see {kibana-ref}/_upgrading_multiple_kibana_instances.html#logging-config-changes[configuring logging].
+
+//For additional information, see {kibana-ref}/_upgrading_multiple_kibana_instances.html#logging-config-changes[configuring logging].


### PR DESCRIPTION
Comments out link to {kibana-ref}/_upgrading_multiple_kibana_instances.html#logging-config-changes[configuring logging] to avert broken links.