### PR TITLE
[DOCS] Stop a single node

### DIFF
--- a/docs/en/install-upgrade/upgrading-elasticsearch.asciidoc
+++ b/docs/en/install-upgrade/upgrading-elasticsearch.asciidoc
@@ -109,7 +109,7 @@ jobs with large model states.
 . [[upgrade-node]] *Shut down a single node*.
 +
 --
-To shut down a single node depends on what is currently used to run {es}. For example, if using `systemd` or SysV `init` see the commands below.
+To shut down a single node depends on what is currently used to run {es}. For example, if using `systemd` or SysV `init` run the commands below.
 
 * If you are running {es} with `systemd`:
 +

--- a/docs/en/install-upgrade/upgrading-elasticsearch.asciidoc
+++ b/docs/en/install-upgrade/upgrading-elasticsearch.asciidoc
@@ -109,7 +109,7 @@ jobs with large model states.
 . [[upgrade-node]] *Shut down a single node*.
 +
 --
-To stop running a single node depends on what is currently used to run the nodes. For example, if using `systemd` or SysV see the commands below.
+To shut down a single node depends on what is currently used to run {es}. For example, if using `systemd` or SysV `init` see the commands below.
 
 * If you are running {es} with `systemd`:
 +

--- a/docs/en/install-upgrade/upgrading-elasticsearch.asciidoc
+++ b/docs/en/install-upgrade/upgrading-elasticsearch.asciidoc
@@ -109,6 +109,8 @@ jobs with large model states.
 . [[upgrade-node]] *Shut down a single node*.
 +
 --
+To stop running a single node depends on what is currently used to run the nodes. For example, if using `systemd` or SysV see the commands below.
+
 * If you are running {es} with `systemd`:
 +
 [source,sh]
@@ -121,13 +123,6 @@ sudo systemctl stop elasticsearch.service
 [source,sh]
 --------------------------------------------------
 sudo -i service elasticsearch stop
---------------------------------------------------
-
-* If you are running {es} as a daemon:
-+
-[source,sh]
---------------------------------------------------
-kill $(cat pid)
 --------------------------------------------------
 --
 


### PR DESCRIPTION
In line 19 of the [shut down node](https://github.com/elastic/elasticsearch/blame/master/docs/reference/upgrade/shut-down-node.asciidoc#L19) doc, it suggests `kill $(cat pid)` to stop a daemon process. Removed as not everyone is running Elasticsearch using a daemon. 

Fixes #88558