### PR TITLE
Fixes GH links on Apache and Nginx OOTB job pages

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-apache.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-apache.asciidoc
@@ -14,10 +14,10 @@ use fields and data types from the Elastic Common Schema (ECS).
 These {anomaly-jobs} find unusual activity in HTTP access logs.
 
 For more details, see the {dfeed} and job definitions in
-https://github.com/elastic/integrations/blob/{branch}/packages/apache/kibana/ml_module/apache-Logs-ml.json[GitHub].
+https://github.com/elastic/integrations/blob/main/packages/apache/kibana/ml_module/apache-Logs-ml.json[GitHub].
 Note that these jobs are available in {kib} only if data exists that matches the
 query specified in the
-https://github.com/elastic/integrations/blob/{branch}/packages/apache/kibana/ml_module/apache-Logs-ml.json#L11[manifest file].
+https://github.com/elastic/integrations/blob/main/packages/apache/kibana/ml_module/apache-Logs-ml.json#L11[manifest file].
 
 |===
 |Name |Description |Job |Datafeed

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-apache.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-apache.asciidoc
@@ -24,28 +24,28 @@ https://github.com/elastic/integrations/blob/main/packages/apache/kibana/ml_modu
 
 |low_request_rate_apache
 |Detects low request rates.
-|https://github.com/elastic/integrations/blob/{branch}/packages/apache/kibana/ml_module/apache-Logs-ml.json#L215[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/{branch}/packages/apache/kibana/ml_module/apache-Logs-ml.json#L370[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/apache/kibana/ml_module/apache-Logs-ml.json#L215[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/apache/kibana/ml_module/apache-Logs-ml.json#L370[image:images/link.svg[A link icon]]
 
 |source_ip_request_rate_apache
 |Detects unusual source IPs - high request rates.
-|https://github.com/elastic/integrations/blob/{branch}/packages/apache/kibana/ml_module/apache-Logs-ml.json#L176[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/{branch}/packages/apache/kibana/ml_module/apache-Logs-ml.json#L349[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/apache/kibana/ml_module/apache-Logs-ml.json#L176[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/apache/kibana/ml_module/apache-Logs-ml.json#L349[image:images/link.svg[A link icon]]
 
 |source_ip_url_count_apache
 |Detects unusual source IPs - high distinct count of URLs.
-|https://github.com/elastic/integrations/blob/{branch}/packages/apache/kibana/ml_module/apache-Logs-ml.json#L136[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/{branch}/packages/apache/kibana/ml_module/apache-Logs-ml.json#L328[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/apache/kibana/ml_module/apache-Logs-ml.json#L136[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/apache/kibana/ml_module/apache-Logs-ml.json#L328[image:images/link.svg[A link icon]]
 
 |status_code_rate_apache
 |Detects unusual status code rates.
-|https://github.com/elastic/integrations/blob/{branch}/packages/apache/kibana/ml_module/apache-Logs-ml.json#L90[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/{branch}/packages/apache/kibana/ml_module/apache-Logs-ml.json#L307[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/apache/kibana/ml_module/apache-Logs-ml.json#L90[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/apache/kibana/ml_module/apache-Logs-ml.json#L307[image:images/link.svg[A link icon]]
 
 |visitor_rate_apache
 |Detects unusual visitor rates.
-|https://github.com/elastic/integrations/blob/{branch}/packages/apache/kibana/ml_module/apache-Logs-ml.json#L47[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/{branch}/packages/apache/kibana/ml_module/apache-Logs-ml.json#L260[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/apache/kibana/ml_module/apache-Logs-ml.json#L47[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/apache/kibana/ml_module/apache-Logs-ml.json#L260[image:images/link.svg[A link icon]]
 |===
 
 [discrete]

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-nginx.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-nginx.asciidoc
@@ -23,28 +23,28 @@ https://github.com/elastic/integrations/blob/main/packages/nginx/kibana/ml_modul
 
 |low_request_rate_nginx
 |Detect low request rates
-|https://github.com/elastic/integrations/blob/{branch}/packages/nginx/kibana/ml_module/nginx-Logs-ml.json#L215[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/{branch}/packages/nginx/kibana/ml_module/nginx-Logs-ml.json#L370[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/nginx/kibana/ml_module/nginx-Logs-ml.json#L215[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/nginx/kibana/ml_module/nginx-Logs-ml.json#L370[image:images/link.svg[A link icon]]
 
 |source_ip_request_rate_nginx
 |Detect unusual source IPs - high request rates
-|https://github.com/elastic/integrations/blob/{branch}/packages/nginx/kibana/ml_module/nginx-Logs-ml.json#L176[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/{branch}/packages/nginx/kibana/ml_module/nginx-Logs-ml.json#L349[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/nginx/kibana/ml_module/nginx-Logs-ml.json#L176[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/nginx/kibana/ml_module/nginx-Logs-ml.json#L349[image:images/link.svg[A link icon]]
 
 |source_ip_url_count_nginx
 |Detect unusual source IPs - high distinct count of URLs
-|https://github.com/elastic/integrations/blob/{branch}/packages/nginx/kibana/ml_module/nginx-Logs-ml.json#L136[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/{branch}/packages/nginx/kibana/ml_module/nginx-Logs-ml.json#L328[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/nginx/kibana/ml_module/nginx-Logs-ml.json#L136[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/nginx/kibana/ml_module/nginx-Logs-ml.json#L328[image:images/link.svg[A link icon]]
 
 |status_code_rate_nginx
 |Detect unusual status code rates
-|https://github.com/elastic/integrations/blob/{branch}/packages/nginx/kibana/ml_module/nginx-Logs-ml.json#L90[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/{branch}/packages/nginx/kibana/ml_module/nginx-Logs-ml.json#L307[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/nginx/kibana/ml_module/nginx-Logs-ml.json#L90[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/nginx/kibana/ml_module/nginx-Logs-ml.json#L307[image:images/link.svg[A link icon]]
 
 |visitor_rate_nginx
 |Detect unusual visitor rates
-|https://github.com/elastic/integrations/blob/{branch}/packages/nginx/kibana/ml_module/nginx-Logs-ml.json#L47[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/{branch}/packages/nginx/kibana/ml_module/nginx-Logs-ml.json#L260[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/nginx/kibana/ml_module/nginx-Logs-ml.json#L47[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/nginx/kibana/ml_module/nginx-Logs-ml.json#L260[image:images/link.svg[A link icon]]
 
 |=== 
 

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-nginx.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-nginx.asciidoc
@@ -16,7 +16,7 @@ Find unusual activity in HTTP access logs.
 
 These jobs are available in {kib} only if
 data exists that matches the query specified in the 
-https://github.com/elastic/integrations/blob/{branch}/packages/nginx/kibana/ml_module/nginx-Logs-ml.json[manifest file].
+https://github.com/elastic/integrations/blob/main/packages/nginx/kibana/ml_module/nginx-Logs-ml.json[manifest file].
 
 |===
 |Name |Description |Job |Datafeed


### PR DESCRIPTION
## Overview

This PR changes links on the Apache and Nginx pages that point to the GH repo where the spec files are stored. Until 8.1, it was the Kibana repo (version controlled). From 8.2, it's the Integrations repo (not version controlled). For this reason, the links from 8.2 to 8.6 are broken. This PR fixes this problem. 7.17 is also affected as it's an active (updated) branch.