### PR TITLE
[DOCS] Adds semantic search endpoint to the list of trained model APIs

### DIFF
--- a/docs/en/stack/ml/nlp/ml-nlp-apis.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-apis.asciidoc
@@ -29,9 +29,7 @@ All the trained models endpoints have the following base:
 
 
 // SEMANTIC SEARCH
-* {ref}/semantic-search-api.html[Semantic search]
-
-NOTE: The Semantic search endpoint has the following base:
+The Semantic search endpoint has the following base:
 +
 --
 [source,js]
@@ -39,4 +37,5 @@ NOTE: The Semantic search endpoint has the following base:
 <target>/_semantic_search
 ----
 // NOTCONSOLE
---
+
+* {ref}/semantic-search-api.html[Semantic search]

--- a/docs/en/stack/ml/nlp/ml-nlp-apis.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-apis.asciidoc
@@ -30,8 +30,7 @@ All the trained models endpoints have the following base:
 
 // SEMANTIC SEARCH
 The Semantic search endpoint has the following base:
-+
---
+
 [source,js]
 ----
 <target>/_semantic_search

--- a/docs/en/stack/ml/nlp/ml-nlp-apis.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-apis.asciidoc
@@ -27,3 +27,16 @@ All the trained models endpoints have the following base:
 // UPDATE
 * {ref}/put-trained-models-aliases.html[Update trained model aliases]
 
+
+// SEMANTIC SEARCH
+* {ref}/semantic-search-api.html[Semantic search]
+
+NOTE: The Semantic search endpoint has the following base:
++
+--
+[source,js]
+----
+<target>/_semantic_search
+----
+// NOTCONSOLE
+--


### PR DESCRIPTION
## Overview

This PR adds a link of the semantic search endpoint to the quick reference list of the trained model APIs.

### Preview

[API quick reference](https://stack-docs_2270.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-nlp-apis.html)