### PR TITLE
[DOCS] Modifies regression API example

### DIFF
--- a/docs/en/stack/ml/df-analytics/ml-dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-regression.asciidoc
@@ -384,9 +384,11 @@ PUT _ml/data_frame/analytics/model-flight-delays-regression
     "regression": {
       "dependent_variable": "FlightDelayMin",
       "training_percent": 90,
-      "num_top_feature_importance_values": 5
+      "num_top_feature_importance_values": 5,
+      "randomize_seed": 1000
     }
   },
+  "model_memory_limit": "50mb",
   "analyzed_fields": {
     "includes": [],
     "excludes": [


### PR DESCRIPTION
## Overview

This PR sets the model memory limit to 50 MB in the regression API example to avoid running out of memory when users try the API example out.

### Preview

[Creating a regression model]() --available soon