### PR TITLE
[DOCS] Updates AD at scale piece with autoscaling detail

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/anomaly-detection-scale.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/anomaly-detection-scale.asciidoc
@@ -56,7 +56,7 @@ increasing the number of nodes in your environment.
 
 In {ecloud}, you can enable {ref}/xpack-autoscaling.html[autoscaling] so that 
 the {ml} nodes in your cluster scale up or down based on current {ml} 
-memory requirements. The {ecloud} infrastructure allows you to create 
+memory and CPU requirements. The {ecloud} infrastructure allows you to create 
 {ml-jobs} up to the size that fits on the maximum node size that the 
 cluster can scale to (usually somewhere between 58GB and 64GB) rather than what 
 would fit in the current cluster. If you attempt to use autoscaling outside of 


### PR DESCRIPTION
## Overview

This PR updates the "Autoscaling..." section of the anomaly detection at scale piece by adding the CPU-based scaling criterion to the text.

### Preview

[Anomaly detection at scale – 1. Consider autoscaling...](https://stack-docs_2275.docs-preview.app.elstc.co/guide/en/machine-learning/master/anomaly-detection-scale.html#node-sizing)