### PR TITLE
Adds Painless-related deprecation warnings limitation and removes POST data API limitation

### DIFF
--- a/docs/en/getting-started/get-started-docker.asciidoc
+++ b/docs/en/getting-started/get-started-docker.asciidoc
@@ -209,6 +209,11 @@ endif::[]
 
 . To access {kib}, click the generated link in your terminal.
 
+[NOTE]
+====
+If the generated link is to host `0.0.0.0` you may have to replace it with `127.0.0.1`
+====
+
   .. In your browser, paste the enrollment token that you copied when starting
   {es} and click the button to connect your {kib} instance with {es}.
 

--- a/docs/en/stack/ml/anomaly-detection/ml-limitations.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-limitations.asciidoc
@@ -144,7 +144,7 @@ significantly slow the job. Use an indexed field as a time field when running
 [[ml-limitations-painless-script]]
 === Deprecation warnings for Painless scripts in {dfeeds}
 
-If a {dfeed} contains Painless scripts that use deprecated synatx, deprecation 
+If a {dfeed} contains Painless scripts that use deprecated syntax, deprecation 
 warnings are displayed when the {dfeed} is previewed or started. However, it is 
 not possible to check for deprecation warnings across all {dfeeds} as a bulk 
 action because running the required queries might be a resource intensive 

--- a/docs/en/stack/ml/anomaly-detection/ml-limitations.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-limitations.asciidoc
@@ -140,6 +140,17 @@ the performance impact of calculating field values at query time can
 significantly slow the job. Use an indexed field as a time field when running 
 {anomaly-jobs}.
 
+[discrete]
+[[ml-limitations-painless-script]]
+=== Deprecation warnings for Painless scripts
+
+If a {dfeed} contains Painless scripts that use deprecated synatx, deprecation 
+warnings are displayed when the {dfeed} is previewed or started. However, it is 
+not possible to check for deprecation warnings across all {dfeeds} as a bulk 
+action because running the required queries might be a resource intensive 
+process. Therefore any deprecation warnings due to deprecated Painless syntax is 
+not available in the Upgrade assistant.
+
 
 [discrete]
 [[ad-operational-limitations]]
@@ -159,16 +170,6 @@ Additionally, a dictionary used to influence the categorization process contains
 only English words. This means categorization might work better in English than
 in other languages. The ability to customize the dictionary will be added in a
 future release.
-
-
-[discrete]
-=== Post data API requires JSON format
-
-The post data API enables you to send data to a job for analysis. The data that
-you send to the job must use the JSON format.
-
-For more information about this API, see
-{ref}/ml-post-data.html[Post Data to Jobs].
 
 
 [discrete]

--- a/docs/en/stack/ml/anomaly-detection/ml-limitations.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-limitations.asciidoc
@@ -142,7 +142,7 @@ significantly slow the job. Use an indexed field as a time field when running
 
 [discrete]
 [[ml-limitations-painless-script]]
-=== Deprecation warnings for Painless scripts
+=== Deprecation warnings for Painless scripts in {dfeeds}
 
 If a {dfeed} contains Painless scripts that use deprecated synatx, deprecation 
 warnings are displayed when the {dfeed} is previewed or started. However, it is 

--- a/docs/en/stack/ml/anomaly-detection/ml-limitations.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-limitations.asciidoc
@@ -148,7 +148,7 @@ If a {dfeed} contains Painless scripts that use deprecated syntax, deprecation
 warnings are displayed when the {dfeed} is previewed or started. However, it is 
 not possible to check for deprecation warnings across all {dfeeds} as a bulk 
 action because running the required queries might be a resource intensive 
-process. Therefore any deprecation warnings due to deprecated Painless syntax is 
+process. Therefore any deprecation warnings due to deprecated Painless syntax are 
 not available in the Upgrade assistant.
 
 


### PR DESCRIPTION
## Overview

This PR applies the following changes on the anomaly detection limitations page:
* adds a limitation about deprecation messages for datafeeds that use Painless with deprecated syntax,
* removes a limitation regarding POST data API usage.

### Preview

[Deprecation warnings for Painless scripts](https://stack-docs_2125.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-limitations.html#ml-limitations-painless-script)