### PR TITLE
[DOCS] Adds authentication methods to NLP import guide

### DIFF
--- a/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
@@ -86,7 +86,7 @@ For more details, refer to https://github.com/elastic/eland#nlp-with-pytorch.
 
 There are four authentication methods availabe when using the import script:
 
-* Cloud ID authentication for Elastic Cloud users:
+* Elastic Cloud users can use Cloud ID as an alternative to `--url`:
   
 [source, shell]
 --------------------------------------------------
@@ -107,7 +107,7 @@ eland_import_hub_model --url https://<hostname>:<port> -u <username> -p <passwor
 eland_import_hub_model --url https://<hostname>:<port> --es-api-key <api-key>
 --------------------------------------------------
 
-* HTTP authenthication (credentials are provided as the part of the cluster 
+* HTTP authentication (credentials are provided as the part of the cluster 
   URL):
   
 [source, shell]

--- a/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
@@ -84,20 +84,28 @@ For more details, refer to https://github.com/elastic/eland#nlp-with-pytorch.
 [[authentication]]
 === Authentication methods
 
-There are four authentication methods availabe when using the import script:
+The following authentication options are available when using the import script:
 
-* Elastic Cloud users can use Cloud ID as an alternative to `--url`:
-  
-[source, shell]
---------------------------------------------------
-eland_import_hub_model --cloud-id <cloud-id> -u <username> -p <password>
---------------------------------------------------
-
-* username/password authentication:
+* username/password authentication (specified with the `-u` and `-p` options):
   
 [source, shell]
 --------------------------------------------------
 eland_import_hub_model --url https://<hostname>:<port> -u <username> -p <password>
+--------------------------------------------------
+
+* username/password authentication (embedded in the URL parameter):
+
+[source, shell]
+--------------------------------------------------
+eland_import_hub_model --url https://<user>:<password>@<hostname>:<port>
+--------------------------------------------------
+
+* Elastic Cloud users can use Cloud ID instead of the URL parameter (`--es-url` 
+  and `--cloud-id` are mutually exclusive):
+  
+[source, shell]
+--------------------------------------------------
+eland_import_hub_model --cloud-id <cloud-id> -u <username> -p <password>
 --------------------------------------------------
 
 * API key authentication:
@@ -105,14 +113,6 @@ eland_import_hub_model --url https://<hostname>:<port> -u <username> -p <passwor
 [source, shell]
 --------------------------------------------------
 eland_import_hub_model --url https://<hostname>:<port> --es-api-key <api-key>
---------------------------------------------------
-
-* HTTP authentication (credentials are provided as the part of the cluster 
-  URL):
-  
-[source, shell]
---------------------------------------------------
-eland_import_hub_model --url https://<user>:<password>@<hostname>:<port>
 --------------------------------------------------
 
 

--- a/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
@@ -50,7 +50,8 @@ Eland encapsulates both the conversion of Hugging Face transformer models to
 their TorchScript representations and the chunking process in a single Python
 method; it is therefore the recommended import method.
 
-. Install the {eland-docs}/installation.html[Eland Python client] with PyTorch extra dependencies.
+. Install the {eland-docs}/installation.html[Eland Python client] with PyTorch 
+extra dependencies.
 +
 --
 [source,shell]
@@ -63,22 +64,39 @@ python -m pip install 'eland[pytorch]'
 . Run the `eland_import_hub_model` script. For example:
 +
 --
-[source,js]
+[source]
 --------------------------------------------------
-eland_import_hub_model --url <clusterUrl> \ <1>
+eland_import_hub_model <<authentication>> \ <1>
 --hub-model-id elastic/distilbert-base-cased-finetuned-conll03-english \ <2>
---task-type ner <3>
+--task-type ner \ <3>
 --------------------------------------------------
 // NOTCONSOLE
 --
-
-<1> Specify the URL to access your cluster. For example, 
-`https://<user>:<password>@<hostname>:<port>`.
+<1> Use an authentication method to access your cluster. Refer to 
+<<authentication>> to learn more. 
 <2> Specify the identifier for the model in the Hugging Face model hub.
 <3> Specify the type of NLP task. Supported values are `fill_mask`, `ner`,
 `text_classification`, `text_embedding`, and `zero_shot_classification`.
 
 For more details, refer to https://github.com/elastic/eland#nlp-with-pytorch.
+
+[discrete]
+[[authentication]]
+=== Authentication methods
+
+There are four authentication methods availabe when using the import script:
+* Cloud ID authentication for Elastic Cloud users:
+  `eland_import_hub_model --cloud-id <cloud-id> -u <username> -p <password>`
+* username/password authentication:
+  `eland_import_hub_model --url https://<hostname>:<port> -u <username> -p <password>`
+* API key authentication:
+  `eland_import_hub_model --url https://<hostname>:<port> --es-api-key <api-key>`
+* HTTP authenthication (credentials are provided as the part of the cluster 
+  URL):
+  `eland_import_hub_model --url https://<user>:<password>@<hostname>:<port>`.
+
+Credentials can also be specified as environment variables with 
+`ES_USERNAME/ES_PASSWORD` or `ES_API_KEY`. 
 
 [discrete]
 [[ml-nlp-deploy-model]]

--- a/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
@@ -64,9 +64,9 @@ python -m pip install 'eland[pytorch]'
 . Run the `eland_import_hub_model` script. For example:
 +
 --
-[source]
+[source, shell]
 --------------------------------------------------
-eland_import_hub_model <<authentication>> \ <1>
+eland_import_hub_model <authentication> \ <1>
 --hub-model-id elastic/distilbert-base-cased-finetuned-conll03-english \ <2>
 --task-type ner \ <3>
 --------------------------------------------------
@@ -85,6 +85,7 @@ For more details, refer to https://github.com/elastic/eland#nlp-with-pytorch.
 === Authentication methods
 
 There are four authentication methods availabe when using the import script:
+
 * Cloud ID authentication for Elastic Cloud users:
   `eland_import_hub_model --cloud-id <cloud-id> -u <username> -p <password>`
 * username/password authentication:
@@ -95,8 +96,6 @@ There are four authentication methods availabe when using the import script:
   URL):
   `eland_import_hub_model --url https://<user>:<password>@<hostname>:<port>`.
 
-Credentials can also be specified as environment variables with 
-`ES_USERNAME/ES_PASSWORD` or `ES_API_KEY`. 
 
 [discrete]
 [[ml-nlp-deploy-model]]

--- a/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
@@ -100,7 +100,7 @@ eland_import_hub_model --url https://<hostname>:<port> -u <username> -p <passwor
 eland_import_hub_model --url https://<user>:<password>@<hostname>:<port>
 --------------------------------------------------
 
-* Elastic Cloud users can use Cloud ID instead of the URL (`--es-url` 
+* Elastic Cloud users can use Cloud ID instead of the URL (`--url` 
   and `--cloud-id` are mutually exclusive):
   
 [source, shell]

--- a/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
@@ -100,7 +100,7 @@ eland_import_hub_model --url https://<hostname>:<port> -u <username> -p <passwor
 eland_import_hub_model --url https://<user>:<password>@<hostname>:<port>
 --------------------------------------------------
 
-* Elastic Cloud users can use Cloud ID instead of the URL parameter (`--es-url` 
+* Elastic Cloud users can use Cloud ID instead of the URL (`--es-url` 
   and `--cloud-id` are mutually exclusive):
   
 [source, shell]

--- a/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
@@ -87,14 +87,26 @@ For more details, refer to https://github.com/elastic/eland#nlp-with-pytorch.
 There are four authentication methods availabe when using the import script:
 
 * Cloud ID authentication for Elastic Cloud users:
-  `eland_import_hub_model --cloud-id <cloud-id> -u <username> -p <password>`
+  
+  ```
+  eland_import_hub_model --cloud-id <cloud-id> -u <username> -p <password>
+  ```
 * username/password authentication:
-  `eland_import_hub_model --url https://<hostname>:<port> -u <username> -p <password>`
+  
+  ```
+  eland_import_hub_model --url https://<hostname>:<port> -u <username> -p <password>
+  ```
 * API key authentication:
-  `eland_import_hub_model --url https://<hostname>:<port> --es-api-key <api-key>`
+  
+  ```
+  eland_import_hub_model --url https://<hostname>:<port> --es-api-key <api-key>
+  ```
 * HTTP authenthication (credentials are provided as the part of the cluster 
   URL):
-  `eland_import_hub_model --url https://<user>:<password>@<hostname>:<port>`.
+  
+  ```
+  eland_import_hub_model --url https://<user>:<password>@<hostname>:<port>
+  ```
 
 
 [discrete]

--- a/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
@@ -88,25 +88,32 @@ There are four authentication methods availabe when using the import script:
 
 * Cloud ID authentication for Elastic Cloud users:
   
-  ```
-  eland_import_hub_model --cloud-id <cloud-id> -u <username> -p <password>
-  ```
+[source, shell]
+--------------------------------------------------
+eland_import_hub_model --cloud-id <cloud-id> -u <username> -p <password>
+--------------------------------------------------
+
 * username/password authentication:
   
-  ```
-  eland_import_hub_model --url https://<hostname>:<port> -u <username> -p <password>
-  ```
+[source, shell]
+--------------------------------------------------
+eland_import_hub_model --url https://<hostname>:<port> -u <username> -p <password>
+--------------------------------------------------
+
 * API key authentication:
   
-  ```
-  eland_import_hub_model --url https://<hostname>:<port> --es-api-key <api-key>
-  ```
+[source, shell]
+--------------------------------------------------
+eland_import_hub_model --url https://<hostname>:<port> --es-api-key <api-key>
+--------------------------------------------------
+
 * HTTP authenthication (credentials are provided as the part of the cluster 
   URL):
   
-  ```
-  eland_import_hub_model --url https://<user>:<password>@<hostname>:<port>
-  ```
+[source, shell]
+--------------------------------------------------
+eland_import_hub_model --url https://<user>:<password>@<hostname>:<port>
+--------------------------------------------------
 
 
 [discrete]

--- a/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
@@ -93,7 +93,7 @@ The following authentication options are available when using the import script:
 eland_import_hub_model --url https://<hostname>:<port> -u <username> -p <password>
 --------------------------------------------------
 
-* username/password authentication (embedded in the URL parameter):
+* username/password authentication (embedded in the URL):
 
 [source, shell]
 --------------------------------------------------


### PR DESCRIPTION
## Overview

Related to https://github.com/elastic/eland/pull/461 and https://github.com/elastic/eland/pull/462

This PR adds an `Authentication methods` section to the NLP import guide that lists the available methods with examples.

### Preview

[Authentication methods](https://stack-docs_2132.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-nlp-deploy-models.html#authentication)