### PR TITLE
[DOCS] Add update API link to deployment NLP steps

### DIFF
--- a/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
@@ -152,7 +152,10 @@ increases the speed of {infer} requests. The value of this setting must not
 exceed the number of available allocated processors per node.
 
 You can view the allocation status in {kib} or by using the
-{ref}/get-trained-models-stats.html[get trained model stats API].
+{ref}/get-trained-models-stats.html[get trained model stats API]. If you to
+change the number of allocations, you can use the
+{ref}/update-trained-model-deployment.html[update trained model stats API] after
+the allocation status is `started`.
 
 [discrete]
 [[ml-nlp-test-inference]]


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch/pull/90728

This PR adds a link to the new [update trained model deployment API](https://www.elastic.co/guide/en/elasticsearch/reference/master/update-trained-model-deployment.html) in the [Deploy NLP trained model steps](https://www.elastic.co/guide/en/machine-learning/master/ml-nlp-deploy-models.html#ml-nlp-deploy-model).

When https://github.com/elastic/kibana/issues/144550 is complete and this action can be performed within Kibana, that should be mentioned here as well.

NOTE: The API mentions "assignment_state" whereas in this PR I'm using "allocation status", since that's what I see in the docs for the get trained model stats output. If it's not correct, we need to update for consistency.