### PR TITLE
Fixes grammar based on linting tool results in NLP docs

### DIFF
--- a/docs/en/stack/ml/nlp/ml-nlp-classify-text.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-classify-text.asciidoc
@@ -7,8 +7,8 @@ zero-shot text classification
 :description: NLP tasks that classify input text or determine \
 the language of text. 
 
-These NLP tasks enable you to identify the language of text and classify or label 
-unstructured input text:
+These NLP tasks enable you to identify the language of text and classify or 
+label unstructured input text:
 
 * <<ml-nlp-lang-ident>>
 * <<ml-nlp-text-classification>>
@@ -66,7 +66,7 @@ and determine whether the following text is a news topic related to "SPORTS",
 
 The zero-shot classification task offers the ability to classify text without 
 training a model on a specific set of classes. Instead, you provide the classes 
-when you deploy the model or at inference time. It uses a model trained on a 
+when you deploy the model or at {infer} time. It uses a model trained on a 
 large data set that has gained a general language understanding and asks the 
 model how well the labels you provided fit with your text.
 
@@ -77,7 +77,7 @@ For example, you might want to perform multi-class classification and determine
 whether a news topic is related to "SPORTS", "BUSINESS", "LOCAL", or 
 "ENTERTAINMENT". However, in this case the model is not trained specifically for 
 news classification; instead, the possible labels are provided together with the 
-input text at inference time:
+input text at {infer} time:
 
 [source,js]
 ----------------------------------
@@ -104,7 +104,7 @@ The task returns the following result:
 // NOTCONSOLE
 
 
-You can use the same model to perform inference with different classes, such as:
+You can use the same model to perform {infer} with different classes, such as:
 
 [source,js]
 ----------------------------------
@@ -130,6 +130,6 @@ The task returns the following result:
 ----------------------------------
 // NOTCONSOLE
 
-Since you can adjust the labels while you perform inference, this type of task 
-is exceptionally flexible. If you are consistently using the same labels, 
-however, it might be better to use a fine-tuned text classification model.
+Since you can adjust the labels while you perform {infer}, this type of task is 
+exceptionally flexible. If you are consistently using the same labels, however, 
+it might be better to use a fine-tuned text classification model.

--- a/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
@@ -30,9 +30,9 @@ https://huggingface.co/models[Hugging Face]. These instructions assume you're
 using one of those models and do not describe how to create new models. For the
 current list of supported model architectures, refer to <<ml-nlp-model-ref>>.
 
-If you choose to perform language identification by using
-the `lang_ident_model_1` that is provided in the cluster, no further steps are
-required to import or deploy the model. You can skip to using the model in
+If you choose to perform {lang-ident} by using the `lang_ident_model_1` that is 
+provided in the cluster, no further steps are required to import or deploy the 
+model. You can skip to using the model in 
 <<ml-nlp-inference,ingestion pipelines>>.
 
 [discrete]

--- a/docs/en/stack/ml/nlp/ml-nlp-inference.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-inference.asciidoc
@@ -1,13 +1,13 @@
 [[ml-nlp-inference]]
-= Add NLP inference to ingest pipelines
-:keywords: {ml-init}, {stack}, {nlp}, inference 
+= Add NLP {infer} to ingest pipelines
+:keywords: {ml-init}, {stack}, {nlp}, {infer} 
 
 After you <<ml-nlp-deploy-models,deploy a trained model in your cluster>>, you
 can use it to perform {nlp} tasks in ingest pipelines.
 
 . Verify that all of the
 {ref}/ingest.html#ingest-prerequisites[ingest pipeline prerequisites] are met.
-. <<ml-nlp-inference-processor,Add an inference processor to an ingest pipeline>>.
+. <<ml-nlp-inference-processor,Add an {infer} processor to an ingest pipeline>>.
 . <<ml-nlp-inference-ingest-docs,Ingest documents>>.
 . <<ml-nlp-inference-discover,View the results>>.
 
@@ -15,17 +15,17 @@ can use it to perform {nlp} tasks in ingest pipelines.
 
 [discrete]
 [[ml-nlp-inference-processor]]
-== Add an inference processor to an ingest pipeline
+== Add an {infer} processor to an ingest pipeline
 
-In {kib}, you can create and edit pipelines in **Stack Management** >
+In {kib}, you can create and edit pipelines in **{stack-manage-app}** >
 **Ingest Pipelines**.
 
 [role="screenshot"]
 image::images/ml-nlp-pipeline-lang.png[Creating a pipeline in the Stack Management app,align="center"]
 
 . Click **Create pipeline** or edit an existing pipeline.
-. Add an {ref}/inference-processor.html[inference processor] to your pipeline:
-.. Click **Add a processor** and select the **Inference** processor type.
+. Add an {ref}/inference-processor.html[{infer} processor] to your pipeline:
+.. Click **Add a processor** and select the **{infer-cap}** processor type.
 .. Set **Model ID** to the name of your trained model, for example
 `elastic__distilbert-base-cased-finetuned-conll03-english` or
 `lang_ident_model_1`.
@@ -46,8 +46,8 @@ languages in a field with a different name, you must map your field name to
 --
 ... You can also optionally add
 {ref}/inference-processor.html#inference-processor-classification-opt[classification configuration options]
-in the **Inference configuration** section. For example, to include the top five
-language predictions:
+in the **{infer-cap} configuration** section. For example, to include the top 
+five language predictions:
 +
 --
 [source,js]
@@ -166,7 +166,7 @@ You can now use your ingest pipeline to perform NLP tasks on your data.
 
 Before you add data, consider which mappings you want to use. For example, you
 can create explicit mappings with the create index API in the
-**Dev Tools** > **Console**:
+**{dev-tools-app}** > **Console**:
 
 [source,console]
 ----
@@ -254,13 +254,13 @@ with a "too many requests" 429 error code.
 == View the results
 
 Before you can verify the results of the pipelines, you must
-{kibana-ref}/data-views.html[create data views]. Then you can explore your data
-in **Discover**:
+{kibana-ref}/data-views.html[create {data-sources}]. Then you can explore your 
+data in **Discover**:
 
 [role="screenshot"]
 image::images/ml-nlp-discover-ner.png[A document from the NER pipeline in the Discover app,align="center"]
 
-The `ml.inference.predicted_value` field contains the output from the inference
+The `ml.inference.predicted_value` field contains the output from the {infer}
 processor. In this NER example, there are two documents that contain the
 `Elastic` organization entity.
 
@@ -289,8 +289,8 @@ check the following possible causes:
 you are using the built-in `lang_ident_model_1` model, you must ensure your
 model is successfully deployed. Refer to <<ml-nlp-deploy-model>>.
 . The default input field name expected by your trained model is not present in
-your source document. Use the **Field Map** option in your inference processor
-to set the appropriate field name.
+your source document. Use the **Field Map** option in your {infer} processor to 
+set the appropriate field name.
 . There are too many requests. If you are using bulk ingest, reduce the number
 of documents in the bulk request. If you are reindexing, use the `size`
 parameter to decrease the number of documents processed in each batch.

--- a/docs/en/stack/ml/nlp/ml-nlp-lang-ident.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-lang-ident.asciidoc
@@ -87,4 +87,4 @@ script.
 [[ml-lang-ident-readings]]
 === Further reading
 
-* https://www.elastic.co/blog/multilingual-search-using-language-identification-in-elasticsearch[Multilingual search using language identification in {es}]
+* https://www.elastic.co/blog/multilingual-search-using-language-identification-in-elasticsearch[Multilingual search using {lang-ident} in {es}]

--- a/docs/en/stack/ml/nlp/ml-nlp-overview.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-overview.asciidoc
@@ -24,8 +24,8 @@ which is an underlying native library for PyTorch. Trained models must be in a
 TorchScript representation for use with {stack} {ml} features.
 
 As in the cases of <<ml-dfa-classification,classification>> and
-<<ml-dfa-regression,regression>>, after you deploy a model to your cluster, you
-can use it to make predictions (also known as _inference_) against incoming 
+<<ml-dfa-regression,{regression}>>, after you deploy a model to your cluster, you
+can use it to make predictions (also known as _{infer}_) against incoming 
 data. You can perform the following NLP operations:
 
 * <<ml-nlp-extract-info>>

--- a/docs/en/stack/ml/nlp/ml-nlp-search-compare.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-search-compare.asciidoc
@@ -22,7 +22,7 @@ This task is responsible for producing only the embedding. When the
 embedding is created, it can be stored in a 
 {ref}/dense-vector.html[dense_vector] field and used at search time. For 
 example, you can use these vectors in a 
-{ref}/knn-search.html[k-nearest neighbour (kNN) search] to achieve semantic 
+{ref}/knn-search.html[k-nearest neighbor (kNN) search] to achieve semantic 
 search capabilities.
 
 The following is an example of producing a text embedding:


### PR DESCRIPTION
## Overview

This PR fixes grammatical errors/places where shared attributes are not used in NLP documentation. These fixes are based on the [linting tool](https://github.com/elastic/docs-lint) results.