### PR TITLE
Removes beta tag from NLP landing page

### DIFF
--- a/docs/en/stack/ml/nlp/ml-nlp.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp.asciidoc
@@ -6,7 +6,6 @@
 
 [partintro]	
 --
-beta::[]
 
 You can use {stack-ml-features} to analyze natural language data and make
 predictions.


### PR DESCRIPTION
## Overview

This PR removes a `beta` tag from the NLP landing page.