### PR TITLE
[DOCS] Add Elastic Security breaking changes to Installation and Upgrade Guide for 8.1

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -67,9 +67,9 @@ the complete list, go to {ref}/breaking-changes.html[{es} breaking changes].
 ++++
 
 This list summarizes the most important breaking changes in {elastic-sec} {version}. For
-the complete list, go to {security-guide-all}/8.0/release-notes-header-8.0.0.html#breaking-changes-8.0.0[{elastic-sec} breaking changes].
+the complete list, go to {security-guide-all}/8.1/release-notes-header-8.1.0.html#breaking-changes-8.1.0[{elastic-sec} breaking changes].
 
-include::{security-repo-dir}/release-notes/8.0.asciidoc[tag=breaking-changes]
+include::{security-repo-dir}/release-notes/8.1.asciidoc[tag=breaking-changes]
 
 [[kibana-breaking-changes]]
 === {kib} breaking changes


### PR DESCRIPTION
Fixes https://github.com/elastic/stack-docs/issues/2075. 

Preview:
* [Elastic Installation and Upgrade Guide | Breaking changes]
* [Elastic Security breaking changes]

## Notes
* Version # in the previews will be 8.2.0 because that's the current version in main/master; we'll backport to 8.1.0.
* The breaking changes page in the Install & Upgrade Guide is built using [includes of tagged regions](https://docs.asciidoctor.org/asciidoc/latest/directives/include-tagged-regions/), so I added tags to the relevant region in the Release Notes page in the Security Docs repo.