### PR TITLE
Updates classification conceptual docs

### DIFF
--- a/docs/en/stack/ml/df-analytics/ml-dfa-classification.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-classification.asciidoc
@@ -19,7 +19,7 @@ is for predicting discrete, categorical values.
 
 When you create a {classification} job, you must specify which field contains 
 the classes that you want to predict. This field is known as the _{depvar}_. It
-must contain no more than 30 classes. By default, all other
+can contain maximum 100 classes. By default, all other
 {ref}/put-dfanalytics.html#dfa-supported-fields[supported fields] are included
 in the analysis and are known as _{feature-vars}_. You can optionally include or 
 exclude fields. For more information about field selection, refer to the


### PR DESCRIPTION
## Overview

In 8.5, the maximum number of classes for classification analysis is increased from 30 to 100. This PR adjusts the documentation to represent this change.

### Preview

[Classification](https://stack-docs_2222.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-dfa-classification.html)