### PR TITLE
[DOCS] Fixes typo in link text

### DIFF
--- a/docs/en/stack/ml/index-custom-title-page.html
+++ b/docs/en/stack/ml/index-custom-title-page.html
@@ -120,7 +120,7 @@
         <a href="ml-dfa-regression.html">Predict numerical values with regression</a>
       </li>
       <li>
-        <a href="ml-dfa-classification.html">Predict classes with classifiation</a>
+        <a href="ml-dfa-classification.html">Predict classes with classification</a>
       </li>
       <li>
         <a href="ml-trained-models.html">Deploy trained models</a>


### PR DESCRIPTION
## Overview

This PR fixes a typo in one of the link text strings on the ML landing page.