### PR TITLE
[DOCS] Add missing links in anomaly detection resources

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/ml-ad-resources.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-ad-resources.asciidoc
@@ -5,3 +5,7 @@
 This section contains further resources for using {anomaly-detect}.
 
 * <<ml-limitations>>
+* <<ml-functions>>
+* <<ootb-ml-jobs>>
+* <<ml-ad-troubleshooting>>
+


### PR DESCRIPTION
This PR updates https://www.elastic.co/guide/en/machine-learning/master/ml-ad-resources.html to add links to its nested pages.