### PR TITLE
[8.1] [DOCS] Remove ES Hadoop breaking changes in 8.1+ (#2056)

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -8,7 +8,6 @@ use and make the necessary changes so your code is compatible with {version}.
 ** <<apm-breaking-changes,APM {version} breaking changes>>
 ** <<beats-breaking-changes,Beats {version} breaking changes>>
 ** <<elasticsearch-breaking-changes,{es} {version} breaking changes>>
-** <<elasticsearch-hadoop-breaking-changes,{es} Hadoop {version} breaking changes>>
 ** <<security-breaking-changes,{elastic-sec} {version} breaking changes>>
 ** <<kibana-breaking-changes,Kibana {version} breaking changes>>
 ** <<logstash-breaking-changes,{ls} {version} breaking changes>>
@@ -59,19 +58,6 @@ This list summarizes the most important breaking changes in {es} {version}. For
 the complete list, go to {ref}/breaking-changes.html[{es} breaking changes].
 
 include::{es-repo-dir}/migration/migrate_8_1.asciidoc[tag=notable-breaking-changes]
-
-[[elasticsearch-hadoop-breaking-changes]]
-=== {es} Hadoop breaking changes
-[subs="attributes"]
-++++
-<titleabbrev>{es} Hadoop</titleabbrev>
-++++
-
-This list summarizes the most important breaking changes in {es} Hadoop {version}.
-For the complete list, go to
-{hadoop-ref}/breaking-changes.html[Elasticsearch Hadoop breaking changes].
-
-include::{hadoop-repo-dir}/appendix/breaking.adoc[tag=notable-v8-breaking-changes]
 
 [[security-breaking-changes]]
 === {elastic-sec} breaking changes

--- a/docs/en/install-upgrade/redirects.asciidoc
+++ b/docs/en/install-upgrade/redirects.asciidoc
@@ -3,6 +3,12 @@
 
 The following pages have moved or been deleted.
 
+[role="exclude",id="elasticsearch-hadoop-breaking-changes"]
+=== {es} Hadoop breaking changes
+
+This page no longer exists. For the latest breaking changes, refer to
+{hadoop-ref}/breaking-changes.html[{es} Hadoop breaking changes].
+
 [role="exclude",id="apm-highlights"]
 === APM highlights
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.1`:
 - [[DOCS] Remove ES Hadoop breaking changes in 8.1+ (#2056)](https://github.com/elastic/stack-docs/pull/2056)

<!--- Backport version: 7.0.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)