### PR TITLE
[8.1] [DOCS] Add Elastic Security highlights to Installation and Upgrade Guide (#2046)

### DIFF
--- a/docs/en/install-upgrade/highlights.asciidoc
+++ b/docs/en/install-upgrade/highlights.asciidoc
@@ -7,6 +7,7 @@ highlights notable new features and enhancements in {minor-version}.
 ** <<observability-highlights,Observability>>
 ** <<elasticsearch-highlights,{es}>>
 ** <<kibana-higlights,{kib}>>
+** <<security-highlights,{elastic-sec}>>
 
 [[observability-highlights]]
 === Observability highlights
@@ -46,5 +47,20 @@ This list summarizes the most important enhancements in {kib} {minor-version}.
 :leveloffset: +1
 
 include::{kib-repo-dir}/user/whats-new.asciidoc[tag=notable-highlights]
+
+:leveloffset: -1
+
+[[security-highlights]]
+=== {elastic-sec} highlights
+[subs="attributes"]
+++++
+<titleabbrev>{elastic-sec}</titleabbrev>
+++++
+
+This list summarizes the most important enhancements in {elastic-sec} {minor-version}.
+
+:leveloffset: +1
+
+include::{security-repo-dir}/whats-new.asciidoc[tag=notable-highlights]
 
 :leveloffset: -1


### PR DESCRIPTION
Backports the following commits to 8.1:
 - [DOCS] Add Elastic Security highlights to Installation and Upgrade Guide (#2046)