### PR TITLE
[DOCS] Updates list of security and auditbeat anomaly detection configurations

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-auditbeat.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-auditbeat.asciidoc
@@ -31,28 +31,4 @@ https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/
 
 |===
 
-[discrete]
-[[auditbeat-process-hosts-ecs]]
-== Auditbeat host processes
-
-Detect unusual processes on hosts from auditd data (ECS).
-
-These configurations are only available if data exists that matches the
-recognizer query specified in the
-https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/auditbeat_process_hosts_ecs/manifest.json[manifest file].
-
-|===
-|Name |Description |Job |Datafeed
-
-|hosts_high_count_process_events_ecs
-|Detect unusual increases in process execution rates (ECS)
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/auditbeat_process_hosts_ecs/ml/hosts_high_count_process_events_ecs.json[image:images/link.svg[A link icon]]
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/auditbeat_process_hosts_ecs/ml/datafeed_hosts_high_count_process_events_ecs.json[image:images/link.svg[A link icon]]
-
-|hosts_rare_process_activity_ecs
-|Detect rare process executions on hosts (ECS)
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/auditbeat_process_hosts_ecs/ml/hosts_rare_process_activity_ecs.json[image:images/link.svg[A link icon]]
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/auditbeat_process_hosts_ecs/ml/datafeed_hosts_rare_process_activity_ecs.json[image:images/link.svg[A link icon]]
-
-|===
 // end::auditbeat-jobs[]

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-siem.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-siem.asciidoc
@@ -304,7 +304,7 @@ for data that matches the query.
 [[security-windows-jobs]]
 == Security: Windows
 
-Anomaly detection jobs for Windows host based threat hunting and detection.
+Anomaly detection jobs for Windows host-based threat hunting and detection.
 
 In the {ml-app} app, these configurations are available only when data exists
 that matches the query specified in the

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-siem.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-siem.asciidoc
@@ -120,7 +120,7 @@ for data that matches the query.
 [[security-linux-jobs]]
 == Security: Linux
 
-Anomaly detection jobs for Linux host based threat hunting and detection.
+Anomaly detection jobs for Linux host-based threat hunting and detection.
 
 In the {ml-app} app, these configurations are available only when data exists
 that matches the query specified in the

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-siem.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-siem.asciidoc
@@ -9,159 +9,6 @@ For more information, refer to
 {security-guide}/machine-learning.html[Anomaly detection with machine learning].
 
 [discrete]
-[[security-auditbeat-jobs]]
-== Security: {auditbeat}
-
-Detect suspicious network activity and unusual processes in {auditbeat} data.
-
-In the {ml-app} app, these configurations are available only when data exists
-that matches the query specified in the
-https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_auditbeat/manifest.json#L8[manifest file].
-In the {security-app}, it looks in the {data-source} specified in the
-{kibana-ref}/advanced-options.html#securitysolution-defaultindex[`securitySolution:defaultIndex` advanced setting]
-for data that matches the query.
-
-IMPORTANT: In 7.11 or later versions, use the <<security-linux-jobs>> jobs
-instead.footnote:duplicatelinuxjobs[If you cannot upgrade all your Beats to
-version 7.11 or later and you have both <<security-linux-jobs>> and
-<<security-auditbeat-jobs>> jobs running, you can avoid duplication by stopping
-the following jobs: `linux_anomalous_network_activity_ecs`, 
-`linux_anomalous_network_port_activity_ecs`,
-`linux_anomalous_process_all_hosts_ecs`, `linux_anomalous_user_name_ecs`, 
-`linux_rare_metadata_process`, `linux_rare_metadata_user`,
-`rare_process_by_host_linux_ecs`.]
-
-// tag::siem-auditbeat-jobs[]
-
-|===
-|Name |Description |Job |Datafeed
-
-|linux_anomalous_network_activity_ecs
-|Looks for unusual processes using the network which could indicate command-and-control, lateral movement, persistence, or data exfiltration activity.
-//A process with unusual network activity can denote process exploitation or injection, where the process is used to run persistence mechanisms that allow a malicious actor remote access or control of the host, data exfiltration, and execution of unauthorized network applications.
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_auditbeat/ml/linux_anomalous_network_activity_ecs.json[image:images/link.svg[A link icon]]
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_auditbeat/ml/datafeed_linux_anomalous_network_activity_ecs.json[image:images/link.svg[A link icon]]
-
-|linux_anomalous_network_port_activity_ecs
-|Looks for unusual destination port activity that could indicate command-and-control, persistence mechanism, or data exfiltration activity.
-//Rarely used destination port activity is generally unusual in Linux fleets, and can indicate unauthorized access or threat actor activity.
-NOTE: This job is available only when you use {auditbeat} to ship data.
-footnote:compatible[Some jobs use fields that are not ECS-compliant. These jobs
-are available only when you use {beats} or the {agent} to ship data.]
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_auditbeat/ml/linux_anomalous_network_port_activity_ecs.json[image:images/link.svg[A link icon]]
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_auditbeat/ml/datafeed_linux_anomalous_network_port_activity_ecs.json[image:images/link.svg[A link icon]]
-
-|linux_anomalous_network_service
-|Looks for unusual listening ports that could indicate execution of unauthorized services, backdoors, or persistence mechanisms. NOTE: This job is available only when you use {auditbeat} to ship data.footnote:compatible[]
-|https://github.com/elastic/kibana/blob/{branch})/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_auditbeat/ml/linux_anomalous_network_service.json[image:images/link.svg[A link icon]]
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_auditbeat/ml/datafeed_linux_anomalous_network_service.json[image:images/link.svg[A link icon]]
-
-|linux_anomalous_network_url_activity_ecs
-|Looks for an unusual web URL request from a Linux instance. Curl and wget web request activity is very common but unusual web requests from a Linux server can sometimes be malware delivery or execution.
-//Wget and cURL are commonly used by Linux programs to download code and data. Most of the time, their usage is entirely normal. Generally, because they use a list of URLs, they repeatedly download from the same locations. However, Wget and cURL are sometimes used to deliver Linux exploit payloads, and threat actors use these tools to download additional software and code. For these reasons, unusual URLs can indicate unauthorized downloads or threat activity.
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_auditbeat/ml/linux_anomalous_network_url_activity_ecs.json[image:images/link.svg[A link icon]]
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_auditbeat/ml/datafeed_linux_anomalous_network_url_activity_ecs.json[image:images/link.svg[A link icon]]
-
-|linux_anomalous_process_all_hosts_ecs
-|Looks for processes that are unusual to all Linux hosts. Such unusual processes may indicate unauthorized services, malware, or persistence mechanisms.
-//Searches for rare processes running on multiple hosts in an entire fleet or network. This reduces the detection of false positives since automated maintenance processes usually only run occasionally on a single machine but are common to all or many hosts in a fleet.
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_auditbeat/ml/linux_anomalous_process_all_hosts_ecs.json[image:images/link.svg[A link icon]]
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_auditbeat/ml/datafeed_linux_anomalous_process_all_hosts_ecs.json[image:images/link.svg[A link icon]]
-
-|linux_anomalous_user_name_ecs
-|Rare and unusual users that are not normally active may indicate unauthorized changes or activity by an unauthorized user which may be credentialed access or lateral movement.
-// Searches for activity from users who are not normally active, which can indicate unauthorized changes, activity by unauthorized users, lateral movement, and compromised credentials. In organizations, new usernames are not often created apart from specific types of system activities, such as creating new accounts for new employees. These user accounts quickly become active and routine. Events from rarely used usernames can point to suspicious activity. Additionally, automated Linux fleets tend to see activity from rarely used usernames only when personnel log in to make authorized or unauthorized  changes, or threat actors have acquired credentials and log in for malicious purposes. Unusual usernames can also indicate pivoting, where compromised credentials are used to try and move laterally from one host to another.
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_auditbeat/ml/linux_anomalous_user_name_ecs.json[image:images/link.svg[A link icon]]
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_auditbeat/ml/datafeed_linux_anomalous_user_name_ecs.json[image:images/link.svg[A link icon]]
-
-|linux_network_configuration_discovery
-|Looks for commands related to system network configuration discovery from an unusual user context. This can be due to uncommon troubleshooting activity or due to a compromised account. A compromised account may be used by a threat actor to engage in system network configuration discovery in order to increase their understanding of connected networks and hosts. This information may be used to shape follow-up behaviors such as lateral movement or additional discovery.
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_auditbeat/ml/linux_network_configuration_discovery.json[image:images/link.svg[A link icon]]
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_auditbeat/ml/datafeed_linux_network_configuration_discovery.json[image:images/link.svg[A link icon]]
-
-|linux_network_connection_discovery
-|Looks for commands related to system network connection discovery from an unusual user context. This can be due to uncommon troubleshooting activity or due to a compromised account. A compromised account may be used by a threat actor to engage in system network connection discovery in order to increase their understanding of connected services and systems. This information may be used to shape follow-up behaviors such as lateral movement or additional discovery.
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_auditbeat/ml/linux_network_connection_discovery.json[image:images/link.svg[A link icon]]
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_auditbeat/ml/datafeed_linux_network_connection_discovery.json[image:images/link.svg[A link icon]]
-
-|linux_rare_kernel_module_arguments
-|Looks for unusual kernel modules which are often used for stealth.
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_auditbeat/ml/linux_rare_kernel_module_arguments.json[image:images/link.svg[A link icon]]
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_auditbeat/ml/datafeed_linux_rare_kernel_module_arguments.json[image:images/link.svg[A link icon]]
-
-|linux_rare_metadata_process
-|Looks for anomalous access to the metadata service by an unusual process. The metadata service may be targeted in order to harvest credentials or user data scripts containing secrets.
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_auditbeat/ml/linux_rare_metadata_process.json[image:images/link.svg[A link icon]]
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_auditbeat/ml/datafeed_linux_rare_metadata_process.json[image:images/link.svg[A link icon]]
-
-|linux_rare_metadata_user
-|Looks for anomalous access to the metadata service by an unusual user. The metadata service may be targeted in order to harvest credentials or user data scripts containing secrets.
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_auditbeat/ml/linux_rare_metadata_user.json[image:images/link.svg[A link icon]]
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_auditbeat/ml/datafeed_linux_rare_metadata_user.json[image:images/link.svg[A link icon]]
-
-|linux_rare_sudo_user
-|Looks for sudo activity from an unusual user context.
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_auditbeat/ml/linux_rare_sudo_user.json[image:images/link.svg[A link icon]]
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_auditbeat/ml/datafeed_linux_rare_sudo_user.json[image:images/link.svg[A link icon]]
-
-|linux_rare_user_compiler
-|Looks for compiler activity by a user context which does not normally run compilers. This can be ad-hoc software changes or unauthorized software deployment. This can also be due to local privilege elevation via locally run exploits or malware activity.
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_auditbeat/ml/linux_rare_user_compiler.json[image:images/link.svg[A link icon]]
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_auditbeat/ml/datafeed_linux_rare_user_compiler.json[image:images/link.svg[A link icon]]
-
-|linux_system_information_discovery
-|Looks for commands related to system information discovery from an unusual user context. This can be due to uncommon troubleshooting activity or due to a compromised account. A compromised account may be used to engage in system information discovery in order to gather detailed information about system configuration and software versions. This may be a precursor to selection of a persistence mechanism or a method of privilege elevation.
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_auditbeat/ml/linux_system_information_discovery.json[image:images/link.svg[A link icon]]
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_auditbeat/ml/datafeed_linux_system_information_discovery.json[image:images/link.svg[A link icon]]
-
-|linux_system_process_discovery
-|Looks for commands related to system process discovery from an unusual user context. This can be due to uncommon troubleshooting activity or due to a compromised account. A compromised account may be used to engage in system process discovery in order to increase their understanding of software applications running on a target host or network. This may be a precursor to selection of a persistence mechanism or a method of privilege elevation.
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_auditbeat/ml/linux_system_process_discovery.json[image:images/link.svg[A link icon]]
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_auditbeat/ml/datafeed_linux_system_process_discovery.json[image:images/link.svg[A link icon]]
-
-|linux_system_user_discovery
-|Looks for commands related to system user or owner discovery from an unusual user context. This can be due to uncommon troubleshooting activity or due to a compromised account. A compromised account may be used to engage in system owner or user discovery in order to identify currently active or primary users of a system. This may be a precursor to additional discovery, credential dumping or privilege elevation activity.
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_auditbeat/ml/linux_system_user_discovery.json[image:images/link.svg[A link icon]]
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_auditbeat/ml/datafeed_linux_system_user_discovery.json[image:images/link.svg[A link icon]]
-
-|rare_process_by_host_linux_ecs
-|Detect unusually rare processes on Linux.
-//Identifies rare processes that do not usually run on individual hosts, which can indicate execution of unauthorized services, malware, or persistence mechanisms. Processes are considered rare when they only run occasionally as compared with other processes running on the host.
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_auditbeat/ml/rare_process_by_host_linux_ecs.json[image:images/link.svg[A link icon]]
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_auditbeat/ml/datafeed_rare_process_by_host_linux_ecs.json[image:images/link.svg[A link icon]]
-
-|===
-
-// end::siem-auditbeat-jobs[]
-
-[discrete]
-[[security-auditbeat-authentication-jobs]]
-== Security: {auditbeat} authentication
-
-Detect suspicious authentication events in {auditbeat} data.
-
-In the {ml-app} app, these configurations are available only when data exists
-that matches the query specified in the
-https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_auditbeat_auth/manifest.json#L8[manifest file].
-In the {security-app}, it looks in the {data-source} specified in the
-{kibana-ref}/advanced-options.html#securitysolution-defaultindex[`securitySolution:defaultIndex` advanced setting] for data that matches the query.
-
-// tag::siem-auditbeat-auth-jobs[]
-
-[cols="1,1,1,1"]
-|===
-|Name |Description |Job |Datafeed
-
-|suspicious_login_activity_ecs
-|Identifies an unusually high number of authentication attempts.
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_auditbeat_auth/ml/datafeed_suspicious_login_activity_ecs.json[image:images/link.svg[A link icon]]
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_auditbeat_auth/ml/suspicious_login_activity_ecs.json[image:images/link.svg[A link icon]]
-
-|===
-
-// end::siem-auditbeat-auth-jobs[]
-
-[discrete]
 [[security-authentication]]
 == Security: Authentication
 
@@ -186,7 +33,7 @@ then select it in the job wizard.
 |Name |Description |Job |Datafeed
 
 |auth_high_count_logon_events
-|Looks for an unusually large spike in successful authentication events. This can be due to password spraying, user enumeration or brute force activity.
+|looks for an unusually large spike in successful authentication events. This can be due to password spraying, user enumeration or brute force activity.
 |https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_auth/ml/auth_high_count_logon_events.json[image:images/link.svg[A link icon]]
 |https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_auth/ml/datafeed_auth_high_count_logon_events.json[image:images/link.svg[A link icon]]
 
@@ -196,7 +43,7 @@ then select it in the job wizard.
 |https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_auth/ml/datafeed_auth_high_count_logon_events_for_a_source_ip.json[image:images/link.svg[A link icon]]
 
 |auth_high_count_logon_fails
-|Looks for an unusually large spike in authentication failure events. This can be due to password spraying, user enumeration or brute force activity and may be a precursor to account takeover or credentialed access.
+|looks for an unusually large spike in authentication failure events. This can be due to password spraying, user enumeration or brute force activity and may be a precursor to account takeover or credentialed access.
 |https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_auth/ml/auth_high_count_logon_fails.json[image:images/link.svg[A link icon]]
 |https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_auth/ml/datafeed_auth_high_count_logon_fails.json[image:images/link.svg[A link icon]]
 
@@ -211,10 +58,14 @@ then select it in the job wizard.
 | https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_auth/ml/datafeed_auth_rare_source_ip_for_a_user.json[image:images/link.svg[A link icon]]
 
 |auth_rare_user
-|Looks for an unusual user name in the authentication logs. An unusual user name is one way of detecting credentialed access by means of a new or dormant user account. A user account that is normally inactive, because the user has left the organization, which becomes active, may be due to credentialed access using a
-compromised account password. Threat actors will sometimes also create new users as a means of persisting in a compromised web application.
+|Looks for an unusual user name in the authentication logs. An unusual user name is one way of detecting credentialed access by means of a new or dormant user account. A user account that is normally inactive, because the user has left the organization, which becomes active, may be due to credentialed access using a compromised account password. Threat actors will sometimes also create new users as a means of persisting in a compromised web application.
 |https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_auth/ml/auth_rare_user.json[image:images/link.svg[A link icon]]
 |https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_auth/ml/datafeed_auth_rare_user.json[image:images/link.svg[A link icon]]
+
+|suspicious_login_activity
+|Detect unusually high number of authentication attempts.
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_auth/ml/datafeed_suspicious_login_activity.json[image:images/link.svg[A link icon]]
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_auth/ml/suspicious_login_activity.json[image:images/link.svg[A link icon]]
 
 |===
 
@@ -269,7 +120,7 @@ for data that matches the query.
 [[security-linux-jobs]]
 == Security: Linux
 
-Detect suspicious activity using ECS Linux events.
+Anomaly detection jobs for Linux host based threat hunting and detection.
 
 In the {ml-app} app, these configurations are available only when data exists
 that matches the query specified in the
@@ -278,42 +129,81 @@ In the {security-app}, it looks in the {data-source} specified in the
 {kibana-ref}/advanced-options.html#securitysolution-defaultindex[`securitySolution:defaultIndex` advanced setting]
 for data that matches the query.
 
-IMPORTANT: In 7.11 or later versions, use these jobs instead of the <<security-auditbeat-jobs>> jobs.footnote:duplicatelinuxjobs[]
-
 // tag::security-linux-jobs[]
 
 |===
 |Name |Description |Job |Datafeed
 
-|v2_linux_anomalous_network_port_activity_ecs
-|This is a new refactored job which works on ECS compatible events across multiple indices. Looks for unusual destination port activity that could indicate command-and-control, persistence mechanism, or data exfiltration activity.
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux/ml/v2_linux_anomalous_network_port_activity_ecs.json[image:images/link.svg[A link icon]]
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux/ml/datafeed_v2_linux_anomalous_network_port_activity_ecs.json[image:images/link.svg[A link icon]]
+|v3_linux_anomalous_network_activity
+|Looks for unusual processes using the network which could indicate command-and-control, lateral movement, persistence, or data exfiltration activity.
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux/ml/v3_linux_anomalous_network_activity.json[image:images/link.svg[A link icon]]
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux/ml/datafeed_v3_linux_anomalous_network_activity.json[image:images/link.svg[A link icon]]
 
-|v2_linux_anomalous_process_all_hosts_ecs
-|This is a new refactored job which works on ECS compatible events across multiple indices. Looks for processes that are unusual to all Linux hosts. Such unusual processes may indicate unauthorized services, malware, or persistence mechanisms.
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux/ml/v2_linux_anomalous_process_all_hosts_ecs.json[image:images/link.svg[A link icon]]
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux/ml/datafeed_v2_linux_anomalous_process_all_hosts_ecs.json[image:images/link.svg[A link icon]]
 
-|v2_linux_anomalous_user_name_ecs
-|This is a new refactored job which works on ECS compatible events across multiple indices. Rare and unusual users that are not normally active may indicate unauthorized changes or activity by an unauthorized user which may be credentialed access or lateral movement.
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux/ml/v2_linux_anomalous_user_name_ecs.json[image:images/link.svg[A link icon]]
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux/ml/datafeed_v2_linux_anomalous_user_name_ecs.json[image:images/link.svg[A link icon]]
+|v3_linux_anomalous_network_port_activity
+|Looks for unusual destination port activity that could indicate command-and-control, persistence mechanism, or data exfiltration activity.
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux/ml/v3_linux_anomalous_network_port_activity.json[image:images/link.svg[A link icon]]
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux/ml/datafeed_v3_linux_anomalous_network_port_activity.json[image:images/link.svg[A link icon]]
 
-|v2_linux_rare_metadata_process
-|This is a new refactored job which works on ECS compatible events across multiple indices. Looks for anomalous access to the metadata service by an unusual process. The metadata service may be targeted in order to harvest credentials or user data scripts containing secrets.
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux/ml/v2_linux_rare_metadata_process.json[image:images/link.svg[A link icon]]
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux/ml/datafeed_v2_linux_rare_metadata_process.json[image:images/link.svg[A link icon]]
+|v3_linux_anomalous_process_all_hosts
+|Looks for processes that are unusual to all Linux hosts. Such unusual processes may indicate unauthorized software, malware, or persistence mechanisms.
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux/ml/v3_linux_anomalous_process_all_hosts.json[image:images/link.svg[A link icon]]
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux/ml/datafeed_v3_linux_anomalous_process_all_hosts.json[image:images/link.svg[A link icon]]
 
-|v2_linux_rare_metadata_user
-|This is a new refactored job which works on ECS compatible events across multiple indices. Looks for anomalous access to the metadata service by an unusual user. The metadata service may be targeted in order to harvest credentials or user data scripts containing secrets.
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux/ml/v2_linux_rare_metadata_user.json[image:images/link.svg[A link icon]]
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux/ml/datafeed_v2_linux_rare_metadata_user.json[image:images/link.svg[A link icon]]
+|v3_linux_anomalous_user_name
+|Rare and unusual users that are not normally active may indicate unauthorized changes or activity by an unauthorized user which may be credentialed access or lateral movement.
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux/ml/v3_linux_anomalous_user_name.json[image:images/link.svg[A link icon]]
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux/ml/datafeed_v3_linux_anomalous_user_name.json[image:images/link.svg[A link icon]]
 
-|v2_rare_process_by_host_linux_ecs
-|This is a new refactored job which works on ECS compatible events across multiple indices. Looks for processes that are unusual to a particular Linux host. Such unusual processes may indicate unauthorized services, malware, or persistence mechanisms.
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux/ml/v2_rare_process_by_host_linux_ecs.json[image:images/link.svg[A link icon]]
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux/ml/datafeed_v2_rare_process_by_host_linux_ecs.json[image:images/link.svg[A link icon]]
+|v3_linux_network_configuration_discovery
+|Looks for commands related to system network configuration discovery from an unusual user context. This can be due to uncommon troubleshooting activity or due to a compromised account. A compromised account may be used by a threat actor to engage in system network configuration discovery to increase their understanding of connected networks and hosts. This information may be used to shape follow-up behaviors such as lateral movement or additional discovery.
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux/ml/v3_linux_network_configuration_discovery.json[image:images/link.svg[A link icon]]
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux/ml/v3_datafeed_linux_network_configuration_discovery.json[image:images/link.svg[A link icon]]
+
+|v3_linux_network_connection_discovery
+|Looks for commands related to system network connection discovery from an unusual user context. This can be due to uncommon troubleshooting activity or due to a compromised account. A compromised account may be used by a threat actor to engage in system network connection discovery to increase their understanding of connected services and systems. This information may be used to shape follow-up behaviors such as lateral movement or additional discovery.
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux/ml/v3_linux_network_connection_discovery.json[image:images/link.svg[A link icon]]
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux/ml/v3_datafeed_linux_network_connection_discovery.json[image:images/link.svg[A link icon]]
+
+|v3_linux_rare_metadata_process
+|Looks for anomalous access to the metadata service by an unusual process. The metadata service may be targeted in order to harvest credentials or user data scripts containing secrets.
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux/ml/v3_linux_rare_metadata_process.json[image:images/link.svg[A link icon]]
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux/ml/datafeed_v3_linux_rare_metadata_process.json[image:images/link.svg[A link icon]]
+
+|v3_linux_rare_metadata_user
+|Looks for anomalous access to the metadata service by an unusual user. The metadata service may be targeted in order to harvest credentials or user data scripts containing secrets.
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux/ml/v3_linux_rare_metadata_user.json[image:images/link.svg[A link icon]]
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux/ml/datafeed_v3_linux_rare_metadata_user.json[image:images/link.svg[A link icon]]
+
+|v3_linux_rare_sudo_user
+|Looks for sudo activity from an unusual user context. Unusual user context changes can be due to privilege escalation.
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux/ml/v3_linux_rare_sudo_user.json[image:images/link.svg[A link icon]]
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/securiity_linux/ml/datafeed_v3_linux_rare_sudo_user.json[image:images/link.svg[A link icon]]
+
+|v3_linux_rare_user_compiler
+|Looks for compiler activity by a user context which does not normally run compilers. This can be ad-hoc software changes or unauthorized software deployment. This can also be due to local privilege elevation via locally run exploits or malware activity.
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux/ml/v3_linux_rare_user_compiler.json[image:images/link.svg[A link icon]]
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux/ml/datafeed_v3_linux_rare_user_compiler.json[image:images/link.svg[A link icon]]
+
+|v3_linux_system_information_discovery
+|Looks for commands related to system information discovery from an unusual user context. This can be due to uncommon troubleshooting activity or due to a compromised account. A compromised account may be used to engage in system information discovery to gather detailed information about system configuration and software versions. This may be a precursor to the selection of a persistence mechanism or a method of privilege elevation.
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux/ml/v3_linux_system_information_discovery.json[image:images/link.svg[A link icon]]
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux/ml/datafeed_v3_linux_system_information_discovery.json[image:images/link.svg[A link icon]]
+
+|v3_linux_system_process_discovery
+|Looks for commands related to system process discovery from an unusual user context. This can be due to uncommon troubleshooting activity or due to a compromised account. A compromised account may be used to engage in system process discovery to increase their understanding of software applications running on a target host or network. This may be a precursor to the selection of a persistence mechanism or a method of privilege elevation.
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux/ml/v3_linux_system_process_discovery.json[image:images/link.svg[A link icon]]
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux/ml/datafeed_v3_linux_system_process_discovery.json[image:images/link.svg[A link icon]]
+
+|v3_linux_system_user_discovery
+|Looks for commands related to system user or owner discovery from an unusual user context. This can be due to uncommon troubleshooting activity or due to a compromised account. A compromised account may be used to engage in system owner or user discovery to identify currently active or primary users of a system. This may be a precursor to additional discovery, credential dumping, or privilege elevation activity.
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux/ml/v3_linux_system_user_discovery.json[image:images/link.svg[A link icon]]
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux/ml/datafeed_v3_linux_system_user_discovery.json[image:images/link.svg[A link icon]]
+
+|v3_rare_process_by_host_linux
+|Looks for processes that are unusual to a particular Linux host. Such unusual processes may indicate unauthorized software, malware, or persistence mechanisms.
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux/ml/v3_rare_process_by_host_linux.json[image:images/link.svg[A link icon]]
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_linux/ml/datafeed_v3_rare_process_by_host_linux.json[image:images/link.svg[A link icon]]
 
 |===
 // end::security-linux-jobs[]
@@ -414,7 +304,7 @@ for data that matches the query.
 [[security-windows-jobs]]
 == Security: Windows
 
-Detects suspicious activity using ECS Windows events.
+Anomaly detection jobs for Windows host based threat hunting and detection.
 
 In the {ml-app} app, these configurations are available only when data exists
 that matches the query specified in the
@@ -427,163 +317,71 @@ If there are additional requirements such as installing the Windows System
 Monitor (Sysmon) or auditing process creation in the Windows security event log,
 they are listed for each job.
 
-IMPORTANT: In 7.11 or later versions, use these jobs instead of the
-<<security-winlogbeat-jobs>> jobs.footnote:duplicatewindowsjobs[If you cannot
-upgrade all your Beats to version 7.11 or later and you have both
-<<security-windows-jobs,Security:Windows jobs>> and
-<<security-winlogbeat-jobs,Security:Winlogbeat jobs>> running, you can avoid 
-duplication by stopping the following jobs: `rare_process_by_host_windows_ecs`, 
-`windows_anomalous_network_activity_ecs`, `windows_anomalous_path_activity_ecs`, 
-`windows_anomalous_process_all_hosts_ecs`, `windows_anomalous_process_creation`, 
-`windows_anomalous_user_name_ecs`, `windows_rare_metadata_process`, 
-`windows_rare_metadata_user`]
-
 // tag::security-windows-jobs[]
 
 |===
 |Name |Description |Job |Datafeed
 
-|v2_rare_process_by_host_windows_ecs
-|This is a new refactored job which works on ECS compatible events across multiple indices. Detects unusually rare processes on Windows hosts.
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows/ml/v2_rare_process_by_host_windows_ecs.json[image:images/link.svg[A link icon]]
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows/ml/datafeed_v2_rare_process_by_host_windows_ecs.json[image:images/link.svg[A link icon]]
+|v3_rare_process_by_host_windows
+|Looks for processes that are unusual to a particular Windows host. Such unusual processes may indicate unauthorized software, malware, or persistence mechanisms.
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows/ml/v3_rare_process_by_host_windows.json[image:images/link.svg[A link icon]]
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows/ml/datafeed_v3_rare_process_by_host_windows.json[image:images/link.svg[A link icon]]
 
-|v2_windows_anomalous_network_activity_ecs
-|This is a new refactored job which works on ECS compatible events across multiple indices. Looks for unusual processes using the network which could indicate command-and-control, lateral movement, persistence, or data exfiltration activity.
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows/ml/v2_windows_anomalous_network_activity_ecs.json[image:images/link.svg[A link icon]]
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows/ml/datafeed_v2_windows_anomalous_network_activity_ecs.json[image:images/link.svg[A link icon]]
+|v3_windows_anomalous_network_activity
+|Looks for unusual processes using the network which could indicate command-and-control, lateral movement, persistence, or data exfiltration activity.
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows/ml/v3_windows_anomalous_network_activity.json[image:images/link.svg[A link icon]]
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows/ml/datafeed_v3_windows_anomalous_network_activity.json[image:images/link.svg[A link icon]]
 
-|v2_windows_anomalous_path_activity_ecs
-|This is a new refactored job which works on ECS compatible events across multiple indices. Looks for activity in unusual paths that may indicate execution of malware or persistence mechanisms. Windows payloads often execute from user profile paths.
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows/ml/v2_windows_anomalous_path_activity_ecs.json[image:images/link.svg[A link icon]]
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows/ml/datafeed_v2_windows_anomalous_path_activity_ecs.json[image:images/link.svg[A link icon]]
+|v3_windows_anomalous_path_activity
+|Looks for activity in unusual paths that may indicate execution of malware or persistence mechanisms. Windows payloads often execute from user profile paths.
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows/ml/v3_windows_anomalous_path_activity.json[image:images/link.svg[A link icon]]
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows/ml/datafeed_v3_windows_anomalous_path_activity.json[image:images/link.svg[A link icon]]
 
-|v2_windows_anomalous_process_all_hosts_ecs
-|This is a new refactored job which works on ECS compatible events across multiple indices. Looks for processes that are unusual to all Windows hosts. Such unusual processes may indicate execution of unauthorized services, malware, or persistence mechanisms.
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows/ml/v2_windows_anomalous_process_all_hosts_ecs.json[image:images/link.svg[A link icon]]
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows/ml/datafeed_v2_windows_anomalous_process_all_hosts_ecs.json[image:images/link.svg[A link icon]]
+|v3_windows_anomalous_process_all_hosts
+|Looks for processes that are unusual to all Windows hosts. Such unusual processes may indicate execution of unauthorized software, malware, or persistence mechanisms.
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows/ml/v3_windows_anomalous_process_all_hosts.json[image:images/link.svg[A link icon]]
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows/ml/datafeed_v3_windows_anomalous_process_all_hosts.json[image:images/link.svg[A link icon]]
 
-|v2_windows_anomalous_process_creation
-|This is a new refactored job which works on ECS compatible events across multiple indices. Looks for unusual process relationships which may indicate execution of malware or persistence mechanisms.
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows/ml/v2_windows_anomalous_process_creation.json[image:images/link.svg[A link icon]]
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows/ml/datafeed_v2_windows_anomalous_process_creation.json[image:images/link.svg[A link icon]]
+|v3_windows_anomalous_process_creation
+|Looks for unusual process relationships which may indicate execution of malware or persistence mechanisms.
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows/ml/v3_windows_anomalous_process_creation.json[image:images/link.svg[A link icon]]
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows/ml/datafeed_v3_windows_anomalous_process_creation.json[image:images/link.svg[A link icon]]
 
-|v2_windows_anomalous_user_name_ecs
-|This is a new refactored job which works on ECS compatible events across multiple indices. Rare and unusual users that are not normally active may indicate unauthorized changes or activity by an unauthorized user which may be credentialed access or lateral movement.
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows/ml/v2_windows_anomalous_user_name_ecs.json[image:images/link.svg[A link icon]]
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows/ml/datafeed_v2_windows_anomalous_user_name_ecs.json[image:images/link.svg[A link icon]]
+|v3_windows_anomalous_script
+|Looks for unusual powershell scripts that may indicate execution of malware, or persistence mechanisms.
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows/ml/v3_windows_anomalous_script.json[image:images/link.svg[A link icon]]
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows/ml/datafeed_v3_windows_anomalous_script.json[image:images/link.svg[A link icon]]
 
-|v2_windows_rare_metadata_process
-|This is a new refactored job which works on ECS compatible events across multiple indices. Looks for anomalous access to the metadata service by an unusual process. The metadata service may be targeted in order to harvest credentials or user data scripts containing secrets.
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows/ml/v2_windows_rare_metadata_process.json[image:images/link.svg[A link icon]]
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows/ml/datafeed_v2_windows_rare_metadata_process.json[image:images/link.svg[A link icon]]
+|v3_windows_anomalous_service
+|Looks for rare and unusual Windows service names which may indicate execution of unauthorized services, malware, or persistence mechanisms.
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows/ml/v3_windows_anomalous_service.json[image:images/link.svg[A link icon]]
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows/ml/datafeed_v3_windows_anomalous_service.json[image:images/link.svg[A link icon]]
 
-|v2_windows_rare_metadata_user
-|This is a new refactored job which works on ECS compatible events across multiple indices. Looks for anomalous access to the metadata service by an unusual user. The metadata service may be targeted in order to harvest credentials or user data scripts containing secrets.
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows/ml/v2_windows_rare_metadata_user.json[image:images/link.svg[A link icon]]
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows/ml/datafeed_v2_windows_rare_metadata_user.json[image:images/link.svg[A link icon]]
+|v3_windows_anomalous_user_name
+|Rare and unusual users that are not normally active may indicate unauthorized changes or activity by an unauthorized user which may be credentialed access or lateral movement.
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows/ml/v3_windows_anomalous_user_name.json[image:images/link.svg[A link icon]]
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows/ml/datafeed_v3_windows_anomalous_user_name.json[image:images/link.svg[A link icon]]
+
+|v3_windows_rare_metadata_process
+|Looks for anomalous access to the metadata service by an unusual process. The metadata service may be targeted in order to harvest credentials or user data scripts containing secrets.
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows/ml/v3_windows_rare_metadata_process.json[image:images/link.svg[A link icon]]
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows/ml/datafeed_v3_windows_rare_metadata_process.json[image:images/link.svg[A link icon]]
+
+|v3_windows_rare_metadata_user
+|Looks for anomalous access to the metadata service by an unusual user. The metadata service may be targeted in order to harvest credentials or user data scripts containing secrets.
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows/ml/v3_windows_rare_metadata_user.json[image:images/link.svg[A link icon]]
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows/ml/datafeed_v3_windows_rare_metadata_user.json[image:images/link.svg[A link icon]]
+
+|v3_windows_rare_user_runas_event
+|Unusual user context switches can be due to privilege escalation.
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows/ml/v3_windows_rare_user_runas_event.json[image:images/link.svg[A link icon]]
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows/ml/datafeed_v3_windows_rare_user_runas_event.json[image:images/link.svg[A link icon]]
+
+|v3_windows_rare_user_type10_remote_login
+|Unusual RDP (remote desktop protocol) user logins can indicate account takeover or credentialed access.
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows/ml/v3_windows_rare_user_type10_remote_login.json[image:images/link.svg[A link icon]]
+|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_windows/ml/datafeed_v3_windows_rare_user_type10_remote_login.json[image:images/link.svg[A link icon]]
+
 |===
 // end::security-windows-jobs[]
-
-[discrete]
-[[security-winlogbeat-jobs]]
-== Security: {winlogbeat}
-
-Detect unusual processes and network activity in {winlogbeat} data.
-
-In the {ml-app} app, these configurations are available only when data exists
-that matches the query specified in the
-https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_winlogbeat/manifest.json#L8[manifest file].
-In the {security-app}, it looks in the {data-source} specified in the
-{kibana-ref}/advanced-options.html#securitysolution-defaultindex[`securitySolution:defaultIndex` advanced setting]
-for data that matches the query.
-
-IMPORTANT: In 7.11 or later versions, use the <<security-windows-jobs>> jobs instead.footnote:duplicatewindowsjobs[]
-
-// tag::siem-winlogbeat-jobs[]
-|===
-|Name |Description |Job |Datafeed
-
-|rare_process_by_host_windows_ecs
-|Detect unusually rare processes on Windows.
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_winlogbeat/ml/rare_process_by_host_windows_ecs.json[image:images/link.svg[A link icon]]
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_winlogbeat/ml/datafeed_rare_process_by_host_windows_ecs.json[image:images/link.svg[A link icon]]
-
-|windows_anomalous_network_activity_ecs
-|Looks for unusual processes using the network which could indicate command-and-control, lateral movement, persistence, or data exfiltration activity.
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_winlogbeat/ml/windows_anomalous_network_activity_ecs.json[image:images/link.svg[A link icon]]
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_winlogbeat/ml/datafeed_windows_anomalous_network_activity_ecs.json[image:images/link.svg[A link icon]]
-
-|windows_anomalous_path_activity_ecs
-|Looks for activity in unusual paths that may indicate execution of malware or persistence mechanisms. Windows payloads often execute from user profile paths. 
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_winlogbeat/ml/windows_anomalous_path_activity_ecs.json[image:images/link.svg[A link icon]]
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_winlogbeat/ml/datafeed_windows_anomalous_path_activity_ecs.json[image:images/link.svg[A link icon]]
-
-|windows_anomalous_process_all_hosts_ecs
-|Looks for processes that are unusual to all Windows hosts. Such unusual processes may indicate execution of unauthorized services, malware, or persistence mechanisms.
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_winlogbeat/ml/windows_anomalous_process_all_hosts_ecs.json[image:images/link.svg[A link icon]]
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_winlogbeat/ml/datafeed_windows_anomalous_process_all_hosts_ecs.json[image:images/link.svg[A link icon]]
-
-|windows_anomalous_process_creation
-|Looks for unusual process relationships which may indicate execution of malware or persistence mechanisms.
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_winlogbeat/ml/windows_anomalous_process_creation.json[image:images/link.svg[A link icon]]
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_winlogbeat/ml/datafeed_windows_anomalous_process_creation.json[image:images/link.svg[A link icon]]
-
-|windows_anomalous_script
-|Looks for unusual powershell scripts that may indicate execution of malware, or persistence mechanisms.
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_winlogbeat/ml/windows_anomalous_script.json[image:images/link.svg[A link icon]]
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_winlogbeat/ml/datafeed_windows_anomalous_script.json[image:images/link.svg[A link icon]]
-
-|windows_anomalous_service
-|Looks for rare and unusual Windows services which may indicate execution of unauthorized services, malware, or persistence mechanisms.
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_winlogbeat/ml/windows_anomalous_service.json[image:images/link.svg[A link icon]]
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_winlogbeat/ml/datafeed_windows_anomalous_service.json[image:images/link.svg[A link icon]]
-
-|windows_anomalous_user_name_ecs
-|Rare and unusual users that are not normally active may indicate unauthorized changes or activity by an unauthorized user which may be credentialed access or lateral movement.
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_winlogbeat/ml/windows_anomalous_user_name_ecs.json[image:images/link.svg[A link icon]]
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_winlogbeat/ml/datafeed_windows_anomalous_user_name_ecs.json[image:images/link.svg[A link icon]]
-
-|windows_rare_metadata_process
-|Looks for anomalous access to the metadata service by an unusual process. The metadata service may be targeted in order to harvest credentials or user data scripts containing secrets.
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_winlogbeat/ml/windows_rare_metadata_process.json[image:images/link.svg[A link icon]]
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_winlogbeat/ml/datafeed_windows_rare_metadata_process.json[image:images/link.svg[A link icon]]
-
-|windows_rare_metadata_user
-|Looks for anomalous access to the metadata service by an unusual user. The metadata service may be targeted in order to harvest credentials or user data scripts containing secrets.
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_winlogbeat/ml/windows_rare_metadata_user.json[image:images/link.svg[A link icon]]
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_winlogbeat/ml/datafeed_windows_rare_metadata_user.json[image:images/link.svg[A link icon]]
-
-|windows_rare_user_runas_event
-|Unusual user context switches can be due to privilege escalation.
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_winlogbeat/ml/windows_rare_user_runas_event.json[image:images/link.svg[A link icon]]
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_winlogbeat/ml/datafeed_windows_rare_user_runas_event.json[image:images/link.svg[A link icon]]
-
-|===
-
-// end::siem-winlogbeat-jobs[]
-
-[discrete]
-[[security-winlogbeat-authentication-jobs]]
-== Security: {winlogbeat} authentication
-
-Detect suspicious authentication events in {winlogbeat} data.
-
-In the {ml-app} app, these configurations are available only when data exists
-that matches the query specified in the
-https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_winlogbeat_auth/manifest.json#L8[manifest file].
-In the {security-app}, it looks in the {data-source} specified in the
-{kibana-ref}/advanced-options.html#securitysolution-defaultindex[`securitySolution:defaultIndex` advanced setting]
-for data that matches the query.
-
-// tag::siem-winlogbeat-auth-jobs[]
-|===
-|Name |Description |Job |Datafeed
-
-|windows_rare_user_type10_remote_login
-|Unusual RDP (remote desktop protocol) user logins can indicate account takeover or credentialed access.
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_winlogbeat_auth/ml/windows_rare_user_type10_remote_login.json[image:images/link.svg[A link icon]]
-|https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/siem_winlogbeat_auth/ml/datafeed_windows_rare_user_type10_remote_login.json[image:images/link.svg[A link icon]]
-|===
-// end::siem-winlogbeat-auth-jobs[]
 // end::siem-jobs[]

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-siem.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-siem.asciidoc
@@ -43,7 +43,7 @@ then select it in the job wizard.
 |https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_auth/ml/datafeed_auth_high_count_logon_events_for_a_source_ip.json[image:images/link.svg[A link icon]]
 
 |auth_high_count_logon_fails
-|looks for an unusually large spike in authentication failure events. This can be due to password spraying, user enumeration or brute force activity and may be a precursor to account takeover or credentialed access.
+|Looks for an unusually large spike in authentication failure events. This can be due to password spraying, user enumeration, or brute force activity and may be a precursor to account takeover or credentialed access.
 |https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_auth/ml/auth_high_count_logon_fails.json[image:images/link.svg[A link icon]]
 |https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_auth/ml/datafeed_auth_high_count_logon_fails.json[image:images/link.svg[A link icon]]
 

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-siem.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-siem.asciidoc
@@ -33,7 +33,7 @@ then select it in the job wizard.
 |Name |Description |Job |Datafeed
 
 |auth_high_count_logon_events
-|looks for an unusually large spike in successful authentication events. This can be due to password spraying, user enumeration or brute force activity.
+|Looks for an unusually large spike in successful authentication events. This can be due to password spraying, user enumeration, or brute force activity.
 |https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_auth/ml/auth_high_count_logon_events.json[image:images/link.svg[A link icon]]
 |https://github.com/elastic/kibana/blob/{branch}/x-pack/plugins/ml/server/models/data_recognizer/modules/security_auth/ml/datafeed_auth_high_count_logon_events.json[image:images/link.svg[A link icon]]
 

--- a/docs/en/stack/ml/redirects.asciidoc
+++ b/docs/en/stack/ml/redirects.asciidoc
@@ -153,3 +153,28 @@ This content has moved. See <<sample-data-next>>.
 === Language identification
 
 This content has moved. See <<ml-nlp-lang-ident>>.
+
+[role="exclude",id="auditbeat-process-hosts-ecs"]
+=== Auditbeat host processes
+
+These {anomaly-jobs} were removed in 8.3.0.
+
+[role="exclude",id="security-auditbeat-jobs"]
+=== Security: {auditbeat}
+
+These {anomaly-jobs} were removed in 8.3.0.
+
+[role="exclude",id="security-auditbeat-authentication-jobs"]
+=== Security: {auditbeat} authentication
+
+These {anomaly-jobs} were removed in 8.3.0.
+
+[role="exclude",id="security-winlogbeat-jobs"]
+=== Security: {winlogbeat}
+
+These {anomaly-jobs} were removed in 8.3.0.
+
+[role="exclude",id="security-winlogbeat-authentication-jobs"]
+=== Security: {winlogbeat} authentication
+
+These {anomaly-jobs} were removed in 8.3.0.


### PR DESCRIPTION
Relates to https://github.com/elastic/kibana/pull/131166

This PR updates the job reference information in https://www.elastic.co/guide/en/security/master/prebuilt-ml-jobs.html and https://www.elastic.co/guide/en/security/master/prebuilt-ml-jobs.html

In particular, it refreshes the list of anomaly detection jobs in the "Security:Linux" and "Security:Windows" sections and removes the discontinued "Security:Auditbeat", "Security:Auditbeat authentication", "Security:Winlogbeat", and "Security:Winlogbeat authentication" sections. It also removes the discontinued "Auditbeat host processes" section from [Auditbeat anomaly detection configurations](https://www.elastic.co/guide/en/machine-learning/master/ootb-ml-jobs-auditbeat.html)

This PR must be merged after https://github.com/elastic/security-docs/pull/1998, since otherwise it encounters this build error:

> 16:57:20 INFO:build_docs:ERROR building Elastic Security version master
> ...
> 16:57:20 INFO:build_docs:asciidoctor: WARNING: invalid reference: security-winlogbeat-jobs

### Preview

- https://stack-docs_2140.docs-preview.app.elstc.co/guide/en/machine-learning/master/ootb-ml-jobs-siem.html (same content in https://stack-docs_2140.docs-preview.app.elstc.co/guide/en/security/master/prebuilt-ml-jobs.html)
- https://stack-docs_2140.docs-preview.app.elstc.co/guide/en/machine-learning/master/ootb-ml-jobs-auditbeat.html