### PR TITLE
[DOCS] Add landing page for glossary

### DIFF
--- a/docs/en/glossary/index-custom-title-page.html
+++ b/docs/en/glossary/index-custom-title-page.html
@@ -1,0 +1,85 @@
+<style>
+  * {
+    box-sizing: border-box;
+  }
+
+  body {
+    font-family: Arial, Helvetica, sans-serif;
+  }
+
+  .card {
+    cursor: pointer;
+    padding: 16px;
+    text-align: left;
+    color: #000;
+  }
+
+  .card:hover {
+    box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2);
+    padding: 16px;
+    text-align: left;
+  }
+
+  #guide a.no-text-decoration:hover {
+    text-decoration: none!important;
+  }
+
+  .icon {
+    width: 24px;
+    height: 24px;
+    background-position: bottom;
+    background-size: contain;
+    background-repeat: no-repeat;
+  }
+
+  .ul-col-1 {
+    columns: 1;
+    -webkit-columns: 1;
+    -moz-columns: 1;
+  }
+
+  @media (min-width:769px) {
+    .ul-col-md-2 {
+      columns: 2;
+      -webkit-columns: 2;
+      -moz-columns: 2;
+    }
+  }
+</style>
+
+<div class="legalnotice"></div>
+
+<div class="row my-4">
+  <div class="col-md-6 col-12">
+    <p>
+      <a class="inline-block mr-3" href="terms.html#a-glos">A</a>
+      <a class="inline-block mr-3" href="terms.html#b-glos">B</a>
+      <a class="inline-block mr-3" href="terms.html#c-glos">C</a>
+      <a class="inline-block mr-3" href="terms.html#d-glos">D</a>
+      <a class="inline-block mr-3" href="terms.html#e-glos">E</a>
+      <a class="inline-block mr-3" href="terms.html#f-glos">F</a>
+      <a class="inline-block mr-3" href="terms.html#g-glos">G</a>
+      <a class="inline-block mr-3" href="terms.html#h-glos">H</a>
+      <a class="inline-block mr-3" href="terms.html#i-glos">I</a>
+      <a class="inline-block mr-3" href="terms.html#j-glos">J</a>
+      <a class="inline-block mr-3" href="terms.html#k-glos">K</a>
+      <a class="inline-block mr-3" href="terms.html#l-glos">L</a>
+      <a class="inline-block mr-3" href="terms.html#m-glos">M</a>
+      <a class="inline-block mr-3" href="terms.html#n-glos">N</a>
+      <a class="inline-block mr-3" href="terms.html#o-glos">O</a>
+      <a class="inline-block mr-3" href="terms.html#p-glos">P</a>
+      <a class="inline-block mr-3" href="terms.html#q-glos">Q</a>
+      <a class="inline-block mr-3" href="terms.html#r-glos">R</a>
+      <a class="inline-block mr-3" href="terms.html#s-glos">S</a>
+      <a class="inline-block mr-3" href="terms.html#t-glos">T</a>
+      <a class="inline-block mr-3" href="terms.html#u-glos">U</a>
+      <a class="inline-block mr-3" href="terms.html#v-glos">V</a>
+      <a class="inline-block mr-3" href="terms.html#w-glos">W</a>
+      <a class="inline-block mr-3" href="terms.html#x-glos">X</a>
+      <a class="inline-block mr-3" href="terms.html#y-glos">Y</a>
+      <a class="inline-block mr-3" href="terms.html#z-glos">Z</a>
+  </p>
+  </div>
+</div>
+<p class="my-4"><a href="https://brand.elastic.co/302f66895/p/194a3b-writing-style-guide">Writing style guide</a></p>
+<p class="my-4"><a href="https://www.elastic.co/guide/index.html">View all Elastic docs</a></p>


### PR DESCRIPTION
Since the glossary has only a single page, its initial landing page is quite empty:
![image](https://user-images.githubusercontent.com/26471269/204366882-09c65979-99d1-4824-8586-7ef7d20c9b1e.png)

We could create a simple landing page with links to the glossary's sections by using a `index-custom-title-page.html` page. For example:

![image](https://user-images.githubusercontent.com/26471269/204367180-c56b02bf-9b0f-471b-bef6-f8e4279c5553.png)
