### PR TITLE
[DOCS] Removes unnecessary flag from ml-reverting-model-snapshot.ascidoc

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/anomaly-examples.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/anomaly-examples.asciidoc
@@ -10,19 +10,20 @@ The scenarios in this section describe some best practices for generating useful
 {ml} results and insights from your data.
 
 * <<ml-getting-started>>
-* <<ml-configuring-url>>
+* <<ml-configuring-alerts>>
 * <<ml-configuring-aggregation>>
-* <<ml-configuring-transform>>
 * <<ml-configuring-detector-custom-rules>>
 * <<ml-configuring-categories>>
 * <<ml-reverting-model-snapshot>>
 * <<geographic-anomalies>>
-* <<ml-configuring-alerts>>
+* <<ml-configuring-populations>>
+* <<ml-configuring-transform>>
+* <<ml-configuring-url>>
 * <<ml-delayed-data-detection>>
 * <<mapping-anomalies>>
 * <<ml-jobs-from-lens>>
-* <<ml-configuring-populations>>
 * <<move-jobs>>
+
 
 [discrete]
 [[anomaly-examples-blog-posts]]

--- a/docs/en/stack/ml/anomaly-detection/ml-revert-model-snapshot.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-revert-model-snapshot.asciidoc
@@ -1,4 +1,3 @@
-[role="xpack"]
 [[ml-reverting-model-snapshot]]
 = Reverting to a model snapshot
 


### PR DESCRIPTION
## Overview

This PR removes the `xpack` role from the doc file of the reverting to a model snapshot guide. It also orders the subsections of the Examples section in alphabetical order.