### PR TITLE
Fixes a broken link that points to the latest Eland docs

### DIFF
--- a/docs/en/stack/ml/df-analytics/ml-trained-models.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-trained-models.asciidoc
@@ -144,8 +144,9 @@ export and import jobs in the *{stack-manage-app}* app in {kib}. Refer to
 == Importing an external model to the {stack}
 
 It is possible to import a model to your {es} cluster even if the model is not
-trained by Elastic {dfanalytics}. https://eland.readthedocs.io/[Eland] supports
+trained by Elastic {dfanalytics}. Eland supports
 https://www.elastic.co/guide/en/elasticsearch/client/eland/current/machine-learning.html[importing models]
 directly through its APIs. Please refer to the latest
-https://eland.readthedocs.io/[Eland documentation] for more information
-on supported model types and other details of using Eland to import models with.
+https://eland.readthedocs.io/en/latest/index.html[Eland documentation] for more 
+information on supported model types and other details of using Eland to import 
+models with.


### PR DESCRIPTION
## Overview

This PR fixes a link on the trained model page of the DFA docs that points to the latest Eland documentation.