### PR TITLE
[DOCS] Fix links to ML APIs - part 1

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/ml-api-quickref.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-api-quickref.asciidoc
@@ -12,11 +12,11 @@ All {ml} {anomaly-detect} endpoints have the following base:
 
 The main resources can be accessed with a variety of endpoints:
 
-* {ref}/ml-apis.html#ml-api-anomaly-job-endpoint[+/anomaly_detectors/+]: Create and manage {anomaly-jobs}
-* {ref}/ml-apis.html#ml-api-calendar-endpoint[+/calendars/+]: Create and manage calendars and scheduled events
-* {ref}/ml-apis.html#ml-api-datafeed-endpoint[+/datafeeds/+]: Select data from {es} to be analyzed
-* {ref}/ml-apis.html#ml-api-filter-endpoint[+/filters/+]: Create and manage filters for custom rules
-* {ref}/ml-apis.html#ml-api-result-endpoint[+/results/+]: Access the results of an {anomaly-job}
-* {ref}/ml-apis.html#ml-api-snapshot-endpoint[+/model_snapshots/+]: Manage model snapshots
+* {ref}/ml-apis.html[+/anomaly_detectors/+]: Create and manage {anomaly-jobs}
+* {ref}/ml-apis.html[+/calendars/+]: Create and manage calendars and scheduled events
+* {ref}/ml-apis.html[+/datafeeds/+]: Select data from {es} to be analyzed
+* {ref}/ml-apis.html[+/filters/+]: Create and manage filters for custom rules
+* {ref}/ml-apis.html[+/results/+]: Access the results of an {anomaly-job}
+* {ref}/ml-apis.html[+/model_snapshots/+]: Manage model snapshots
 
 For a full list, see {ref}/ml-apis.html[{ml-cap} {anomaly-detect} APIs].


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch/pull/84005, which encounters the following build errors:

> 16:06:38 INFO:build_docs:Bad cross-document links:
16:06:38 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/machine-learning/master/ml-api-quickref.html contains broken links to:
16:06:38 INFO:build_docs:   - en/elasticsearch/reference/master/ml-apis.html#ml-api-anomaly-job-endpoint
16:06:38 INFO:build_docs:   - en/elasticsearch/reference/master/ml-apis.html#ml-api-calendar-endpoint
16:06:38 INFO:build_docs:   - en/elasticsearch/reference/master/ml-apis.html#ml-api-datafeed-endpoint
16:06:38 INFO:build_docs:   - en/elasticsearch/reference/master/ml-apis.html#ml-api-filter-endpoint
16:06:38 INFO:build_docs:   - en/elasticsearch/reference/master/ml-apis.html#ml-api-result-endpoint
16:06:38 INFO:build_docs:   - en/elasticsearch/reference/master/ml-apis.html#ml-api-snapshot-endpoint