### PR TITLE
Add note to upgrade monitoring deployment before production

### DIFF
--- a/docs/en/install-upgrade/upgrading-stack-cloud.asciidoc
+++ b/docs/en/install-upgrade/upgrading-stack-cloud.asciidoc
@@ -14,6 +14,8 @@ Preview releases and master snapshots are not supported.
 
 {ess} and {ece} do not support the ability to upgrade to or from release candidate builds, such as 8.0.0-rc1.
 
+If you use a separate {cloud}/ec-enable-logging-and-monitoring.html[monitoring deployment], you should upgrade the monitoring deployment before the production deployment. In general, the monitoring deployment and the deployments being monitored should be running the same version of the Elastic Stack. A monitoring deployment cannot monitor production deployments running newer versions of the stack. If necessary, the monitoring deployment can monitor production deployments running the latest release of the previous major version.
+
 IMPORTANT: Although it's simple to upgrade an Elastic Cloud deployment, 
 the new version might include breaking changes that affect your application. 
 Make sure you review the deprecation logs, make any necessary changes, 


### PR DESCRIPTION
Very similar to https://github.com/elastic/cloud/pull/100623, this adds a note to the Cloud Upgrade instructions (v8.0 and higher) in the Installation and Upgrade Guide.

Rel: #100351
