### PR TITLE
[DOCS] Fix hard-coded link in glossary

### DIFF
--- a/docs/en/glossary/glossary.asciidoc
+++ b/docs/en/glossary/glossary.asciidoc
@@ -1246,8 +1246,7 @@ indexing metrics data.
 A type of <<glossary-data-stream,data stream>> optimized for indexing metrics
 <<glossary-time-series-data,time series data>>. A TSDS allows for reduced storage
 size and for a sequence of metrics data points to be considered efficiently as a
-whole. See 
-link:https://www.elastic.co/guide/en/elasticsearch/reference/master/tsds.html[Time series data stream].
+whole. See {ref}/tsds.html[Time series data stream].
 //Source: Elasticsearch
 
 [[glossary-token]] token::


### PR DESCRIPTION
Relates to https://github.com/elastic/docs/issues/2518