### PR TITLE
[DOCS] Fixes AD limitation on frozen data tiers

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/ml-limitations.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-limitations.asciidoc
@@ -108,11 +108,11 @@ in {dfeeds} or jobs. See
 
 [discrete]
 [[ml-frozen-tier-limitations]]
-=== Frozen tiers are not supported
+=== {anomaly-jobs-cap} on frozen tier data cannot be created in {kib}
 
-{ref}/data-tiers.html#frozen-tier[Frozen tiers] cannot be used in {anomaly-jobs} 
-or {dfeeds}. This limitation applies irrespective of whether you create the jobs 
-in {kib} or by using APIs. 
+You cannot create {anomaly-jobs} on 
+{ref}/data-tiers.html#frozen-tier[frozen tier] data through the job wizards in 
+{kib}. If you want to create such jobs, use the APIs instead.
 
 
 [discrete]


### PR DESCRIPTION
## Overview

This PR fixes an inaccurate statement in one of the AD limitations items about frozen data tiers.

### Preview

[Anomaly detection jobs on frozen tier data cannot be created in Kibana]()