### PR TITLE
Removes outdated DFA limitation

### DIFF
--- a/docs/en/stack/ml/df-analytics/ml-dfa-limitations.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-limitations.asciidoc
@@ -8,8 +8,8 @@
 
 
 The following limitations and known problems apply to the {version} release of 
-the Elastic {dfanalytics} feature. The limitations are grouped into four 
-categories:
+the Elastic {dfanalytics} feature. The limitations are grouped into the 
+following categories:
 
 * <<dfa-platform-limitations>> are related to the platform that hosts the {ml} 
   feature of the {stack}.
@@ -17,8 +17,8 @@ categories:
   {dfanalytics-jobs}.
 * <<dfa-operational-limitations>> affect the behavior of the {dfanalytics-jobs} 
   that are running.
-* <<dfa-ui-limitations>> only apply to {dfanalytics-jobs} managed via the user 
-  interface.
+// * <<dfa-ui-limitations>> only apply to {dfanalytics-jobs} managed via the user 
+//   interface.
   
 [discrete]
 [[dfa-platform-limitations]]
@@ -212,15 +212,6 @@ training data (for example by decreasing the training percentage), setting
 relevant for analysis.
 
 
-[discrete]
-[[dfa-ui-limitations]]
-== Limitations in {kib}
-
-[discrete]
-[[dfa-space-limitations]]
-=== Trained models are visible in all {kib} spaces
-
-{kibana-ref}/xpack-spaces.html[Spaces] enable you to organize your
-{dfanalytics-jobs} in {kib} and to see only the jobs and other saved objects
-that belong to your space. However, this limited scoped does not apply to
-<<ml-trained-models,trained models>>; they are are visible in all spaces. 
+// [discrete]
+// [[dfa-ui-limitations]]
+// == Limitations in {kib}


### PR DESCRIPTION
## Overview

This PR removes the limitation item about space-unaware trained models from DFA limitations. From 8.2, trained models are space-aware, so the limitation does not apply anymore. It also comments out the Kibana limitations section as there is no other limitation under this section. It slightly modifies the intro paragraph, too.

Related to https://github.com/elastic/ml-team/issues/495#issuecomment-1096592588.

### Preview

[Limitations](https://stack-docs_2101.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-dfa-limitations.html)