### PR TITLE
[DOCS] Adds Eland install instructions to NLP model import

### DIFF
--- a/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
@@ -50,7 +50,7 @@ Eland encapsulates both the conversion of Hugging Face transformer models to
 their TorchScript representations and the chunking process in a single Python
 method; it is therefore the recommended import method.
 
-. {eland-docs}/installation.html[Install the Eland Python client with PyTorch extra dependencies].
+. Install the {eland-docs}/installation.html[Eland Python client] with PyTorch extra dependencies.
 +
 --
 [source,shell]

--- a/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
@@ -51,6 +51,15 @@ their TorchScript representations and the chunking process in a single Python
 method; it is therefore the recommended import method.
 
 . {eland-docs}/installation.html[Install the Eland Python client].
++
+--
+[source,shell]
+--------------------------------------------------
+python -m pip install 'eland[pytorch]'
+--------------------------------------------------
+// NOTCONSOLE
+--
+
 . Run the `eland_import_hub_model` script. For example:
 +
 --

--- a/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
@@ -50,7 +50,7 @@ Eland encapsulates both the conversion of Hugging Face transformer models to
 their TorchScript representations and the chunking process in a single Python
 method; it is therefore the recommended import method.
 
-. {eland-docs}/installation.html[Install the Eland Python client].
+. {eland-docs}/installation.html[Install the Eland Python client with PyTorch extra dependencies].
 +
 --
 [source,shell]


### PR DESCRIPTION
## Overview

This PR adds the proper Eland install command to the NLP model import instructions.

### Preview

[Import trained model and vocabulary](https://stack-docs_2130.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-nlp-deploy-models.html)