### PR TITLE
Updates 8.5 references to 8.6

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -67,9 +67,9 @@ the complete list, go to {ref}/breaking-changes.html[{es} breaking changes].
 ++++
 
 This list summarizes the most important breaking changes in {elastic-sec} {version}. For
-the complete list, go to {security-guide-all}/8.5/release-notes-header-8.5.0.html#breaking-changes-8.5.0[{elastic-sec} breaking changes].
+the complete list, go to {security-guide-all}/8.6/release-notes-header-8.5.0.html#breaking-changes-8.6.0[{elastic-sec} breaking changes].
 
-include::{security-repo-dir}/release-notes/8.5.asciidoc[tag=breaking-changes]
+include::{security-repo-dir}/release-notes/8.6.asciidoc[tag=breaking-changes]
 
 [[kibana-breaking-changes]]
 === {kib} breaking changes


### PR DESCRIPTION
Fixes #2292

## Notes
* The breaking changes page in the Install & Upgrade Guide is built using [includes of tagged regions](https://docs.asciidoctor.org/asciidoc/latest/directives/include-tagged-regions/), so I added tags to the relevant region in the Release Notes page in the Security Docs repo (see change in in https://github.com/elastic/security-docs/pull/2519).
* This PR's doc build will fail until the `8.6` release notes page is available on the public docsite. This means that, in order for this PR to successfully build, **_BOTH_** of the following requirements need to be met:
  - The `8.6` Security release notes PR merged into main and backported to the `8.6` branch.
  - The `8.6` Security release notes page will need to be built/published on the `8.6` branch and available on the [public docsite](https://www.elastic.co/guide/en/security/current/index.html). 