### PR TITLE
[DOCS] Fixes curl command to check if ES is running

### DIFF
--- a/docs/en/getting-started/get-started-stack.asciidoc
+++ b/docs/en/getting-started/get-started-stack.asciidoc
@@ -211,8 +211,7 @@ prompted:
 
 [source,shell]
 ----
-curl --cacert $ES_PATH_CONF/tls_auto_config_<timestamp>/http_ca.crt \
--u elastic https://localhost:9200
+curl --cacert $ES_PATH_CONF/certs/http_ca.crt -u elastic https://localhost:9200 
 ----
 // NOTCONSOLE
 


### PR DESCRIPTION
## Overview

This PR updates the cURL command to check if ES is running in the getting started guide.

### Preview

[ES is up and running](https://stack-docs_2085.docs-preview.app.elstc.co/guide/en/elastic-stack-get-started/master/get-started-elastic-stack.html#_make_sure_that_elasticsearch_is_up_and_running)