### PR TITLE
Update NLP example to use semantic search

### DIFF
--- a/docs/en/stack/ml/nlp/ml-nlp-text-emb-vector-search-example.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-text-emb-vector-search-example.asciidoc
@@ -1,8 +1,8 @@
 [[ml-nlp-text-emb-vector-search-example]]
-= How to deploy a text embedding model and use it with vector search
+= How to deploy a text embedding model and use it for semantic search
 
 ++++
-<titleabbrev>Text embedding and vector search</titleabbrev>
+<titleabbrev>Text embedding and semantic search</titleabbrev>
 ++++
 :keywords: {ml-init}, {stack}, {nlp}
 
@@ -254,25 +254,13 @@ After the reindexing is finished, the documents in the new index contain the
 
 [discrete]
 [[ex-text-emb-vect-search]]
-== Vector similarity search
+== Semantic search
 
-To perform vector similarity search, you need to obtain the text embedding of a 
-text. This example uses the "How is the weather in Jamaica?" query as the input 
-text. The {ref}/infer-trained-model-deployment.html[_infer API] gives you the 
-embedding of this query as a dense vector:
-
-[source,js]
---------------------------------------------------
-POST /_ml/trained_models/sentence-transformers__msmarco-minilm-l-12-v3/_infer
-{
-  "docs": {
-    "text_field": "How is the weather in Jamaica?"
-  }
-}
---------------------------------------------------
-
-You can use the resulting dense vector in the `query_vector` of a 
-{ref}/knn-search.html[kNN search]:
+After the dataset has been enriched with vector embeddings, you can query the
+data using {ref}/knn-search.html#semantic-search[semantic search]. Pass a
+`query_vector_builder` to the k-nearest neighbor (kNN) vector search API, and
+provide the query text and the model you have used to create vector embeddings.
+This example searches for "How is the weather in Jamaica?":
 
 [source,js]
 --------------------------------------------------
@@ -280,13 +268,12 @@ GET collection-with-embeddings/_search
 {
   "knn": {
     "field": "text_embedding.predicted_value",
-    "query_vector": [
-     0.39521875977516174,
-        -0.3263707458972931,
-        0.26809820532798767,
-        0.30127981305122375,
-     (...)
-    ],
+    "query_vector_builder": {
+      "text_embedding": {
+        "model_id": "sentence-transformers__msmarco-minilm-l-12-v3",
+        "model_text": "How is the weather in Jamaica?"
+      }
+    },
     "k": 10,
     "num_candidates": 100
   },


### PR DESCRIPTION
This PR updates the NLP text embedding example to use the semantic search capabilities released with 8.7. 

I've also updated a few instances of "vector search" with "semantic search", as that will make it easier for folks to find this example.