### PR TITLE
Fixing kibana installation path

### DIFF
--- a/docs/en/getting-started/get-started-stack.asciidoc
+++ b/docs/en/getting-started/get-started-stack.asciidoc
@@ -307,7 +307,7 @@ ifeval::["{release-state}"!="unreleased"]
 ----------------------------------------------------------------------
 curl -L -O https://artifacts.elastic.co/downloads/kibana/kibana-{kibana_version}-linux-x86_64.tar.gz
 tar xzvf kibana-{kibana_version}-linux-x86_64.tar.gz
-cd kibana-{kibana_version}-linux-x86_64/
+cd kibana-{kibana_version}/
 ./bin/kibana
 ----------------------------------------------------------------------
 


### PR DESCRIPTION
Kibana is getting installed inside kibana-8.0.0 folder for Ubuntu