### PR TITLE
[DOCS] Fix 8.6 breaking changes

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -57,7 +57,7 @@ include::{beats-repo-dir}/release-notes/breaking/breaking-8.0.asciidoc[tag=notab
 This list summarizes the most important breaking changes in {es} {version}. For
 the complete list, go to {ref}/breaking-changes.html[{es} breaking changes].
 
-// include::{es-repo-dir}/migration/migrate_8_2.asciidoc[tag=notable-breaking-changes]
+include::{es-repo-dir}/migration/migrate_8_6.asciidoc[tag=notable-breaking-changes]
 
 [[security-breaking-changes]]
 === {elastic-sec} breaking changes
@@ -77,8 +77,6 @@ include::{security-repo-dir}/release-notes/8.6.asciidoc[tag=breaking-changes]
 ++++
 <titleabbrev>{kib}</titleabbrev>
 ++++
-
-coming[8.6.0]
 
 This list summarizes the most important breaking changes in {kib} {version}. For
 the complete list, go to {kibana-ref}/release-notes-8.6.0.html#breaking-changes-8.6.0[{kib} breaking changes].


### PR DESCRIPTION
This PR fixes the re-use of Elasticsearch breaking changes in https://www.elastic.co/guide/en/elastic-stack/8.6/elasticsearch-breaking-changes.html and removes a "coming" tag.