### PR TITLE
[DOCS] Adjusts intro para for ELSER

### DIFF
--- a/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
@@ -9,17 +9,14 @@
 
 experimental[]
 
-
 Elastic Learned Sparse EncodeR - or ELSER - is a representational model trained 
-by Elastic that creates a sparse vector representation of a text. As a retrieval 
-model, ELSER performs text-expansion for more relevant search results with 
-expanding a passage to a sparse representation of tokens that are carefully 
-chosen to improve a semantically relevant retrieval.
+by Elastic that enables you to perform 
+{ref}/semantic-search-elser.html[semantic search] to improve search relevance. 
+With this search type you can retrieve search results based on contextual 
+meaning and user intent, rather than exact keyword matches.
 
-You can use ELSER for various NLP tasks, such as 
-{ref}/semantic-search-elser.html[semantic search]. ELSER is an out-of-domain 
-model which means it doesn't need to be fine-tuned on your data - it provides 
-relevant search results out of the box.
+ELSER is an out-of-domain model that does not require fine-tuning, making it 
+adaptable for various use cases out of the box.
 
 // TO DO: Refer to this blog post, to learn more about ELSER.
 


### PR DESCRIPTION
## Overview

The ELSER page intro was about how ELSER works and what technology it is based on. While it is important information, the first paragraph of the page must describe what the model can do for the users. For this reason, this PR changes the perspective of the first paragraph and describes how ELSER can help users. The technical background will be explained in a more detailed way in a blog post anyway and the intro will contain a link to that post, so anyone can learn more about it.

### Preview

* [ELSER](https://stack-docs_2393.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-nlp-elser.html)