### PR TITLE
[DOCS] Add Elastic Security highlights to Installation and Upgrade Guide

### DIFF
--- a/docs/en/install-upgrade/highlights.asciidoc
+++ b/docs/en/install-upgrade/highlights.asciidoc
@@ -7,6 +7,7 @@ highlights notable new features and enhancements in {minor-version}.
 ** <<observability-highlights,Observability>>
 ** <<elasticsearch-highlights,{es}>>
 ** <<kibana-higlights,{kib}>>
+** <<security-highlights,{elastic-sec}>>
 
 [[observability-highlights]]
 === Observability highlights
@@ -46,5 +47,20 @@ This list summarizes the most important enhancements in {kib} {minor-version}.
 :leveloffset: +1
 
 include::{kib-repo-dir}/user/whats-new.asciidoc[tag=notable-highlights]
+
+:leveloffset: -1
+
+[[security-higlights]]
+=== {elastic-sec} highlights
+[subs="attributes"]
+++++
+<titleabbrev>{elastic-sec}</titleabbrev>
+++++
+
+This list summarizes the most important enhancements in {elastic-sec} {minor-version}.
+
+:leveloffset: +1
+
+include::{security-repo-dir}/whats-new.asciidoc[tag=notable-highlights]
 
 :leveloffset: -1

--- a/docs/en/install-upgrade/highlights.asciidoc
+++ b/docs/en/install-upgrade/highlights.asciidoc
@@ -50,7 +50,7 @@ include::{kib-repo-dir}/user/whats-new.asciidoc[tag=notable-highlights]
 
 :leveloffset: -1
 
-[[security-higlights]]
+[[security-highlights]]
 === {elastic-sec} highlights
 [subs="attributes"]
 ++++

--- a/docs/en/install-upgrade/index.asciidoc
+++ b/docs/en/install-upgrade/index.asciidoc
@@ -5,6 +5,7 @@
 :beats-repo-dir:     {beats-root}/libbeat/docs
 :es-repo-dir:        {elasticsearch-root}/docs/reference
 :hadoop-repo-dir:    {elasticsearch-hadoop-root}/docs/src/reference/asciidoc
+:security-repo-dir:  {security-docs-root}/docs
 :kib-repo-dir:       {kibana-root}/docs
 :ls-repo-dir:        {logstash-root}/docs
 :obs-repo-dir:       {observability-docs-root}/docs/en/observability


### PR DESCRIPTION
Resolves https://github.com/elastic/security-docs/issues/1571.

Previews:
* [Highlights landing page](https://stack-docs_2046.docs-preview.app.elstc.co/guide/en/elastic-stack/master/elastic-stack-highlights.html)
* [Elastic Security highlights](https://stack-docs_2046.docs-preview.app.elstc.co/guide/en/elastic-stack/master/security-highlights.html)

Note: Version # in the previews will be 8.2.0 because that's the current version in main/master; we'll backport to 8.0.0 and 8.1.0.

## Additional PRs
To complete this PR, these other changes were necessary:
* https://github.com/elastic/security-docs/pull/1575
* https://github.com/elastic/security-docs/pull/1578