### PR TITLE
[DOCS] Fixes XGBoost typo

### DIFF
--- a/docs/en/stack/ml/df-analytics/ml-dfa-classification.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-classification.asciidoc
@@ -32,9 +32,9 @@ exclude fields. For more information about field selection, refer to the
 
 //tag::classification-algorithms[]
 {classanalysis-cap} uses an ensemble algorithm that is similar to extreme 
-gradient boosting (XGboost) which combines multiple weak models into a composite 
+gradient boosting (XGBoost) which combines multiple weak models into a composite 
 one. It uses decision trees to learn to predict the probability that a data 
-point belongs to a certain class. XGboost trains a sequence of decision 
+point belongs to a certain class. XGBoost trains a sequence of decision 
 trees and every decision tree learns from the mistakes of the forest so far. 
 In each iteration, the trees added to the forest improve the decision quality of 
 the combined decision forest. The classification algorithm optimizes for a loss 

--- a/docs/en/stack/ml/df-analytics/ml-dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-regression.asciidoc
@@ -23,8 +23,8 @@ the field you want to predict.
 
 //tag::regression-algorithms[]
 {regression-cap} uses an ensemble learning technique that is similar to extreme 
-gradient boosting (XGboost) which combines decision trees with gradient boosting 
-methodologies. XGboost trains a sequence of decision trees and every decision 
+gradient boosting (XGBoost) which combines decision trees with gradient boosting 
+methodologies. XGBoost trains a sequence of decision trees and every decision 
 tree learns from the mistakes of the forest so far. In each iteration, the trees 
 added to the forest improve the decision quality of the combined decision 
 forest. By default, the regression algorithm optimizes for a 


### PR DESCRIPTION
## Overview

The correct form of the technique is XGBoost. This PR fixes the occurrences of the word that include an error.