### PR TITLE
Removes reference to semantic search endpoint from docs

### DIFF
--- a/docs/en/stack/ml/nlp/ml-nlp-apis.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-apis.asciidoc
@@ -26,15 +26,3 @@ All the trained models endpoints have the following base:
 * {ref}/stop-trained-model-deployment.html[Stop trained model deployment]
 // UPDATE
 * {ref}/put-trained-models-aliases.html[Update trained model aliases]
-
-
-// SEMANTIC SEARCH
-The Semantic search endpoint has the following base:
-
-[source,js]
-----
-<target>/_semantic_search
-----
-// NOTCONSOLE
-
-* {ref}/semantic-search-api.html[Semantic search]


### PR DESCRIPTION
## Overview

Related to: https://github.com/elastic/elasticsearch/pull/93500
Removes a reference to the semantic search endpoint from the NLP API page.