### PR TITLE
[DOCS] Deprecate deployment infer API

### DIFF
--- a/docs/en/stack/ml/nlp/ml-nlp-apis.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-apis.asciidoc
@@ -19,8 +19,7 @@ All the trained models endpoints have the following base:
 * {ref}/get-trained-models.html[Get trained models]
 * {ref}/get-trained-models-stats.html[Get trained models statistics]
 // INFER
-* {ref}/infer-trained-model.html[Infer trained model] deprecated:[8.3.0]
-* {ref}/infer-trained-model-deployment.html[Infer trained model deployment]
+* {ref}/infer-trained-model.html[Infer trained model]
 // START
 * {ref}//start-trained-model-deployment.html[Start trained model deployment]
 // STOP

--- a/docs/en/stack/ml/nlp/ml-nlp-apis.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-apis.asciidoc
@@ -19,6 +19,7 @@ All the trained models endpoints have the following base:
 * {ref}/get-trained-models.html[Get trained models]
 * {ref}/get-trained-models-stats.html[Get trained models statistics]
 // INFER
+* {ref}/infer-trained-model.html[Infer trained model] deprecated:[8.3.0]
 * {ref}/infer-trained-model-deployment.html[Infer trained model deployment]
 // START
 * {ref}//start-trained-model-deployment.html[Start trained model deployment]

--- a/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
@@ -169,7 +169,7 @@ For example, to try a named entity recognition task, provide some sample text:
 
 [source,console]
 --------------------------------------------------
-POST /_ml/trained_models/elastic__distilbert-base-uncased-finetuned-conll03-english/_infer
+POST /_ml/trained_models/elastic__distilbert-base-cased-finetuned-conll03-english/_infer
 {
   "docs":[{"text_field": "Sasha bought 300 shares of Acme Corp in 2022."}]
 }
@@ -184,19 +184,19 @@ recognized entities:
 {
   "inference_results" : [
     {
-      "predicted_value" : "[Sasha](ORG&Sasha) bought 300 shares of [Acme Corp](ORG&Acme+Corp) in 2022.",
+      "predicted_value" : "[Sasha](PER&Sasha) bought 300 shares of [Acme Corp](ORG&Acme+Corp) in 2022.",
       "entities" : [
         {
-          "entity" : "sasha",
-          "class_name" : "ORG",
-          "class_probability" : 0.7618975251681134,
+          "entity" : "Sasha",
+          "class_name" : "PER",
+          "class_probability" : 0.9953193407987492,
           "start_pos" : 0,
           "end_pos" : 5
         },
         {
-          "entity" : "acme corp",
+          "entity" : "Acme Corp",
           "class_name" : "ORG",
-          "class_probability" : 0.9986672643811757,
+          "class_probability" : 0.9996392198381716,
           "start_pos" : 27,
           "end_pos" : 36
         }

--- a/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
@@ -124,12 +124,13 @@ NOTE: This {kib} functionality is currently available only for the
 <<ml-nlp-model-ref-ner,third party named entity recognition models>>.
 
 Alternatively, you can use the
-{ref}/infer-trained-model-deployment.html[infer trained model deployment API].
+{ref}/infer-trained-model.html[infer trained model API].
 For example, to try a named entity recognition task, provide some sample text:
 
+//TBD: Test new API request and response
 [source,console]
 --------------------------------------------------
-POST /_ml/trained_models/elastic__distilbert-base-cased-finetuned-conll03-english/deployment/_infer
+POST /_ml/trained_models/elastic__distilbert-base-cased-finetuned-conll03-english/_infer
 {
     "docs":{
         "text_field":"Sasha bought 300 shares of Acme Corp in 2022."

--- a/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
@@ -167,12 +167,11 @@ Alternatively, you can use the
 {ref}/infer-trained-model.html[infer trained model API].
 For example, to try a named entity recognition task, provide some sample text:
 
-//TBD: Test new API request and response
 [source,console]
 --------------------------------------------------
-POST /_ml/trained_models/elastic__distilbert-base-cased-finetuned-conll03-english/_infer
+POST /_ml/trained_models/elastic__distilbert-base-uncased-finetuned-conll03-english/_infer
 {
-  "docs":[{"text_field":"Sasha bought 300 shares of Acme Corp in 2022."}]
+  "docs":[{"text_field": "Sasha bought 300 shares of Acme Corp in 2022."}]
 }
 --------------------------------------------------
 // TEST[skip:TBD]
@@ -183,21 +182,25 @@ recognized entities:
 [source,console-result]
 ----
 {
-  "predicted_value" : "[Sasha](ORG&Sasha) bought 300 shares of [Acme Corp](ORG&Acme+Corp) in 2022.",
-  "entities" : [
+  "inference_results" : [
     {
-      "entity" : "sasha",
-      "class_name" : "ORG",
-      "class_probability" : 0.7618975251681134,
-      "start_pos" : 0,
-      "end_pos" : 5
-    },
-    {
-      "entity" : "acme corp",
-      "class_name" : "ORG",
-      "class_probability" : 0.9986672643811757,
-      "start_pos" : 27,
-      "end_pos" : 36
+      "predicted_value" : "[Sasha](ORG&Sasha) bought 300 shares of [Acme Corp](ORG&Acme+Corp) in 2022.",
+      "entities" : [
+        {
+          "entity" : "sasha",
+          "class_name" : "ORG",
+          "class_probability" : 0.7618975251681134,
+          "start_pos" : 0,
+          "end_pos" : 5
+        },
+        {
+          "entity" : "acme corp",
+          "class_name" : "ORG",
+          "class_probability" : 0.9986672643811757,
+          "start_pos" : 27,
+          "end_pos" : 36
+        }
+      ]
     }
   ]
 }

--- a/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
@@ -141,9 +141,7 @@ For example, to try a named entity recognition task, provide some sample text:
 --------------------------------------------------
 POST /_ml/trained_models/elastic__distilbert-base-cased-finetuned-conll03-english/_infer
 {
-    "docs":{
-        "text_field":"Sasha bought 300 shares of Acme Corp in 2022."
-        }
+  "docs":[{"text_field":"Sasha bought 300 shares of Acme Corp in 2022."}]
 }
 --------------------------------------------------
 // TEST[skip:TBD]
@@ -154,19 +152,19 @@ recognized entities:
 [source,console-result]
 ----
 {
-  "predicted_value" : "[Sasha](PER&Sasha) bought 300 shares of [Acme Corp](ORG&Acme+Corp) in 2022.",
+  "predicted_value" : "[Sasha](ORG&Sasha) bought 300 shares of [Acme Corp](ORG&Acme+Corp) in 2022.",
   "entities" : [
     {
-      "entity" : "Sasha",
-      "class_name" : "PER",
-      "class_probability" : 0.9953193611298665,
+      "entity" : "sasha",
+      "class_name" : "ORG",
+      "class_probability" : 0.7618975251681134,
       "start_pos" : 0,
       "end_pos" : 5
     },
     {
-      "entity" : "Acme Corp",
+      "entity" : "acme corp",
       "class_name" : "ORG",
-      "class_probability" : 0.9996392201598554,
+      "class_probability" : 0.9986672643811757,
       "start_pos" : 27,
       "end_pos" : 36
     }


### PR DESCRIPTION
This PR makes documentation changes related to https://github.com/elastic/elasticsearch/pull/86361

In particular, it updates the ML Guide to use the new URL for the infer API and it updates the API example output in the "Deploy trained models" page.

### Preview

- https://stack-docs_2123.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-nlp-apis.html
- https://stack-docs_2123.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-nlp-deploy-models.html#ml-nlp-test-inference