### PR TITLE
Update upgrading-stack.asciidoc

### DIFF
--- a/docs/en/install-upgrade/upgrading-stack.asciidoc
+++ b/docs/en/install-upgrade/upgrading-stack.asciidoc
@@ -45,7 +45,7 @@ IMPORTANT: You cannot downgrade {es} nodes after upgrading.
 If you cannot complete the upgrade process, 
 you will need to restore from the snapshot.
 
-NOTE: You should upgrade the monitoring cluster before the production cluster. In general, the monitoring cluster and the clusters being monitored should be running the same version of the stack. A monitoring cluster cannot monitor production clusters running newer versions of the stack. If necessary, the monitoring cluster can monitor production clusters running the latest release of the previous major version.
+. If you use a separate {ref}/monitoring-production.html[monitoring cluster], you should upgrade the monitoring cluster before the production cluster. In general, the monitoring cluster and the clusters being monitored should be running the same version of the stack. A monitoring cluster cannot monitor production clusters running newer versions of the stack. If necessary, the monitoring cluster can monitor production clusters running the latest release of the previous major version.
 // end::generic-upgrade-steps[]
 ////
 

--- a/docs/en/install-upgrade/upgrading-stack.asciidoc
+++ b/docs/en/install-upgrade/upgrading-stack.asciidoc
@@ -45,7 +45,7 @@ IMPORTANT: You cannot downgrade {es} nodes after upgrading.
 If you cannot complete the upgrade process, 
 you will need to restore from the snapshot.
 
-. You should upgrade the monitoring cluster before the production cluster. In general, the monitoring cluster and the clusters being monitored should be running the same version of the stack. A monitoring cluster cannot monitor production clusters running newer versions of the stack. If necessary, the monitoring cluster can monitor production clusters running the latest release of the previous major version.
+NOTE: You should upgrade the monitoring cluster before the production cluster. In general, the monitoring cluster and the clusters being monitored should be running the same version of the stack. A monitoring cluster cannot monitor production clusters running newer versions of the stack. If necessary, the monitoring cluster can monitor production clusters running the latest release of the previous major version.
 // end::generic-upgrade-steps[]
 ////
 

--- a/docs/en/install-upgrade/upgrading-stack.asciidoc
+++ b/docs/en/install-upgrade/upgrading-stack.asciidoc
@@ -45,10 +45,7 @@ IMPORTANT: You cannot downgrade {es} nodes after upgrading.
 If you cannot complete the upgrade process, 
 you will need to restore from the snapshot.
 
-Refer to the upgrade instructions for your environment:
-
-* <<upgrade-elastic-stack-for-elastic-cloud,Upgrade on Elastic Cloud>>
-* <<upgrading-elastic-stack-on-prem,Upgrade on-prem>>
+. You should upgrade the monitoring cluster before the production cluster. In general, the monitoring cluster and the clusters being monitored should be running the same version of the stack. A monitoring cluster cannot monitor production clusters running newer versions of the stack. If necessary, the monitoring cluster can monitor production clusters running the latest release of the previous major version.
 // end::generic-upgrade-steps[]
 ////
 


### PR DESCRIPTION
The customers are seeing issues when they try to upgrade the production cluster before the monitoring cluster.
see https://github.com/elastic/sdh-elasticsearch/issues/5702#issuecomment-1067475797 and https://github.com/elastic/support-known-issues/issues/1062

Also 
```
Refer to the upgrade instructions for your environment:

Upgrade on Elastic Cloud
Upgrade on-prem
```
is already at the end of the same page (https://www.elastic.co/guide/en/elastic-stack/current/upgrading-elastic-stack.html#prepare-to-upgrade) and it is better being at the end.

### Preview

https://stack-docs_2092.docs-preview.app.elstc.co/guide/en/elastic-stack/8.1/upgrading-elastic-stack.html