### PR TITLE
[DOCS] Amends the instructions in the anomaly detection tutorial

### DIFF
--- a/docs/en/stack/ml/get-started/ml-gs-jobs.asciidoc
+++ b/docs/en/stack/ml/get-started/ml-gs-jobs.asciidoc
@@ -6,7 +6,6 @@
 IMPORTANT: The results on this page might be 
 different than the actual values you get when using the sample data sets. This 
 behavior is expected as the data points in the data sets might change over time.
-different versions.
 
 The {kib} sample data sets include some pre-configured {anomaly-jobs} for you to
 play with. You can use either of the following methods to add the jobs:

--- a/docs/en/stack/ml/get-started/ml-gs-jobs.asciidoc
+++ b/docs/en/stack/ml/get-started/ml-gs-jobs.asciidoc
@@ -3,9 +3,9 @@
 [[sample-data-jobs]]
 = Create sample {anomaly-jobs} in {kib}
 
-IMPORTANT: The results you can see in the screenshots of this page might be 
+IMPORTANT: The results on this page might be 
 different than the actual values you get when using the sample data sets. This 
-behavior is expected as the data points in the data sets might change in 
+behavior is expected as the data points in the data sets might change over time.
 different versions.
 
 The {kib} sample data sets include some pre-configured {anomaly-jobs} for you to

--- a/docs/en/stack/ml/get-started/ml-gs-jobs.asciidoc
+++ b/docs/en/stack/ml/get-started/ml-gs-jobs.asciidoc
@@ -3,6 +3,11 @@
 [[sample-data-jobs]]
 = Create sample {anomaly-jobs} in {kib}
 
+IMPORTANT: The results you can see in the screenshots of this page might be 
+different than the actual values you get when using the sample data sets. This 
+behavior is expected as the data points in the data sets might change in 
+different versions.
+
 The {kib} sample data sets include some pre-configured {anomaly-jobs} for you to
 play with. You can use either of the following methods to add the jobs:
 

--- a/docs/en/stack/ml/get-started/ml-gs-results.asciidoc
+++ b/docs/en/stack/ml/get-started/ml-gs-results.asciidoc
@@ -32,14 +32,17 @@ It has a single detector that uses the `low_count` function and limited job
 properties. You might use a job like this if you want to determine when the
 request rate on your web site drops significantly. 
 
-Let's start by looking at this simple job in the
-**Single Metric Viewer**:
+Let's start by looking at this simple job in the **Single Metric Viewer**:
 
 . Select the *Anomaly Detection* tab in *{ml-app}* to see the list of your
 {anomaly-jobs}.
 
 . Click the chart icon in the *Actions* column for your `low_request_rate` job
 to view its results in the **Single Metric Viewer**.
+
+. Use the relative mode of the date picker to select a start date one week in 
+the past and an end date one months in the future to cover the majority of the 
+analyzed data points.
 
 [role="screenshot"]
 image::images/ml-gs-job1-analysis.jpg["Single Metric Viewer for low_request_rate job"]

--- a/docs/en/stack/ml/get-started/ml-gs-results.asciidoc
+++ b/docs/en/stack/ml/get-started/ml-gs-results.asciidoc
@@ -41,7 +41,7 @@ Let's start by looking at this simple job in the **Single Metric Viewer**:
 to view its results in the **Single Metric Viewer**.
 
 . Use the relative mode of the date picker to select a start date one week in 
-the past and an end date one months in the future to cover the majority of the 
+the past and an end date one month in the future to cover the majority of the 
 analyzed data points.
 
 [role="screenshot"]


### PR DESCRIPTION
## Overview

This PR: 
* adds an admonition to the tutorial that informs the users that their results might differ from the results seen in the screenshots
* adds an extra step to the instructions to make sure that the anomaly in the analysis is visible in the SMV.

### Preview

[Create sample jobs...](https://stack-docs_2301.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-getting-started.html#sample-data-jobs) -- admonition block
[Single metric job results](https://stack-docs_2301.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-getting-started.html#ml-gs-results-smv) -- new step in the instructions