### PR TITLE
Adds limitation item about anomaly detection jobs and frozen tier data

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/ml-limitations.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-limitations.asciidoc
@@ -107,10 +107,10 @@ in {dfeeds} or jobs. See
 {ref}/searching_a_frozen_index.html[Searching a frozen index].
 
 [discrete]
-[[ml-frozen-tire-limitations]]
-=== Frozen tires are not supported
+[[ml-frozen-tier-limitations]]
+=== Frozen tiers are not supported
 
-{ref}/data-tiers.html#frozen-tier[Frozen tires] camnot be used in {anomaly-jobs} 
+{ref}/data-tiers.html#frozen-tier[Frozen tiers] cannot be used in {anomaly-jobs} 
 or {dfeeds}. This limitation applies irrespective of whether you create the jobs 
 in {kib} or by using APIs. 
 

--- a/docs/en/stack/ml/anomaly-detection/ml-limitations.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-limitations.asciidoc
@@ -106,6 +106,14 @@ possible to specify the `ignore_throttled` query parameter for search requests
 in {dfeeds} or jobs. See
 {ref}/searching_a_frozen_index.html[Searching a frozen index].
 
+[discrete]
+[[ml-frozen-tire-limitations]]
+=== Frozen tires are not supported
+
+{ref}/data-tiers.html#frozen-tier[Frozen tires] camnot be used in {anomaly-jobs} 
+or {dfeeds}. This limitation applies irrespective of whether you create the jobs 
+in {kib} or by using APIs. 
+
 
 [discrete]
 [[ml-forecast-config-limitations]]


### PR DESCRIPTION
## Overview

Related issue: https://github.com/elastic/machine-learning-qa/issues/1449
This PR adds a new item to the list of anomaly detection limitations. Frozen tier data is not supported for anomaly detection.

### Preview

[AD limitations]()