### PR TITLE
[DOCS] Update certificate path in Docker installation

### DIFF
--- a/docs/en/getting-started/get-started-docker.asciidoc
+++ b/docs/en/getting-started/get-started-docker.asciidoc
@@ -121,6 +121,9 @@ endif::[]
 TIP: You might need to scroll back a bit in the terminal to view the password
 and enrollment token.
 
+. Copy the generated password and enrollment token and save them in a secure
+location. These values are shown only when you start {es} for the first time.
+
 . Copy the `http_ca.crt` security certificate from your Docker container to
 your local machine. 
 +

--- a/docs/en/getting-started/get-started-docker.asciidoc
+++ b/docs/en/getting-started/get-started-docker.asciidoc
@@ -121,26 +121,13 @@ endif::[]
 TIP: You might need to scroll back a bit in the terminal to view the password
 and enrollment token.
 
-. Copy the generated password and enrollment token and save them in a secure
-location. These values are shown only when you start {es} for the first time.
-
-. Locate the CA certificate in your container. This command returns the path
-to the `http_ca.crt` certificate, which you'll use in the next step.
-+
-[source,sh]
-----
-docker exec -it es01 /bin/bash -c "find /usr/share/elasticsearch -name http_ca.crt"
-----
-
 . Copy the `http_ca.crt` security certificate from your Docker container to
 your local machine. 
 +
 [source,sh]
 ----
-docker cp es01:/usr/share/elasticsearch/config/tls_auto_config_<timestamp>/http_ca.crt .
+docker cp es01:/usr/share/elasticsearch/config/certs/http_ca.crt .
 ----
-`<timestamp>`:: The timestamp of when the auto-configuration process created
-the security files directory in your Docker container.
 
 . Open a new terminal and verify that you can connect to your {es}
 cluster by making an authenticated call, using the `http_ca.crt` file that you


### PR DESCRIPTION
Update the path where auto generated certificates are stored in the docker instructions