### PR TITLE
Add mergify configuration file for stack-docs

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,95 @@
+pull_request_rules:
+  - name: ask to resolve conflict
+    conditions:
+      - -merged
+      - -closed
+      - conflict
+    actions:
+        comment:
+          message: |
+            This pull request is now in conflict. Could you fix it @{{author}}? 🙏
+            To fixup this pull request, you can check out it locally. See documentation: https://help.github.com/articles/checking-out-pull-requests-locally/
+            ```
+            git fetch <remote-repo>
+            git checkout -b {{head}} <remote-repo>/{{head}}
+            git merge <remote-repo>/{{base}}
+            git push <remote-repo> {{head}}
+            ```
+  - name: backport patches to 8.1 branch
+    conditions:
+      - merged
+      - base=main
+      - label=backport-8.1
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        branches:
+          - "8.1"
+        title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"
+        labels:
+          - backport
+  - name: backport patches to 8.0 branch
+    conditions:
+      - merged
+      - base=main
+      - label=backport-8.0
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        branches:
+          - "8.0"
+        title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"
+        labels:
+          - backport
+  - name: backport patches to 7.17 branch
+    conditions:
+      - merged
+      - base=main
+      - label=backport-7.17
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        branches:
+          - "7.17"
+        title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"
+        labels:
+          - backport
+  - name: notify the backport policy
+    conditions:
+      - -label~=^backport
+      - base=main
+    actions:
+      comment:
+        message: |
+          This pull request does not have a backport label. Could you fix it @{{author}}? 🙏
+          To fixup this pull request, you need to add the backport labels for the needed
+          branches, such as:
+          * `backport-/d./d` is the label to automatically backport to the `/d./d` branch. `/d` is the digit
+          **NOTE**: `backport-skip` has been added to this pull request.
+      label:
+        add:
+          - backport-skip
+  - name: remove backport-skip label
+    conditions:
+      - label~=^backport-\d
+      - -merged
+      - -closed
+    actions:
+      label:
+        remove:
+          - backport-skip
+  - name: notify the backport has not been merged yet
+    conditions:
+      - -merged
+      - -closed
+      - author=mergify[bot]
+      - "#check-success>0"
+      - schedule=Mon-Mon 06:00-10:00[Europe/Paris]
+      - "#assignee>=1"
+    actions:
+      comment:
+        message: |
+          This pull request has not been merged yet. Could you please review and merge it @{{ assignee | join(', @') }}? 🙏

--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ Within this repo, the `/docs/en/` directory is structured as follows:
 | __install-upgrade__ | Contains the source files for the [Elastic Installation and Upgrade Guide](https://www.elastic.co/guide/en/elastic-stack/current/index.html).|
 | __stack/ml__ | Contains the source files for the [Machine Learning Guide](https://www.elastic.co/guide/en/machine-learning/current/index.html).|
 
+## Backporting
+
+In general, we backport documentation changes only to [live stack versions](https://github.com/elastic/docs/blob/master/conf.yaml#L74).
+
+To automatically create backport PRs, add the appropriate backport labels (such as `backport-8.1`).
+
+If no backport PRs are required or you want to backport manually, add the `backport-skip` label. We recommend using the [backport tool](https://github.com/sqren/backport) to easily open backport PRs. If you need help, ping __[@mlr-docs](https://github.com/orgs/elastic/teams/mlr-docs)__ and we'd be happy to help.
+
 ## Build
 
 To build the docs:


### PR DESCRIPTION
The security and observability repos use Mergify to automate backports. This PR copies the method used in observability-docs (https://github.com/elastic/observability-docs/blob/main/.mergify.yml), since it uses new, backport-specific labels (backport-x.y), rather than changing/overloading the behaviour of existing labels.

Before we merge this PR, we must create backport labels that meet the conditions, as seen in https://github.com/elastic/observability-docs/labels?q=backport