### PR TITLE
Activate include for Beats breaking changes

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -44,8 +44,7 @@ include::{apm-repo-dir}/apm-breaking.asciidoc[tag=notable-v8-breaking-changes]
 This list summarizes the most important breaking changes in Beats.
 For the complete list, go to {beats-ref}/breaking-changes.html[Beats breaking changes].
 
-//include::{beats-repo-dir}/release-notes/breaking/breaking-8.3.asciidoc[tag=notable-breaking-changes]
-
+include::{beats-repo-dir}/release-notes/breaking/breaking-8.3.asciidoc[tag=notable-breaking-changes]
 
 [[elasticsearch-breaking-changes]]
 === {es} breaking changes


### PR DESCRIPTION
Merge AFTER https://github.com/elastic/beats/pull/31987 is merged and backported.

Build will fail until https://github.com/elastic/beats/pull/31987 is merged.