### PR TITLE
[DOCS] Adds links to the inference example that point to the NLP blog posts

### DIFF
--- a/docs/en/stack/ml/nlp/ml-nlp-inference.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-inference.asciidoc
@@ -298,3 +298,11 @@ parameter to decrease the number of documents processed in each batch.
 These common failure scenarios and others can be captured by adding failure
 processors to your pipeline. For more examples, refer to
 {ref}/ingest.html#handling-pipeline-failures[Handling pipeline failures].
+
+[discrete]
+[[nlp-example-reading]]
+== Further reading
+
+* https://www.elastic.co/blog/how-to-deploy-nlp-text-embeddings-and-vector-search[How to deploy NLP: Text Embeddings and Vector Search]
+* https://www.elastic.co/blog/how-to-deploy-nlp-named-entity-recognition-ner-example[How to deploy NLP: Named entity recognition (NER) example]
+* https://www.elastic.co/blog/how-to-deploy-nlp-sentiment-analysis-example[How to deploy NLP: Sentiment Analysis Example]


### PR DESCRIPTION
## Overview

This PR adds the links of the NLP example blog posts to a section called `Further reading` at the end of the NLP inference page.

### Preview

[NLP inference - Further reading]()