### PR TITLE
Update link for Beats breaking changes include

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -44,7 +44,7 @@ include::{apm-repo-dir}/apm-breaking.asciidoc[tag=notable-v8-breaking-changes]
 This list summarizes the most important breaking changes in Beats.
 For the complete list, go to {beats-ref}/breaking-changes.html[Beats breaking changes].
 
-include::{beats-repo-dir}/release-notes/breaking/breaking-8.0.asciidoc[tag=notable-breaking-changes]
+include::{beats-repo-dir}/release-notes/breaking/breaking-8.4.asciidoc[tag=notable-breaking-changes]
 
 
 [[elasticsearch-breaking-changes]]


### PR DESCRIPTION
This content has a dependency on https://github.com/elastic/beats/pull/32768.

MERGE AFTER https://github.com/elastic/beats/pull/32768 is merged _and_ successfully backported to 8.4.
