### PR TITLE
Removes pages from the how-to section

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/anomaly-detection-scale.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/anomaly-detection-scale.asciidoc
@@ -113,8 +113,7 @@ detectors.
 If you have high cardinality `by` or `partition` fields, ensure you have 
 sufficient memory resources available for the job. Alternatively, consider if 
 the job can be split into smaller jobs by using a {dfeed} query. For very high 
-cardinality, using a <<ml-configuring-populations,population analysis>> may be 
-more appropriate.
+cardinality, using a population analysis may be more appropriate.
 
 To change partitioning fields, influencers and/or detectors, you need to clone 
 or create a new job.
@@ -293,8 +292,6 @@ series. It builds a profile of what a "typical" entity does over a specified
 time period and then identifies when one is behaving abnormally compared to the 
 population. Use population analysis for analyzing high cardinality fields if you 
 expect that the entities of the population generally behave in the same way.
-
-For more information, refer to <<ml-configuring-populations>>.
 
 
 [discrete]

--- a/docs/en/stack/ml/anomaly-detection/anomaly-how-tos.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/anomaly-how-tos.asciidoc
@@ -9,13 +9,13 @@ gaining deep insights might require some additional planning and configuration.
 The guides in this section describe some best practices for generating useful
 {ml} results and insights from your data.
 
-* <<ml-configuring-aggregation, Using aggregations in {dfeeds}>>
+* <<ml-configuring-alerts, Generating alerts for {anomaly-jobs}>>
+* <<ml-configuring-aggregation, Aggregating data for fester performance>>
 * <<ml-configuring-transform, Using runtime fields in {dfeeds}>>
 * <<ml-configuring-detector-custom-rules>>
 * <<ml-reverting-model-snapshot>>
 * <<geographic-anomalies>>
 * <<mapping-anomalies>>
-* <<ml-configuring-populations>>
 * <<ml-configuring-url>>
 * <<ml-jobs-from-lens>>
 * <<move-jobs>>

--- a/docs/en/stack/ml/anomaly-detection/index.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/index.asciidoc
@@ -36,15 +36,11 @@ include::{es-repo-dir}/ml/anomaly-detection/ml-configuring-transform.asciidoc[le
 
 include::{es-repo-dir}/ml/anomaly-detection/ml-configuring-detector-custom-rules.asciidoc[leveloffset=+2]
 
-include::{es-repo-dir}/ml/anomaly-detection/ml-configuring-categories.asciidoc[leveloffset=+2]
-
 include::ml-revert-model-snapshot.asciidoc[leveloffset=+2]
 
 include::geographic-anomalies.asciidoc[leveloffset=+2]
 
 include::mapping-anomalies.asciidoc[leveloffset=+2]
-
-include::{es-repo-dir}/ml/anomaly-detection/ml-configuring-populations.asciidoc[leveloffset=+2]
 
 include::{es-repo-dir}/ml/anomaly-detection/ml-configuring-url.asciidoc[leveloffset=+2]
 

--- a/docs/en/stack/ml/anomaly-detection/ml-ad-run-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-ad-run-jobs.asciidoc
@@ -52,8 +52,7 @@ which is more efficient than running multiple jobs against the same data.
 to the behavior of the population.
 
 * The categorization wizard creates jobs that group log messages into categories
-and use `count` or `rare` functions to detect anomalies within them. See
-<<ml-configuring-categories>>.
+and use `count` or `rare` functions to detect anomalies within them.
 
 * The advanced wizard creates jobs that can have multiple detectors and enables
 you to configure all job settings.

--- a/docs/en/stack/ml/anomaly-detection/ml-ad-run-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-ad-run-jobs.asciidoc
@@ -49,8 +49,7 @@ many of the more advanced configuration options.
 which is more efficient than running multiple jobs against the same data.
 
 * The population wizard creates jobs that detect activity that is unusual compared
-to the behavior of the population. For more information, see
-<<ml-configuring-populations>>.
+to the behavior of the population.
 
 * The categorization wizard creates jobs that group log messages into categories
 and use `count` or `rare` functions to detect anomalies within them. See

--- a/docs/en/stack/ml/anomaly-detection/ml-limitations.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-limitations.asciidoc
@@ -163,8 +163,7 @@ not available in the Upgrade assistant.
 Categorization identifies static parts of unstructured logs and groups similar
 messages together. The default categorization tokenizer assumes English language
 log messages. For other languages you must define a different
-`categorization_analyzer` for your job. For more information, see
-<<ml-configuring-categories>>.
+`categorization_analyzer` for your job.
 
 Additionally, a dictionary used to influence the categorization process contains
 only English words. This means categorization might work better in English than

--- a/docs/en/stack/ml/get-started/ml-gs-results.asciidoc
+++ b/docs/en/stack/ml/get-started/ml-gs-results.asciidoc
@@ -250,4 +250,3 @@ found for two customers:
 [role="screenshot"]
 image::images/ml-gs-job4-explorer.jpg["Anomaly charts for the high_sum_total_sales job"]
 
-For more information, see <<ml-configuring-populations>>.

--- a/docs/en/stack/ml/redirects.asciidoc
+++ b/docs/en/stack/ml/redirects.asciidoc
@@ -16,7 +16,12 @@ This page has moved. See <<ml-ad-datafeeds>>.
 [role="exclude",id="ml-configuring-pop"]
 === Performing population analysis
 
-This page has moved. See <<ml-configuring-populations>>.
+This page has been removed.
+
+[role="exclude",id="ml-configuring-populations"]
+=== Configuring population analysis
+
+This page has been removed.
 
 [role="exclude",id="ml-inference-models"]
 === Trained {ml} models as functions

--- a/docs/en/stack/ml/redirects.asciidoc
+++ b/docs/en/stack/ml/redirects.asciidoc
@@ -16,12 +16,17 @@ This page has moved. See <<ml-ad-datafeeds>>.
 [role="exclude",id="ml-configuring-pop"]
 === Performing population analysis
 
-This page has been removed.
+This page has been removed. Refer to <<population-jobs>>.
 
 [role="exclude",id="ml-configuring-populations"]
 === Configuring population analysis
 
-This page has been removed.
+This page has been removed. Refer to <<population-jobs>>.
+
+[role="exclude",id="ml-configuring-categories"]
+=== Detecting anomalous categories of data
+
+This page has been removed. Refer to <<categorization-jobs>>.
 
 [role="exclude",id="ml-inference-models"]
 === Trained {ml} models as functions


### PR DESCRIPTION
## Overview

Related to https://github.com/elastic/ml-team/issues/867.
This PR removes the pages about categorization and population jobs under the How-to section of the book. A higher-level description of these jobs is available on the page about the different types of anomaly detection jobs. This PR is part of the anomaly detection documentation reorganization effort.