### PR TITLE
[8.1][DOCS] Add list of supported NLP model architectures (#1989)

### DIFF
--- a/docs/en/stack/ml/nlp/index.asciidoc
+++ b/docs/en/stack/ml/nlp/index.asciidoc
@@ -6,4 +6,6 @@ include::ml-nlp-search-compare.asciidoc[leveloffset=+2]
 include::ml-nlp-deploy-models.asciidoc[leveloffset=+1]
 include::ml-nlp-inference.asciidoc[leveloffset=+1]
 include::ml-nlp-apis.asciidoc[leveloffset=+1]
+include::ml-nlp-resources.asciidoc[leveloffset=+1]
+include::ml-nlp-model-ref.asciidoc[leveloffset=+2]
 

--- a/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
@@ -21,16 +21,14 @@ models.
 
 Per the <<ml-nlp-overview>>, there are multiple ways that you can use NLP
 features within the {stack}. After you determine which type of NLP task you want
-to perform, you must choose an appropriate trained model.
-
-IMPORTANT: The {stack-ml-features} support transformer models that conform to
-the standard BERT model interface and use the WordPiece tokenization algorithm.
+to perform, you must choose an appropriate trained model. 
 
 The simplest method is to use a model that has already been fine-tuned for the
 type of analysis that you want to perform. For example, there are models and
 data sets available for specific NLP tasks on
 https://huggingface.co/models[Hugging Face]. These instructions assume you're
-using one of those models and do not describe how to create new models.
+using one of those models and do not describe how to create new models. For the
+current list of supported model architectures, refer to <<ml-nlp-model-ref>>.
 
 If you choose to perform language identification by using
 the `lang_ident_model_1` that is provided in the cluster, no further steps are

--- a/docs/en/stack/ml/nlp/ml-nlp-model-ref.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-model-ref.asciidoc
@@ -1,0 +1,86 @@
+[[ml-nlp-model-ref]]
+= Third party NLP models
+
+The {stack-ml-features} support transformer models that conform to the standard
+BERT model interface and use the WordPiece tokenization algorithm.
+
+The current list of supported architectures is:
+
+* BERT
+* DPR bi-encoders
+* DistilBERT
+* ELECTRA
+* MobileBERT
+* RetriBERT
+* MPNet
+* SentenceTransformers bi-encoders with the above transformer architectures
+
+In general, any trained model that has a supported architecture is deployable in
+{es} by using eland. However, it is not possible to test every third party
+model. The following lists are therefore provided for informational purposes
+only and may not be current. Elastic makes no warranty or assurance that the
+{ml-features} will continue to interoperate with these third party models in the
+way described, or at all.
+
+These models are listed by NLP task; for more information about those tasks,
+refer to <<ml-nlp-overview>>.
+
+[discrete]
+[[ml-nlp-model-ref-mask]]
+== Third party fill-mask models
+
+* https://huggingface.co/bert-base-uncased
+* https://huggingface.co/microsoft/mpnet-base
+
+[discrete]
+[[ml-nlp-model-ref-ner]]
+== Third party named entity recognition models
+
+* https://huggingface.co/dslim/bert-base-NER
+* https://huggingface.co/elastic/distilbert-base-uncased-finetuned-conll03-english
+* https://huggingface.co/elastic/distilbert-base-cased-finetuned-conll03-english
+
+[discrete]
+[[ml-nlp-model-ref-text-embedding]]
+== Third party text embedding models
+
+Using `SentenceTransformerWrapper`:
+
+* https://huggingface.co/sentence-transformers/all-MiniLM-L12-v2
+* https://huggingface.co/sentence-transformers/LaBSE
+* https://huggingface.co/sentence-transformers/msmarco-distilbert-base-tas-b 
+* https://huggingface.co/sentence-transformers/msmarco-MiniLM-L-12-v3
+* https://huggingface.co/sentence-transformers/nli-bert-base-cls-pooling
+* https://huggingface.co/sentence-transformers/bert-base-nli-cls-token
+* https://huggingface.co/sentence-transformers/facebook-dpr-ctx_encoder-multiset-base
+* https://huggingface.co/sentence-transformers/facebook-dpr-question_encoder-single-nq-base
+* https://huggingface.co/sentence-transformers/paraphrase-mpnet-base-v2
+
+Using `DPREncoderWrapper`:
+
+* https://huggingface.co/facebook/dpr-ctx_encoder-single-nq-base
+* https://huggingface.co/facebook/dpr-question_encoder-single-nq-base
+* https://huggingface.co/facebook/dpr-ctx_encoder-multiset-base
+* https://huggingface.co/facebook/dpr-question_encoder-multiset-base
+* https://huggingface.co/castorini/ance-dpr-context-multi
+* https://huggingface.co/castorini/ance-dpr-question-multi
+* https://huggingface.co/castorini/bpr-nq-ctx-encoder
+* https://huggingface.co/castorini/bpr-nq-question-encoder
+
+[discrete]
+[[ml-nlp-model-ref-text-classification]]
+=== Third party text classification models
+
+* https://huggingface.co/distilbert-base-uncased-finetuned-sst-2-english
+* https://huggingface.co/bhadresh-savani/distilbert-base-uncased-emotion
+* https://huggingface.co/Hate-speech-CNERG/dehatebert-mono-english
+* https://huggingface.co/ProsusAI/finbert
+* https://huggingface.co/nateraw/bert-base-uncased-emotion
+
+[discrete]
+[[ml-nlp-model-ref-zero-shot]]
+== Third party zero-shot text classification models
+
+* https://huggingface.co/typeform/distilbert-base-uncased-mnli
+* https://huggingface.co/typeform/mobilebert-uncased-mnli
+* https://huggingface.co/typeform/squeezebert-mnli

--- a/docs/en/stack/ml/nlp/ml-nlp-overview.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-overview.asciidoc
@@ -16,7 +16,8 @@ that time, it has become the inspiration for most of today’s modern NLP
 techniques. The {stack} {ml} features are structured around BERT and
 transformer models. These features support BERT’s tokenization scheme (called
 WordPiece) and transformer models that conform to the standard BERT model
-interface.
+interface. For the current list of supported architectures, refer to
+<<ml-nlp-model-ref>>.
 
 To incorporate transformer models and make predictions, {es} uses libtorch,
 which is an underlying native library for PyTorch. Trained models must be in a

--- a/docs/en/stack/ml/nlp/ml-nlp-resources.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-resources.asciidoc
@@ -1,0 +1,6 @@
+[[ml-nlp-resources]]
+= Resources
+
+This section contains further resources for using {nlp}.
+
+* <<ml-nlp-model-ref>>


### PR DESCRIPTION
Backports https://github.com/elastic/stack-docs/pull/1989