### PR TITLE
[DOCS] Adds info about available field statistics in AD and DFA wizards

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/job-tips.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/job-tips.asciidoc
@@ -30,8 +30,7 @@ Detectors can also contain properties that affect which types of entities or
 events are considered anomalous. For example, you can specify whether entities
 are analyzed relative to their own previous behavior or relative to other
 entities in a population. There are also multiple options for splitting the data
-into categories and partitions. Some of these more advanced job configurations
-are described in <<anomaly-examples>>.
+into categories and partitions.
 
 If your job does not contain a  detector or the detector does not contain a 
 <<ml-functions,valid function>>, you receive an error. If a job contains

--- a/docs/en/stack/ml/df-analytics/ml-dfa-classification.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-classification.asciidoc
@@ -90,6 +90,10 @@ necessary to perform an analytics task. You can create {dfanalytics-jobs} via
 Select {classification} as the analytics type, then select the field that you 
 want to predict (the {depvar}). You can also include and exclude fields.
 
+TIP: You can view the statistics of the selectable fields in the {dfanalytics} 
+wizard. The field statistics displayed in a flyout provide more meaningful 
+context to help you select relevant fields.
+
 To improve performance, consider using a small `training_percent` value to train 
 the model more quickly. It is a good strategy to make progress iteratively: run 
 the analysis with a small training percentage, then evaluate the performance. 

--- a/docs/en/stack/ml/df-analytics/ml-dfa-outlier-detection.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-outlier-detection.asciidoc
@@ -112,6 +112,10 @@ Select {oldetection} as the analytics type that the {dfanalytics-job} performs.
 You can also decide to include and exclude fields to/from the analysis when you 
 create the job.
 
+TIP: You can view the statistics of the selectable fields in the {dfanalytics} 
+wizard. The field statistics displayed in a flyout provide more meaningful 
+context to help you select relevant fields.
+
 
 [discrete]
 [[dfa-outlier-detection-start]]

--- a/docs/en/stack/ml/df-analytics/ml-dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-regression.asciidoc
@@ -78,6 +78,10 @@ Select {regression} as the analytics type for the job, then select
 the field that you want to predict (the {depvar}). You can also include and 
 exclude fields to/from the analysis.
 
+TIP: You can view the statistics of the selectable fields in the {dfanalytics} 
+wizard. The field statistics displayed in a flyout provide more meaningful 
+context to help you select relevant fields.
+
 
 [discrete]
 [[dfa-regression-start]]

--- a/docs/en/stack/ml/get-started/ml-getting-started.asciidoc
+++ b/docs/en/stack/ml/get-started/ml-getting-started.asciidoc
@@ -63,6 +63,7 @@ user that has authority to manage {anomaly-jobs}. See <<setup>>.
 .. From the {kib} home page, click *Add data*, then select *Sample data*.
 
 .. Pick a data set. In this tutorial, you'll use the *Sample web logs*. While
-you're here, feel free to click *Add data* on all of the available sample data sets.
+you're here, feel free to click *Add data* on all of the available sample data 
+sets.
 
 These data sets are now ready be analyzed in {ml} jobs in {kib}.

--- a/docs/en/stack/ml/get-started/ml-gs-jobs.asciidoc
+++ b/docs/en/stack/ml/get-started/ml-gs-jobs.asciidoc
@@ -3,9 +3,9 @@
 [[sample-data-jobs]]
 = Create sample {anomaly-jobs} in {kib}
 
-IMPORTANT: The results on this page might be 
-different than the actual values you get when using the sample data sets. This 
-behavior is expected as the data points in the data sets might change over time.
+IMPORTANT: The results on this page might be different than the actual values 
+you get when using the sample data sets. This behavior is expected as the data 
+points in the data sets might change over time.
 
 The {kib} sample data sets include some pre-configured {anomaly-jobs} for you to
 play with. You can use either of the following methods to add the jobs:
@@ -36,7 +36,8 @@ value that is seen within a bucket. Others perform some aggregation over the
 length of the bucket. For example, `mean` calculates the mean of all the data
 points seen within the bucket.
 
-For more information, see <<ml-ad-datafeeds>>, <<ml-buckets>>, and <<ml-functions>>.
+For more information, see <<ml-ad-datafeeds>>, <<ml-buckets>>, and 
+<<ml-functions>>.
 ****
 
 If you want to see all of the configuration details for your jobs and {dfeeds},

--- a/docs/en/stack/ml/get-started/ml-gs-visualizer.asciidoc
+++ b/docs/en/stack/ml/get-started/ml-gs-visualizer.asciidoc
@@ -23,7 +23,7 @@ exception for your {kib} URL.
 
 . Click *Select index* and choose the `kibana_sample_data_logs` {data-source}.
 
-. Use the time filter to select a time period that you're interested in
+. Use the time filter to select a time period that you're interested in 
 exploring. Alternatively, click
 *Use full kibana_sample_data_logs data* to view the full time range of data.
 
@@ -63,4 +63,8 @@ later in the tutorial.
 --
 
 Now that you're familiar with the data in the `kibana_sample_data_logs` index,
-you can create some {anomaly-jobs} to analyze it. 
+you can create some {anomaly-jobs} to analyze it.
+
+TIP: You can view the statistics of the selectable fields in the 
+{anomaly-detect} wizard. The field statistics displayed in a flyout provide more 
+meaningful context to help you select relevant fields.


### PR DESCRIPTION
## Overview

This PR adds a TIP about the available field stats in the anomaly detection and the data frame analytics wizards.
The PR also removes a link that is not relevant anymore and fixes some line breaks.