### PR TITLE
[DOCS] Adds section title and anchor for model deployment in air-gaped env

### DIFF
--- a/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
@@ -158,6 +158,13 @@ change the number of allocations, you can use the
 the allocation status is `started`.
 
 [discrete]
+[[ml-nlp-deploy-model-air-gaped]]
+== Deploy an NLP model in an air-gaped environment
+
+[TO DO]
+
+
+[discrete]
 [[ml-nlp-test-inference]]
 == Try it out
 


### PR DESCRIPTION
## Overview

This PR adds an empty section to the `Deploy trained models` page that will explain how to deploy trained models in an air-gaped environment. It also adds a section ID, so the section will have its own anchor (`#ml-nlp-deploy-model-air-gaped`) on the page.

Content will be added soon.