### PR TITLE
Update ML docs for NER support

### DIFF
--- a/docs/en/stack/ml/nlp/ml-nlp-model-ref.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-model-ref.asciidoc
@@ -194,9 +194,9 @@ The predicted value here for `[MASK]` is `"France"` with a score of 1.2.
 
 Named entity recognition is a specific token classification task. Each token in 
 the sequence is scored related to a specific set of classification labels. For 
-the Elastic Stack, we use Inside-Outside-Beginning (IOB) tagging. Additionally,
-only the following classification labels are supported: "O", "B_MISC", "I_MISC", 
-"B_PER", "I_PER", "B_ORG", "I_ORG", "B_LOC", "I_LOC".
+the Elastic Stack, we use Inside-Outside-Beginning (IOB) tagging. Elastic supports any NER entities
+as long as they are IOB tagged. The default values are:
+"O", "B_MISC", "I_MISC", "B_PER", "I_PER", "B_ORG", "I_ORG", "B_LOC", "I_LOC".
 
 The `"O"` entity label indicates that the current token is outside any entity.
 `"I"` indicates that the token is inside an entity.


### PR DESCRIPTION
As of 8.4.0, Elasticsearch supports any IOB tagged NER entities.