### PR TITLE
[DOCS] Fix links to ML APIs

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/ml-api-quickref.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-api-quickref.asciidoc
@@ -12,11 +12,11 @@ All {ml} {anomaly-detect} endpoints have the following base:
 
 The main resources can be accessed with a variety of endpoints:
 
-* {ref}/ml-apis.html#ml-api-anomaly-job-endpoint[+/anomaly_detectors/+]: Create and manage {anomaly-jobs}
-* {ref}/ml-apis.html#ml-api-calendar-endpoint[+/calendars/+]: Create and manage calendars and scheduled events
-* {ref}/ml-apis.html#ml-api-datafeed-endpoint[+/datafeeds/+]: Select data from {es} to be analyzed
-* {ref}/ml-apis.html#ml-api-filter-endpoint[+/filters/+]: Create and manage filters for custom rules
-* {ref}/ml-apis.html#ml-api-result-endpoint[+/results/+]: Access the results of an {anomaly-job}
-* {ref}/ml-apis.html#ml-api-snapshot-endpoint[+/model_snapshots/+]: Manage model snapshots
+* {ref}/ml-ad-apis.html#ml-api-anomaly-job-endpoint[+/anomaly_detectors/+]: Create and manage {anomaly-jobs}
+* {ref}/ml-ad-apis.html#ml-api-calendar-endpoint[+/calendars/+]: Create and manage calendars and scheduled events
+* {ref}/ml-ad-apis.html#ml-api-datafeed-endpoint[+/datafeeds/+]: Select data from {es} to be analyzed
+* {ref}/ml-ad-apis.html#ml-api-filter-endpoint[+/filters/+]: Create and manage filters for custom rules
+* {ref}/ml-ad-apis.html#ml-api-result-endpoint[+/results/+]: Access the results of an {anomaly-job}
+* {ref}/ml-ad-apis.html#ml-api-snapshot-endpoint[+/model_snapshots/+]: Manage model snapshots
 
-For a full list, see {ref}/ml-apis.html[{ml-cap} {anomaly-detect} APIs].
+For a full list, see {ref}/ml-ad-apis.html[{ml-cap} {anomaly-detect} APIs].

--- a/docs/en/stack/ml/anomaly-detection/ml-calendars.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-calendars.asciidoc
@@ -5,7 +5,7 @@ The {ml} model is not ill-affected and you do not receive spurious results.
 
 You can create calendars and scheduled events in the **Settings** pane on the
 **Machine Learning** page in {kib} or by using
-{ref}/ml-apis.html[{ml-cap} {anomaly-detect} APIs].
+{ref}/ml-ad-apis.html[{ml-cap} {anomaly-detect} APIs].
 
 A scheduled event must have a start time, end time, and description. In general,
 scheduled events are short in duration (typically lasting from a few hours to a


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch/pull/84005 and https://github.com/elastic/stack-docs/pull/2050