### PR TITLE
[DOCS] Remove ES Hadoop breaking changes in 8.1+

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -55,6 +55,18 @@ the complete list, go to {ref}/breaking-changes.html[{es} breaking changes].
 
 // include::{es-repo-dir}/migration/migrate_8_2.asciidoc[tag=notable-breaking-changes]
 
+[[security-breaking-changes]]
+=== {elastic-sec} breaking changes
+[subs="attributes"]
+++++
+<titleabbrev>{elastic-sec}</titleabbrev>
+++++
+
+This list summarizes the most important breaking changes in {elastic-sec} {version}. For
+the complete list, go to {security-guide-all}/8.0/release-notes-header-8.0.0.html#breaking-changes-8.0.0[{elastic-sec} breaking changes].
+
+include::{security-repo-dir}/release-notes/8.0.asciidoc[tag=breaking-changes]
+
 [[kibana-breaking-changes]]
 === {kib} breaking changes
 [subs="attributes"]

--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -7,7 +7,6 @@ use and make the necessary changes so your code is compatible with {version}.
 ** <<apm-breaking-changes,APM {version} breaking changes>>
 ** <<beats-breaking-changes,Beats {version} breaking changes>>
 ** <<elasticsearch-breaking-changes,{es} {version} breaking changes>>
-** <<elasticsearch-hadoop-breaking-changes,{es} Hadoop {version} breaking changes>>
 ** <<kibana-breaking-changes,Kibana {version} breaking changes>>
 ** <<logstash-breaking-changes,{ls} {version} breaking changes>>
 
@@ -54,19 +53,6 @@ This list summarizes the most important breaking changes in {es} {version}. For
 the complete list, go to {ref}/breaking-changes.html[{es} breaking changes].
 
 // include::{es-repo-dir}/migration/migrate_8_2.asciidoc[tag=notable-breaking-changes]
-
-[[elasticsearch-hadoop-breaking-changes]]
-=== {es} Hadoop breaking changes
-[subs="attributes"]
-++++
-<titleabbrev>{es} Hadoop</titleabbrev>
-++++
-
-This list summarizes the most important breaking changes in {es} Hadoop {version}.
-For the complete list, go to
-{hadoop-ref}/breaking-changes.html[Elasticsearch Hadoop breaking changes].
-
-include::{hadoop-repo-dir}/appendix/breaking.adoc[tag=notable-v8-breaking-changes]
 
 [[kibana-breaking-changes]]
 === {kib} breaking changes

--- a/docs/en/install-upgrade/redirects.asciidoc
+++ b/docs/en/install-upgrade/redirects.asciidoc
@@ -3,6 +3,12 @@
 
 The following pages have moved or been deleted.
 
+[role="exclude",id="elasticsearch-hadoop-breaking-changes"]
+=== {es} Hadoop {version} breaking changes
+
+This page no longer exists. For the latest breaking changes, refer to
+{hadoop-ref}/breaking-changes.html[{es} Hadoop breaking changes].
+
 [role="exclude",id="apm-highlights"]
 === APM highlights
 

--- a/docs/en/install-upgrade/redirects.asciidoc
+++ b/docs/en/install-upgrade/redirects.asciidoc
@@ -4,7 +4,7 @@
 The following pages have moved or been deleted.
 
 [role="exclude",id="elasticsearch-hadoop-breaking-changes"]
-=== {es} Hadoop {version} breaking changes
+=== {es} Hadoop breaking changes
 
 This page no longer exists. For the latest breaking changes, refer to
 {hadoop-ref}/breaking-changes.html[{es} Hadoop breaking changes].


### PR DESCRIPTION
Elasticsearch for Hadoop rarely releases breaking changes outside of major releases.

This commit removes the breaking changes page for ES Hadoop from the Elastic Upgrade Guide in 8.1+. It also adds a redirect page that points users back to the ES Hadoop docs.

### Preview
Redirect page: https://stack-docs_2056.docs-preview.app.elstc.co/guide/en/elastic-stack/master/elasticsearch-hadoop-breaking-changes.html