### PR TITLE
[DOCS] Fixes a URL on the compatible third-party NLP models page

### DIFF
--- a/docs/en/stack/ml/nlp/ml-nlp-model-ref.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-model-ref.asciidoc
@@ -103,7 +103,7 @@ Suitable similarity functions:	`cosine`
 Suitable similarity functions:	`dot_product`
 * https://huggingface.co/sentence-transformers/msmarco-MiniLM-L12-cos-v5[msmarco MiniLM L12 v5]
 Suitable similarity functions:	`dot_product`, `cosine`, `l2_norm`
-* https://huggingface.co/sentence-transformers/paraphrase-multilingual-mpnet-base-v2[paraphrase mpnet base v2]
+* https://huggingface.co/sentence-transformers/paraphrase-mpnet-base-v2[paraphrase mpnet base v2]
 Suitable similarity functions:	`cosine`
 
 Using `DPREncoderWrapper`:


### PR DESCRIPTION
## Overview

This PR fixes a URL on the third-party NLP models page which currently points to an incorrect page.

### Preview

[Compatible third-party NLP model list]()