### PR TITLE
[DOCS] Changes NLP examples to use proper JSON structure and objects

### DIFF
--- a/docs/en/stack/ml/nlp/ml-nlp-classify-text.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-classify-text.asciidoc
@@ -36,9 +36,8 @@ text is "POSITIVE" or "NEGATIVE":
 
 [source,js]
 ----------------------------------
-...
 {
-    "input_text": "This was the best movie I’ve seen in the last decade!"
+    docs: [{"text_field": "This was the best movie I’ve seen in the last decade!"}]
 }
 ...
 ----------------------------------
@@ -51,9 +50,8 @@ and determine whether the following text is a news topic related to "SPORTS",
 
 [source,js]
 ----------------------------------
-...
 {
-    "input_text": "The Blue Jays played their final game in Toronto last night and came out with a win over the Yankees, highlighting just how far the team has come this season."
+    docs: [{"text_field": "The Blue Jays played their final game in Toronto last night and came out with a win over the Yankees, highlighting just how far the team has come this season."}]
 }
 ...
 ----------------------------------
@@ -81,12 +79,14 @@ input text at {infer} time:
 
 [source,js]
 ----------------------------------
-...
 {
-    "input_text": "The S&P 500 gained a meager 12 points in the day’s trading. Trade volumes remain consistent with those of the past week while investors await word from the Fed about possible rate increases.",
-    "labels": ["SPORTS", "BUSINESS", "LOCAL", "ENTERTAINMENT"]
+    docs: [{"text_field": "The S&P 500 gained a meager 12 points in the day’s trading. Trade volumes remain consistent with those of the past week while investors await word from the Fed about possible rate increases."}],
+    "inference_config": {
+        "zero_shot_classification": {
+            "labels": ["SPORTS", "BUSINESS", "LOCAL", "ENTERTAINMENT"]
+        }
+    }
 }
-...
 ----------------------------------
 // NOTCONSOLE
 
@@ -97,7 +97,8 @@ The task returns the following result:
 ----------------------------------
 ...
 {
-    "result": "BUSINESS"
+    "predicted_value": "BUSINESS"
+    ...
 }
 ...
 ----------------------------------
@@ -108,12 +109,14 @@ You can use the same model to perform {infer} with different classes, such as:
 
 [source,js]
 ----------------------------------
-...
 {
-    "input_text": "Hello support team. I’m writing to inquire about the possibility of sending my broadband router in for repairs. The internet is really slow and the router keeps rebooting! It’s a big problem because I’m in the middle of binge-watching The Mandalorian!",
-    "labels": ["urgent", "internet", "phone", "cable", "mobile", "tv"]
+    docs: [{"text_field": "Hello support team. I’m writing to inquire about the possibility of sending my broadband router in for repairs. The internet is really slow and the router keeps rebooting! It’s a big problem because I’m in the middle of binge-watching The Mandalorian!"}]
+    "inference_config": {
+        "zero_shot_classification": {
+            "labels": ["urgent", "internet", "phone", "cable", "mobile", "tv"]
+        }
+    }
 }
-...
 ----------------------------------
 // NOTCONSOLE
 
@@ -124,7 +127,8 @@ The task returns the following result:
 ----------------------------------
 ...
 {
-    "result": ["urgent", "internet", "tv"]
+    "predicted_value": ["urgent", "internet", "tv"]
+    ...
 }
 ...
 ----------------------------------

--- a/docs/en/stack/ml/nlp/ml-nlp-extract-info.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-extract-info.asciidoc
@@ -33,9 +33,8 @@ also phrases, consisting of multiple words.
 
 [source,js]
 ----------------------------------
-...
 {
-    "text_field": "Elastic is headquartered in Mountain View, California."
+    "docs": [{"text_field": "Elastic is headquartered in Mountain View, California."}]
 }
 ...
 ----------------------------------
@@ -46,20 +45,23 @@ The task returns the following result:
 
 [source,js]
 ----------------------------------
-...
 {
-  "results": [
-    {
-      "entity": "Elastic",
-      "class": "organization"
-    },
-    {
-      "entity": "Mountain View",
-      "class": "location"
-    },
-    {
-      "entity": "California",
-      "class": "location"
+  "inference_results": [{
+    ...
+      entities: [
+        {
+          "entity": "Elastic",
+          "class": "organization"
+        },
+        {
+          "entity": "Mountain View",
+          "class": "location"
+        },
+        {
+          "entity": "California",
+          "class": "location"
+        }
+      ]
     }
   ]
 }
@@ -83,9 +85,8 @@ tell the model which word to predict.
 
 [source,js]
 ----------------------------------
-...
 {
-    "input": "The capital city of France is [MASK]."
+    docs: [{"text_field": "The capital city of France is [MASK]."}]
 }
 ...
 ----------------------------------
@@ -97,7 +98,8 @@ The task returns the following result:
 ----------------------------------
 ...
 {
-  "result": "Paris"
+  "predicted_value": "Paris"
+  ...
 }
 ...
 ----------------------------------
@@ -118,7 +120,6 @@ shown by the following examples:
 
 [source,js]
 ----------------------------------
-...
 {
     "docs": [{"text_field": "The Amazon rainforest (Portuguese: Floresta Amazônica or Amazônia; Spanish: Selva Amazónica, Amazonía or usually Amazonia; French: Forêt amazonienne; Dutch: Amazoneregenwoud), also known in English as Amazonia or the Amazon Jungle, is a moist broadleaf forest that covers most of the Amazon basin of South America. This basin encompasses 7,000,000 square kilometres (2,700,000 sq mi), of which 5,500,000 square kilometres (2,100,000 sq mi) are covered by the rainforest. This region includes territory belonging to nine nations. The majority of the forest is contained within Brazil, with 60% of the rainforest, followed by Peru with 13%, Colombia with 10%, and with minor amounts in Venezuela, Ecuador, Bolivia, Guyana, Suriname and French Guiana. States or departments in four nations contain "Amazonas" in their names. The Amazon represents over half of the planet's remaining rainforests, and comprises the largest and most biodiverse tract of tropical rainforest in the world, with an estimated 390 billion individual trees divided into 16,000 species."}],
     "inference_config": {"question_answering": {"question": "Which name is also used to describe the Amazon rainforest in English?"}}

--- a/docs/en/stack/ml/nlp/ml-nlp-search-compare.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-search-compare.asciidoc
@@ -29,9 +29,8 @@ The following is an example of producing a text embedding:
 
 [source,js]
 ----------------------------------
-...
 {
-    "input": "The quick brown fox jumps over the lazy dog."
+    docs: [{"text_field": "The quick brown fox jumps over the lazy dog."}]
 }
 ...
 ----------------------------------
@@ -44,7 +43,8 @@ The task returns the following result:
 ----------------------------------
 ...
 {
-    "results": [0.293478, -0.23845, ..., 1.34589e2, 0.119376]
+    "predicted_value": [0.293478, -0.23845, ..., 1.34589e2, 0.119376]
+    ...
 }
 ...
 ----------------------------------


### PR DESCRIPTION
## Overview

In the NLP conceptual documentation, the examples used pseudo-JSON snippets for the sake of simplicity. This PR changes the examples to use the actual JSON objects and structure to provide more accurate example snippets even if the structure is a bit more complex.

### Preview

* [Classify text](https://stack-docs_2172.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-nlp-classify-text.html)
* [Extract info](https://stack-docs_2172.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-nlp-extract-info.html)
* [Search and compare](https://stack-docs_2172.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-nlp-search-compare.html)