### PR TITLE
[8.0] [DOCS] Add Elastic Security breaking changes to Installation and Upgrade Guide (#2039)

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -8,6 +8,7 @@ use and make the necessary changes so your code is compatible with {version}.
 ** <<beats-breaking-changes,Beats {version} breaking changes>>
 ** <<elasticsearch-breaking-changes,{es} {version} breaking changes>>
 ** <<elasticsearch-hadoop-breaking-changes,{es} Hadoop {version} breaking changes>>
+** <<security-breaking-changes,{elastic-sec} {version} breaking changes>>
 ** <<kibana-breaking-changes,Kibana {version} breaking changes>>
 ** <<logstash-breaking-changes,{ls} {version} breaking changes>>
 
@@ -111,6 +112,18 @@ For the complete list, go to
 {hadoop-ref}/breaking-changes.html[Elasticsearch Hadoop breaking changes].
 
 include::{hadoop-repo-dir}/appendix/breaking.adoc[tag=notable-v8-breaking-changes]
+
+[[security-breaking-changes]]
+=== {elastic-sec} breaking changes
+[subs="attributes"]
+++++
+<titleabbrev>{elastic-sec}</titleabbrev>
+++++
+
+This list summarizes the most important breaking changes in {elastic-sec} {version}. For
+the complete list, go to {security-guide-all}/8.0/release-notes-header-8.0.0.html#breaking-changes-8.0.0[{elastic-sec} breaking changes].
+
+include::{security-repo-dir}/release-notes/8.0.asciidoc[tag=breaking-changes]
 
 [[kibana-breaking-changes]]
 === {kib} breaking changes

--- a/docs/en/install-upgrade/index.asciidoc
+++ b/docs/en/install-upgrade/index.asciidoc
@@ -5,6 +5,7 @@
 :beats-repo-dir:     {beats-root}/libbeat/docs
 :es-repo-dir:        {elasticsearch-root}/docs/reference
 :hadoop-repo-dir:    {elasticsearch-hadoop-root}/docs/src/reference/asciidoc
+:security-repo-dir:  {security-docs-root}/docs
 :kib-repo-dir:       {kibana-root}/docs
 :ls-repo-dir:        {logstash-root}/docs
 :obs-repo-dir:       {observability-docs-root}/docs/en/observability


### PR DESCRIPTION
Backports the following commits to 8.0:
 - [DOCS] Add Elastic Security breaking changes to Installation and Upgrade Guide (#2039)