### PR TITLE
Marks recommended models in the third party models list

### DIFF
--- a/docs/en/stack/ml/nlp/ml-nlp-model-ref.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-model-ref.asciidoc
@@ -50,20 +50,20 @@ and to get started.
 == Third party named entity recognition models
 
 * https://huggingface.co/dslim/bert-base-NER[BERT base NER]
-* **https://huggingface.co/elastic/distilbert-base-cased-finetuned-conll03-english[DistilBERT base cased finetuned conll03 English]**
+* https://huggingface.co/elastic/distilbert-base-cased-finetuned-conll03-english[**DistilBERT base cased finetuned conll03 English**]
 * https://huggingface.co/philschmid/distilroberta-base-ner-conll2003[DistilRoBERTa base NER conll2003]
-* **https://huggingface.co/elastic/distilbert-base-uncased-finetuned-conll03-english[DistilBERT base uncased finetuned conll03 English]**
+* https://huggingface.co/elastic/distilbert-base-uncased-finetuned-conll03-english[**DistilBERT base uncased finetuned conll03 English**]
 * https://huggingface.co/HooshvareLab/distilbert-fa-zwnj-base-ner[DistilBERT fa zwnj base NER]
 
 [discrete]
 [[ml-nlp-model-ref-question-answering]]
 == Third party question answering models
 
-* * **https://huggingface.co/sentence-transformers/all-mpnet-base-v2[All MPNet base v2]**
+* https://huggingface.co/sentence-transformers/all-mpnet-base-v2[**All MPNet base v2**]
 * https://huggingface.co/bert-large-uncased-whole-word-masking-finetuned-squad[BERT large model (uncased) whole word masking finetuned on SQuAD]
 * https://huggingface.co/distilbert-base-cased-distilled-squad[DistilBERT base cased distilled SQuAD]
 * https://huggingface.co/deepset/electra-base-squad2[Electra base squad2]
-* **https://huggingface.co/sentence-transformers/multi-qa-mpnet-base-cos-v1[Multi QA MPNet base cos v1]**
+* https://huggingface.co/sentence-transformers/multi-qa-mpnet-base-cos-v1[**Multi QA MPNet base cos v1**]
 * https://huggingface.co/deepset/tinyroberta-squad2[TinyRoBERTa squad2]
 
 
@@ -96,7 +96,7 @@ Using `SentenceTransformerWrapper`:
 Suitable similarity functions:	`dot_product`, `cosine`, `l2_norm`
 * https://huggingface.co/sentence-transformers/all-MiniLM-L12-v2[All MiniLM L12 v2]
 Suitable similarity functions:	`dot_product`, `cosine`, `l2_norm`
-* **https://huggingface.co/sentence-transformers/all-mpnet-base-v2[All MPNet base v2]**
+* https://huggingface.co/sentence-transformers/all-mpnet-base-v2[**All MPNet base v2**]
 Suitable similarity functions:	`dot_product`, `cosine`, `l2_norm`
 * https://huggingface.co/sentence-transformers/facebook-dpr-ctx_encoder-multiset-base[Facebook dpr-ctx_encoder multiset base]
 Suitable similarity functions:	`dot_product`
@@ -141,7 +141,7 @@ Using `DPREncoderWrapper`:
 
 * https://huggingface.co/facebook/bart-large-mnli[BART large mnli]
 * https://huggingface.co/typeform/distilbert-base-uncased-mnli[DistilBERT base model (uncased)]
-* **https://huggingface.co/valhalla/distilbart-mnli-12-6[DistilBart MNLI]**
+* https://huggingface.co/valhalla/distilbart-mnli-12-6[**DistilBart MNLI**]
 * https://huggingface.co/typeform/mobilebert-uncased-mnli[MobileBERT: a Compact Task-Agnostic BERT for Resource-Limited Devices]
 * https://huggingface.co/cross-encoder/nli-distilroberta-base[NLI DistilRoBERTa base]
 * https://huggingface.co/cross-encoder/nli-roberta-base[NLI RoBERTa base]

--- a/docs/en/stack/ml/nlp/ml-nlp-model-ref.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-model-ref.asciidoc
@@ -33,7 +33,7 @@ These models are listed by NLP task; for more information about those tasks,
 refer to <<ml-nlp-overview>>.
 
 **Models highlighted in bold** in the list below are recommended for evaluation 
-and to get started. 
+purposes and to get started with the Elastic {nlp} features. 
 
 
 [discrete]

--- a/docs/en/stack/ml/nlp/ml-nlp-model-ref.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-model-ref.asciidoc
@@ -32,6 +32,9 @@ way described, or at all.
 These models are listed by NLP task; for more information about those tasks,
 refer to <<ml-nlp-overview>>.
 
+**Models highlighted in bold** in the list below are recommended for evaluation 
+and to get started. 
+
 
 [discrete]
 [[ml-nlp-model-ref-mask]]
@@ -47,18 +50,20 @@ refer to <<ml-nlp-overview>>.
 == Third party named entity recognition models
 
 * https://huggingface.co/dslim/bert-base-NER[BERT base NER]
-* https://huggingface.co/elastic/distilbert-base-cased-finetuned-conll03-english[DistilBERT base cased finetuned conll03 English]
+* **https://huggingface.co/elastic/distilbert-base-cased-finetuned-conll03-english[DistilBERT base cased finetuned conll03 English]**
 * https://huggingface.co/philschmid/distilroberta-base-ner-conll2003[DistilRoBERTa base NER conll2003]
-* https://huggingface.co/elastic/distilbert-base-uncased-finetuned-conll03-english[DistilBERT base uncased finetuned conll03 English]
+* **https://huggingface.co/elastic/distilbert-base-uncased-finetuned-conll03-english[DistilBERT base uncased finetuned conll03 English]**
 * https://huggingface.co/HooshvareLab/distilbert-fa-zwnj-base-ner[DistilBERT fa zwnj base NER]
 
 [discrete]
 [[ml-nlp-model-ref-question-answering]]
 == Third party question answering models
 
+* * **https://huggingface.co/sentence-transformers/all-mpnet-base-v2[All MPNet base v2]**
 * https://huggingface.co/bert-large-uncased-whole-word-masking-finetuned-squad[BERT large model (uncased) whole word masking finetuned on SQuAD]
 * https://huggingface.co/distilbert-base-cased-distilled-squad[DistilBERT base cased distilled SQuAD]
 * https://huggingface.co/deepset/electra-base-squad2[Electra base squad2]
+* **https://huggingface.co/sentence-transformers/multi-qa-mpnet-base-cos-v1[Multi QA MPNet base cos v1]**
 * https://huggingface.co/deepset/tinyroberta-squad2[TinyRoBERTa squad2]
 
 
@@ -73,15 +78,15 @@ Examples of typical scoring functions are: `cosine`, `dot product` and
 
 The embeddings produced by these models should be indexed in {es} using the
 {ref}/dense-vector.html[dense vector field type]
-with an appropriate {ref}/dense-vector.html#dense-vector-params[similarity function]
-chosen for the model. 
+with an appropriate 
+{ref}/dense-vector.html#dense-vector-params[similarity function] chosen for the 
+model. 
 
 To find similar embeddings in {es} use the efficient 
 {ref}/knn-search.html#approximate-knn[Approximate k-nearest neighbor (kNN)]
-search API with a text embedding as the query vector. Approximate 
-kNN search uses the similarity function defined in 
-the dense vector field mapping is used to calculate the relevance.
-For the best results the function must be one of 
+search API with a text embedding as the query vector. Approximate kNN search 
+uses the similarity function defined in the dense vector field mapping is used 
+to calculate the relevance. For the best results the function must be one of 
 the suitable similarity functions for the model.
 
 
@@ -91,7 +96,7 @@ Using `SentenceTransformerWrapper`:
 Suitable similarity functions:	`dot_product`, `cosine`, `l2_norm`
 * https://huggingface.co/sentence-transformers/all-MiniLM-L12-v2[All MiniLM L12 v2]
 Suitable similarity functions:	`dot_product`, `cosine`, `l2_norm`
-* https://huggingface.co/sentence-transformers/all-mpnet-base-v2[All MPNet base v2]
+* **https://huggingface.co/sentence-transformers/all-mpnet-base-v2[All MPNet base v2]**
 Suitable similarity functions:	`dot_product`, `cosine`, `l2_norm`
 * https://huggingface.co/sentence-transformers/facebook-dpr-ctx_encoder-multiset-base[Facebook dpr-ctx_encoder multiset base]
 Suitable similarity functions:	`dot_product`
@@ -136,7 +141,7 @@ Using `DPREncoderWrapper`:
 
 * https://huggingface.co/facebook/bart-large-mnli[BART large mnli]
 * https://huggingface.co/typeform/distilbert-base-uncased-mnli[DistilBERT base model (uncased)]
-* https://huggingface.co/valhalla/distilbart-mnli-12-6[DistilBart MNLI]
+* **https://huggingface.co/valhalla/distilbart-mnli-12-6[DistilBart MNLI]**
 * https://huggingface.co/typeform/mobilebert-uncased-mnli[MobileBERT: a Compact Task-Agnostic BERT for Resource-Limited Devices]
 * https://huggingface.co/cross-encoder/nli-distilroberta-base[NLI DistilRoBERTa base]
 * https://huggingface.co/cross-encoder/nli-roberta-base[NLI RoBERTa base]


### PR DESCRIPTION
## Overview

Related issue: https://github.com/elastic/ml-team/issues/894
This PR highlights recommended models for every task type on the supported models' page. 

### Preview

[Compatible third party NLP models](https://stack-docs_2310.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-nlp-model-ref.html)

