### PR TITLE
[8.0] [DOCS] Update upgrade steps for minor/patch releases (#2057)

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -4,6 +4,7 @@
 Before you upgrade, you must review the breaking changes for each product you
 use and make the necessary changes so your code is compatible with {version}.
 
+// tag::breaking-changes-links[]
 ** <<apm-breaking-changes,APM {version} breaking changes>>
 ** <<beats-breaking-changes,Beats {version} breaking changes>>
 ** <<elasticsearch-breaking-changes,{es} {version} breaking changes>>
@@ -11,15 +12,18 @@ use and make the necessary changes so your code is compatible with {version}.
 ** <<security-breaking-changes,{elastic-sec} {version} breaking changes>>
 ** <<kibana-breaking-changes,Kibana {version} breaking changes>>
 ** <<logstash-breaking-changes,{ls} {version} breaking changes>>
+// end::breaking-changes-links[]
 
+// tag::breaking-changes-admon[]
 [IMPORTANT]
 ===============================
-* Make sure you check the breaking changes for each point release up to the desired new version.
+* Make sure you check the breaking changes for each minor release up to {version}.
 * If you are using {ml} {dfeeds} that contain discontinued search or query
 domain specific language (DSL), the upgrade will fail. In 5.6.5 and later, the
 Upgrade Assistant provides information about which {dfeeds} need to be updated.
 
 ===============================
+// end::breaking-changes-admon[]
 
 [[apm-breaking-changes]]
 === APM breaking changes

--- a/docs/en/install-upgrade/upgrading-elasticsearch.asciidoc
+++ b/docs/en/install-upgrade/upgrading-elasticsearch.asciidoc
@@ -1,22 +1,16 @@
 [[upgrading-elasticsearch]]
 == Upgrade {es}
 
-To upgrade from 7.16 or earlier to {version}, **you must first upgrade to {prev-major-last}**, 
-even if you opt to do a full-cluster restart instead of a rolling upgrade. 
-This enables you to use the **Upgrade Assistant** to <<prepare-to-upgrade, prepare to upgrade>>.
-
 .FIPS Compliance and Java 17
 [IMPORTANT]
 --
-{es} 8.0 requires Java 17 or later.  
+{es} {version} requires Java 17 or later.  
 There is not yet a FIPS-certified security module for Java 17 
-that you can use when running {es} 8.0 in FIPS 140-2 mode.
+that you can use when running {es} {version} in FIPS 140-2 mode.
 If you run in FIPS 140-2 mode, you will either need to request
-an exception from your security organization to upgrade to {es} 8.0, 
+an exception from your security organization to upgrade to {es} {version}, 
 or remain on {es} 7.x until Java 17 is certified. 
-ifeval::["{release-state}"=="released"]
 Alternatively, consider using {ess} in the FedRAMP-certified GovCloud region.
-endif::[]
 --
 
 An {es} cluster can be upgraded one node at
@@ -25,10 +19,8 @@ a time so upgrading does not interrupt service. Running multiple versions of
 not supported, as shards cannot be replicated from upgraded nodes to nodes
 running the older version.
 
-IMPORTANT: Upgrading from a pre-release to 8.0 GA is not supported.
-Pre-releases should only be used for testing in a temporary environment.
-
-When performing a <<rolling-upgrades, rolling upgrade>>:
+Before you start, <<upgrading-elastic-stack,take the upgrade preparation
+steps>>. When performing a <<rolling-upgrades, rolling upgrade>>:
 
 . Upgrade nodes that are **NOT** {ref}/modules-node.html#master-node[master-eligible] first. 
 You can retrieve a list of these nodes with `GET /_nodes/_all,master:false/_none` or by finding all the nodes configured with `node.master: false`.

--- a/docs/en/install-upgrade/upgrading-kibana.asciidoc
+++ b/docs/en/install-upgrade/upgrading-kibana.asciidoc
@@ -1,9 +1,6 @@
 [[upgrading-kibana]]
 == Upgrade {kib}
 
-To upgrade from 7.16 or earlier to {version}, **you must first upgrade to {prev-major-last}**.
-This enables you to use the **Upgrade Assistant** to <<prepare-to-upgrade, prepare to upgrade>>.
-
 [WARNING]
 ====
 {kib} automatically runs saved object migrations when required. To roll back to an
@@ -14,7 +11,8 @@ state. Snapshots include this feature state by default.
 For more information, check {kibana-ref}/saved-object-migrations.html[Migrate saved objects].
 ====
 
-To upgrade {kib}:
+Before you start, <<upgrading-elastic-stack,take the upgrade preparation
+steps>>. To upgrade {kib}:
 
 . Shut down all {kib} instances. {kib} does not support rolling upgrades.
 **Upgrading while older {kib} instances are running can cause data loss or upgrade failures.**

--- a/docs/en/install-upgrade/upgrading-stack-cloud.asciidoc
+++ b/docs/en/install-upgrade/upgrading-stack-cloud.asciidoc
@@ -1,7 +1,7 @@
 [[upgrade-elastic-stack-for-elastic-cloud]]
 === Upgrade on Elastic Cloud
 
-Once you are <<prepare-to-upgrade, prepared to upgrade>>,
+Once you are <<upgrading-elastic-stack, prepared to upgrade>>,
 a single click in the Elastic Cloud console can upgrade a deployment to a newer
 version, add more processing capacity, change plugins, and enable or disable
 high availability, all at the same time. During the upgrade process,

--- a/docs/en/install-upgrade/upgrading-stack-on-prem.asciidoc
+++ b/docs/en/install-upgrade/upgrading-stack-on-prem.asciidoc
@@ -1,7 +1,7 @@
 [[upgrading-elastic-stack-on-prem]]
 === Upgrade Elastic on-prem
 
-Once you are <<prepare-to-upgrade, prepared to upgrade>>,
+Once you are <<upgrading-elastic-stack, prepared to upgrade>>,
 you will need to upgrade each of your Elastic components individually.
 
 . Consider closing {ml} jobs before you start the upgrade process. While {ml}

--- a/docs/en/install-upgrade/upgrading-stack.asciidoc
+++ b/docs/en/install-upgrade/upgrading-stack.asciidoc
@@ -1,11 +1,67 @@
 [[upgrading-elastic-stack]]
 == Upgrade to Elastic {version}
 
+Before you upgrade to {version}, it's important to take some preparation steps.
+ifeval::["{version}"!="8.0.0"]
+These steps vary based on your current version:
+
+* <<prepare-to-upgrade-8x,Upgrade from an earlier 8.x version>>
+* <<prepare-to-upgrade,Upgrade from 7.x>>
+endif::[]
+
+IMPORTANT: Upgrading from a release candidate build, such as 8.0.0-rc1 or
+8.0.0-rc2, is not supported. Pre-releases should only be used for testing in a
+temporary environment.
+
+ifeval::["{version}"!="8.0.0"]
+[discrete]
+[[prepare-to-upgrade-8x]]
+=== Prepare to upgrade from an earlier 8.x version
+
+. Review the breaking changes for each product you use and make the necessary
+changes so your code is compatible with {version}:
++
+--
+include::breaking.asciidoc[tag=breaking-changes-links]
+
+include::breaking.asciidoc[tag=breaking-changes-admon]
+--
+
+include::upgrading-stack.asciidoc[tag=generic-upgrade-steps]
+endif::[]
+
+////
+// List of upgrade steps used in both 8.x and 7.x
+// tag::generic-upgrade-steps[]
+. If you use any {es} plugins, make sure there is a version of each plugin that is
+compatible with {es} version {version}.
+
+. Test the upgrade in an isolated environment before upgrading your production
+cluster.
+
+. Make sure you have a current snapshot before you start the upgrade.
++
+IMPORTANT: You cannot downgrade {es} nodes after upgrading. 
+If you cannot complete the upgrade process, 
+you will need to restore from the snapshot.
+
+Refer to the upgrade instructions for your environment:
+
+* <<upgrade-elastic-stack-for-elastic-cloud,Upgrade on Elastic Cloud>>
+* <<upgrading-elastic-stack-on-prem,Upgrade on-prem>>
+// end::generic-upgrade-steps[]
+////
+
+
+[discrete]
+[[prepare-to-upgrade]]
+=== Prepare to upgrade from 7.x
+
 To upgrade to {version} from 7.16 or earlier, **you must first upgrade to {prev-major-last}**.
 This enables you to use the **Upgrade Assistant** to identify and resolve issues,
 reindex indices created before 7.0, and then perform a rolling upgrade.
 
-**Upgrading to {prev-major-last} before upgrading to 8.0 or later is required 
+**Upgrading to {prev-major-last} before upgrading to {version} is required 
 even if you opt to do a full-cluster restart of your {es} cluster.**
 Alternatively, you can create a new {version} deployment and reindex from remote.
 For more information, see <<upgrading-reindex, Reindex to upgrade>>.
@@ -25,10 +81,6 @@ For more information, see {ref}/xpack-ccr.html[Cross cluster replication] for ve
 You can view your remote clusters from **Stack Management > Remote Clusters**. 
 ====
 
-[discrete]
-[[prepare-to-upgrade]]
-=== Prepare to upgrade
-
 . Use the {kibana-ref-all}/{prev-major-last}/upgrade-assistant.html[Upgrade Assistant] 
 to prepare for your upgrade from {prev-major-last} to {version}.
 The **Upgrade Assistant** identifies deprecated settings and guides
@@ -40,9 +92,12 @@ or reindexing.
 
 . Review the deprecation logs from the **Upgrade Assistant** to 
 determine if your applications are using features that are not supported 
-or behave differently in 8.0 and later.
+or behave differently in 8.x.
 See the <<elastic-stack-breaking-changes,breaking changes>> for more information 
 about changes in {version} that could affect your application.
++
+IMPORTANT: Make sure you check the breaking changes for each minor 8.x release
+up to {version}.
 
 . Make the recommended changes to ensure that your applications 
 continue to operate as expected after the upgrade.
@@ -55,21 +110,4 @@ REST API compatibility should be a bridge to smooth out the upgrade process,
 not a long term strategy. For more information, see
 {ref}/rest-api-compatibility.html[REST API compatibility].
 
-. If you use any {es} plugins, make sure there is a version of each plugin that is
-compatible with {es} version {version}.
-
-. Test the upgrade in an isolated environment before upgrading your production
-cluster.
-
-. Make sure you have a current snapshot before you start the upgrade.
-+
-IMPORTANT: You cannot downgrade {es} nodes after upgrading. 
-If you cannot complete the upgrade process, 
-you will need to restore from the snapshot.
-
-Refer to the upgrade instructions for your environment:
-
-* <<upgrade-elastic-stack-for-elastic-cloud,Upgrade on Elastic Cloud>>
-* <<upgrading-elastic-stack-on-prem,Upgrade on-prem>>
-
-
+include::upgrading-stack.asciidoc[tag=generic-upgrade-steps]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.0`:
 - [[DOCS] Update upgrade steps for minor/patch releases (#2057)](https://github.com/elastic/stack-docs/pull/2057)

<!--- Backport version: 7.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)