### PR TITLE
[8.6][DOCS] Removes reference to semantic search docs

### DIFF
--- a/docs/en/stack/ml/nlp/ml-nlp-apis.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-apis.asciidoc
@@ -26,15 +26,3 @@ All the trained models endpoints have the following base:
 * {ref}/stop-trained-model-deployment.html[Stop trained model deployment]
 // UPDATE
 * {ref}/put-trained-models-aliases.html[Update trained model aliases]
-
-
-// SEMANTIC SEARCH
-The Semantic search endpoint has the following base:
-
-[source,js]
-----
-<target>/_semantic_search
-----
-// NOTCONSOLE
-
-* {ref}/semantic-search-api.html[Semantic search]


### PR DESCRIPTION
## Overview

Related to https://github.com/elastic/elasticsearch/pull/92086.
This PR removes a reference to the semantic search API docs from the NLP API page.