### PR TITLE
Add Cloud entries to shared glossary

### DIFF
--- a/docs/en/glossary/terms/allocator-affinity.asciidoc
+++ b/docs/en/glossary/terms/allocator-affinity.asciidoc
@@ -1,0 +1,5 @@
+
+[[glossary-allocator-affinity]] allocator affinity::
+Controls how {stack} deployments are distributed across the available set of
+allocators in your {ece} installation.
+//Source: Cloud

--- a/docs/en/glossary/terms/allocator-tag.asciidoc
+++ b/docs/en/glossary/terms/allocator-tag.asciidoc
@@ -1,0 +1,6 @@
+
+[[glossary-allocator-tag]] allocator tag:: In {ece}, characterizes hardware
+resources for {stack} deployments. Used by
+<<glossary-instance-configuration,instance configurations>> to determine which
+instances of the {stack} should be placed on what hardware.
+//Source: Cloud

--- a/docs/en/glossary/terms/console.asciidoc
+++ b/docs/en/glossary/terms/console.asciidoc
@@ -1,6 +1,9 @@
 
 [[glossary-console]] Console::
-A tool for interacting with the {es} REST API. You can send requests to {es},
+In {kib}, a tool for interacting with the {es} REST API. You can send requests to {es},
 view responses, view API documentation, and get your request history. See
 {kibana-ref}/console-kibana.html[Console].
 //Source: Kibana
+
+In {ess}, provides web-based access to manage your {ecloud} deployments.
+//Source: Cloud

--- a/docs/en/glossary/terms/console.asciidoc
+++ b/docs/en/glossary/terms/console.asciidoc
@@ -4,6 +4,6 @@ In {kib}, a tool for interacting with the {es} REST API. You can send requests t
 view responses, view API documentation, and get your request history. See
 {kibana-ref}/console-kibana.html[Console].
 //Source: Kibana
-
++
 In {ess}, provides web-based access to manage your {ecloud} deployments.
 //Source: Cloud

--- a/docs/en/glossary/terms/data-center.asciidoc
+++ b/docs/en/glossary/terms/data-center.asciidoc
@@ -1,0 +1,4 @@
+
+[[glossary-data-center]] data center::
+Check <<glossary-zone,availability zone>>.
+//Source: Cloud

--- a/docs/en/glossary/terms/deployment-template.asciidoc
+++ b/docs/en/glossary/terms/deployment-template.asciidoc
@@ -1,0 +1,5 @@
+
+[[glossary-deployment-template]] deployment template::
+A reusable configuration of Elastic products and solutions used to create an 
+{ecloud} <<glossary-deployment,deployment>>.
+//Source: Cloud

--- a/docs/en/glossary/terms/deployment.asciidoc
+++ b/docs/en/glossary/terms/deployment.asciidoc
@@ -1,0 +1,4 @@
+
+[[glossary-deployment]] deployment::
+One or more products from the {stack} configured to work together and run on {ecloud}.
+//Source: Cloud

--- a/docs/en/glossary/terms/ece.asciidoc
+++ b/docs/en/glossary/terms/ece.asciidoc
@@ -1,0 +1,6 @@
+
+[[glossary-ece]] {ece} (ECE)::
+The official enterprise offering to host and manage the {stack} yourself at scale.
+Can be installed on a public cloud platform, such as AWS, GCP or Microsoft Azure,
+on your own private cloud, or on bare metal.
+//Source: Cloud

--- a/docs/en/glossary/terms/eck.asciidoc
+++ b/docs/en/glossary/terms/eck.asciidoc
@@ -1,0 +1,6 @@
+
+[[glossary-eck]] {eck} (ECK)::
+Built on the Kubernetes Operator pattern, ECK extends the basic Kubernetes
+orchestration capabilities to support the setup and management of Elastic
+products and solutions on Kubernetes
+//Source: Cloud

--- a/docs/en/glossary/terms/elastic-stack.asciidoc
+++ b/docs/en/glossary/terms/elastic-stack.asciidoc
@@ -1,0 +1,5 @@
+
+[[glossary-elastic-stack]] {stack}::
+Also known as the _ELK Stack_, the {stack} is the combination of various Elastic
+products that integrate for a scalable and flexible way to manage your data.
+//Source: Cloud

--- a/docs/en/glossary/terms/elasticsearch-service.asciidoc
+++ b/docs/en/glossary/terms/elasticsearch-service.asciidoc
@@ -1,0 +1,6 @@
+
+[[glossary-elasticsearch-service]] {ess}::
+The official hosted {stack} offering, from the makers of {es}. Available as a
+software-as-a-service (SaaS) offering on different cloud platforms, such as AWS,
+GCP, and Microsoft Azure.
+//Source: Cloud

--- a/docs/en/glossary/terms/hardware-profile.asciidoc
+++ b/docs/en/glossary/terms/hardware-profile.asciidoc
@@ -1,0 +1,6 @@
+
+[[glossary-hardware-profile]] hardware profile::
+In {ecloud}, a built-in <<glossary-deployment-template,deployment template>>
+that supports a specific use case for the {stack}, such as a compute optimized
+deployment that provides high vCPU for search-heavy use cases.
+//Source: Cloud

--- a/docs/en/glossary/terms/host-runner.asciidoc
+++ b/docs/en/glossary/terms/host-runner.asciidoc
@@ -1,0 +1,7 @@
+
+[[glossary-host-runner]] host runner (runner)::
+In {ece}, a local control agent that runs on all hosts, used to deploy local
+containers based on role definitions. Ensures that containers assigned to the
+host exist and are able to run, and creates or recreates the containers if
+necessary.
+//Source: Cloud

--- a/docs/en/glossary/terms/instance-configuration.asciidoc
+++ b/docs/en/glossary/terms/instance-configuration.asciidoc
@@ -1,0 +1,6 @@
+
+[[glossary-instance-configuration]] instance-configuration::
+In {ecloud}, enables the instances of the {stack} to run on suitable hardware
+resources by filtering on <<glossary-allocator-tag,allocator tags>>. Used as
+building blocks for <<glossary-deployment-template,deployment templates>>.
+//Source: Cloud

--- a/docs/en/glossary/terms/instance-configuration.asciidoc
+++ b/docs/en/glossary/terms/instance-configuration.asciidoc
@@ -1,5 +1,5 @@
 
-[[glossary-instance-configuration]] instance-configuration::
+[[glossary-instance-configuration]] instance configuration::
 In {ecloud}, enables the instances of the {stack} to run on suitable hardware
 resources by filtering on <<glossary-allocator-tag,allocator tags>>. Used as
 building blocks for <<glossary-deployment-template,deployment templates>>.

--- a/docs/en/glossary/terms/instance-type.asciidoc
+++ b/docs/en/glossary/terms/instance-type.asciidoc
@@ -1,0 +1,5 @@
+
+[[glossary-instance-type]] instance type::
+In {ecloud}, categories for <<glossary-instance,instances>> representing
+an Elastic feature or cluster node types, such as `master`, `ml` or `data`.
+//Source: Cloud

--- a/docs/en/glossary/terms/instance.asciidoc
+++ b/docs/en/glossary/terms/instance.asciidoc
@@ -1,0 +1,7 @@
+
+[[glossary-instance]] instance::
+A product from the {stack} that is running in an {ecloud} deployment, such as
+an {es} node or a {kib} instance. When you choose more 
+<<glossary-zone,availability zones>>, the system automatically creates more
+instances for you.
+//Source: Cloud

--- a/docs/en/glossary/terms/kibana.asciidoc
+++ b/docs/en/glossary/terms/kibana.asciidoc
@@ -1,0 +1,4 @@
+
+[[glossary-kibana]] kibana::
+A user interface that lets you visualize your {es} data and navigate the {stack}. 
+//Source: Cloud

--- a/docs/en/glossary/terms/kibana.asciidoc
+++ b/docs/en/glossary/terms/kibana.asciidoc
@@ -1,4 +1,4 @@
 
-[[glossary-kibana]] kibana::
+[[glossary-kibana]] {kib}::
 A user interface that lets you visualize your {es} data and navigate the {stack}. 
 //Source: Cloud

--- a/docs/en/glossary/terms/no-op.asciidoc
+++ b/docs/en/glossary/terms/no-op.asciidoc
@@ -1,0 +1,6 @@
+
+[[glossary-no-op]] no-op::
+In {ecloud}, the application of a rolling update on your deployment without
+actually applying any configuration changes. This type of update can be useful
+to resolve certain health warnings. 
+//Source: Cloud

--- a/docs/en/glossary/terms/solution.asciidoc
+++ b/docs/en/glossary/terms/solution.asciidoc
@@ -1,0 +1,6 @@
+
+[[glossary-solution]] solution::
+In {ecloud}, deployments with specialized
+<<glossary-deployment-template,templates>> that are pre-configured with sensible
+defaults and settings for common use cases.
+//Source: Cloud

--- a/docs/en/glossary/terms/vcpu.asciidoc
+++ b/docs/en/glossary/terms/vcpu.asciidoc
@@ -1,0 +1,7 @@
+
+[[glossary-vcpu]] vCPU::
+vCPU stands for virtual central processing unit. In {ecloud}, vCPUs are virtual
+compute units assigned to your nodes. The value is dependent on the size and
+hardware profile of the instance. The instance may be eligible for vCPU boosting
+depending on the size.
+//Source: Cloud


### PR DESCRIPTION
This adds terms from the Cloud glossaries that were missing from our newly assembled and very nice [shared glossary](https://www.elastic.co/guide/en/elastic-stack-glossary/current/terms.html). 

Rel: https://github.com/elastic/platform-docs-team/issues/49