### PR TITLE
[main] [DOCS] Remove anchor from upgrade docs (#2027)

### DIFF
--- a/docs/en/install-upgrade/upgrading-stack.asciidoc
+++ b/docs/en/install-upgrade/upgrading-stack.asciidoc
@@ -67,7 +67,6 @@ IMPORTANT: You cannot downgrade {es} nodes after upgrading.
 If you cannot complete the upgrade process, 
 you will need to restore from the snapshot.
 
-[[upgrade-order-elastic-stack]]
 Refer to the upgrade instructions for your environment:
 
 * <<upgrade-elastic-stack-for-elastic-cloud,Upgrade on Elastic Cloud>>


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.0` to `main`:
 - [[DOCS] Remove anchor from upgrade docs (#2027)](https://github.com/elastic/stack-docs/pull/2027)

<!--- Backport version: 7.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)