### PR TITLE
[DOCS] Add Elastic Security breaking changes to Installation and Upgrade Guide for 8.4

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -67,9 +67,9 @@ the complete list, go to {ref}/breaking-changes.html[{es} breaking changes].
 ++++
 
 This list summarizes the most important breaking changes in {elastic-sec} {version}. For
-the complete list, go to {security-guide-all}/8.3/release-notes-header-8.3.0.html#breaking-changes-8.3.0[{elastic-sec} breaking changes].
+the complete list, go to {security-guide-all}/8.4/release-notes-header-8.4.0.html#breaking-changes-8.4.0[{elastic-sec} breaking changes].
 
-include::{security-repo-dir}/release-notes/8.3.asciidoc[tag=breaking-changes]
+include::{security-repo-dir}/release-notes/8.4.asciidoc[tag=breaking-changes]
 
 [[kibana-breaking-changes]]
 === {kib} breaking changes


### PR DESCRIPTION
Fixes #2216 
Preview:

Notes

The breaking changes page in the Install & Upgrade Guide is built using [includes of tagged regions](https://docs.asciidoctor.org/asciidoc/latest/directives/include-tagged-regions/), so I added tags to the relevant region in the Release Notes page in the Security Docs repo (see change in in https://github.com/elastic/security-docs/pull/1828).
This PR's doc build will fail until the 8.4 release notes page is available on the public docsite. This means that, in order for this PR to successfully build, BOTH of the following requirements need to be met:
The 8.4 Security release notes PR merged into main and backported to the 8.4 branch.
The 8.4 Security release notes page will need to be built/published on the 8.4 branch and available on the [public docsite](https://www.elastic.co/guide/en/security/current/index.html).