### PR TITLE
Moves out third-party NLP model list from Resources

### DIFF
--- a/docs/en/stack/ml/nlp/index.asciidoc
+++ b/docs/en/stack/ml/nlp/index.asciidoc
@@ -6,6 +6,5 @@ include::ml-nlp-search-compare.asciidoc[leveloffset=+2]
 include::ml-nlp-deploy-models.asciidoc[leveloffset=+1]
 include::ml-nlp-inference.asciidoc[leveloffset=+1]
 include::ml-nlp-apis.asciidoc[leveloffset=+1]
-include::ml-nlp-resources.asciidoc[leveloffset=+1]
-include::ml-nlp-model-ref.asciidoc[leveloffset=+2]
+include::ml-nlp-model-ref.asciidoc[leveloffset=+1]
 

--- a/docs/en/stack/ml/nlp/ml-nlp-model-ref.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-model-ref.asciidoc
@@ -1,5 +1,10 @@
 [[ml-nlp-model-ref]]
-= Third party NLP models
+= Compatible third party NLP models
+++++
+<titleabbrev>Compatible third party models</titleabbrev>
+++++
+:keywords: {ml-init}, {stack}, {nlp}
+:description: The list of compatible third party NLP models.
 
 The {stack-ml-features} support transformer models that conform to the standard
 BERT model interface and use the WordPiece tokenization algorithm.

--- a/docs/en/stack/ml/nlp/ml-nlp-resources.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-resources.asciidoc
@@ -1,6 +1,0 @@
-[[ml-nlp-resources]]
-= Resources
-
-This section contains further resources for using {nlp}.
-
-* <<ml-nlp-model-ref>>


### PR DESCRIPTION
## Overview

This PR moves out the third-party NLP models page from the `Resources` section. Currently, there is no other content/page in this section, so putting the content there only means that users need to click through the Resources section to get the page. We might want to reconsider adding back `Resources` when we'll have more content that could be added to the section.