### PR TITLE
Add 8.5 to mergify

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -15,6 +15,20 @@ pull_request_rules:
             git merge <remote-repo>/{{base}}
             git push <remote-repo> {{head}}
             ```
+  - name: backport patches to 8.5 branch
+    conditions:
+      - merged
+      - base=main
+      - label=backport-8.5
+    actions:
+      backport:
+        assignees:
+          - "{{ author }}"
+        branches:
+          - "8.4"
+        title: "[{{ destination_branch }}] {{ title }} (backport #{{ number }})"
+        labels:
+          - backport
   - name: backport patches to 8.4 branch
     conditions:
       - merged


### PR DESCRIPTION
This PR update the mergify configuration file to use the backport-8.5 label and the 8.5 branch.