### PR TITLE
Clarify login flow

### DIFF
--- a/docs/en/getting-started/get-started-docker.asciidoc
+++ b/docs/en/getting-started/get-started-docker.asciidoc
@@ -413,7 +413,7 @@ docker-compose up -d
 ----
 
 . When the deployment has started, open a browser and navigate to http://localhost:5601[http://localhost:5601] to
-access {kib}, where you can load sample data and interact with your cluster. You can use the `elastic` user with
+access {kib}, where you can load sample data and interact with your cluster. Log in as the `elastic` user with
 the `ELASTIC_PASSWORD` value to get access.
 
 [[docker-compose-remove-containers]]

--- a/docs/en/getting-started/get-started-docker.asciidoc
+++ b/docs/en/getting-started/get-started-docker.asciidoc
@@ -413,7 +413,8 @@ docker-compose up -d
 ----
 
 . When the deployment has started, open a browser and navigate to http://localhost:5601[http://localhost:5601] to
-access {kib}, where you can load sample data and interact with your cluster.
+access {kib}, where you can load sample data and interact with your cluster. You can use the `elastic` user with
+the `ELASTIC_PASSWORD` value to get access.
 
 [[docker-compose-remove-containers]]
 [discrete]


### PR DESCRIPTION
This will clarify that users should use the `elastic` user to log into Kibana after the installation.

cc @lockewritesdocs 