### PR TITLE
[DOCS] Adds limitation item about ELSER v1

### DIFF
--- a/docs/en/stack/ml/nlp/index.asciidoc
+++ b/docs/en/stack/ml/nlp/index.asciidoc
@@ -11,4 +11,5 @@ include::ml-nlp-model-ref.asciidoc[leveloffset=+1]
 include::ml-nlp-examples.asciidoc[leveloffset=+1]
 include::ml-nlp-ner-example.asciidoc[leveloffset=+2]
 include::ml-nlp-text-emb-vector-search-example.asciidoc[leveloffset=+2]
+include::ml-nlp-limitations.asciidoc[leveloffset=+1]
 

--- a/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
@@ -9,17 +9,14 @@
 
 experimental[]
 
-
 Elastic Learned Sparse EncodeR - or ELSER - is a representational model trained 
-by Elastic that creates a sparse vector representation of a text. As a retrieval 
-model, ELSER performs text-expansion for more relevant search results with 
-expanding a passage to a sparse representation of tokens that are carefully 
-chosen to improve a semantically relevant retrieval.
+by Elastic that enables you to perform 
+{ref}/semantic-search-elser.html[semantic search] to improve search relevance. 
+With this search type you can retrieve search results based on contextual 
+meaning and user intent, rather than exact keyword matches.
 
-You can use ELSER for various NLP tasks, such as 
-{ref}/semantic-search-elser.html[semantic search]. ELSER is an out-of-domain 
-model which means it doesn't need to be fine-tuned on your data - it provides 
-relevant search results out of the box.
+ELSER is an out-of-domain model that does not require fine-tuning, making it 
+adaptable for various use cases out of the box.
 
 // TO DO: Refer to this blog post, to learn more about ELSER.
 

--- a/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
@@ -33,25 +33,35 @@ for semantic search or the trial period activated.
 
 
 [discrete]
-[[download-elser]]
-== Download ELSER
+[[download-deploy-elser]]
+== Download and deploy ELSER
 
-You can download ELSER either from **{ml-app}** > **Trained Models**, from 
-**{ents}** > **Indices**, or by using the Dev Console.
+You can download and deploy ELSER either from **{ml-app}** > **Trained Models**, 
+from **{ents}** > **Indices**, or by using the Dev Console.
 
 [discrete]
 [[trained-model]]
 === Using the Trained Models page
 
 1. In {kib}, navigate to **{ml-app}** > **Trained Models**. ELSER can be found 
-in the list of Trained Models.
-2. Click the Download model button under **Actions**. You can check the download 
-status on the **Notifications** page.
+in the list of trained models.
+2. Click the **Download model** button under **Actions**. You can check the 
+download status on the **Notifications** page.
 +
 --
 [role="screenshot"]
 image::images/ml-nlp-elser-download.png[alt="Downloading ELSER",align="center"]
 --
+3. After the download is finished, start the deployment by clicking the 
+**Start deployment** button.
+4. Provide a deployment ID, select the priority, and set the number of 
+allocations and threads per allocation values.
++
+--
+[role="screenshot"]
+image::images/ml-nlp-deploy-elser.png[alt="Deploying ELSER",align="center"]
+--
+5. Click Start.
 
 
 [discrete]
@@ -65,10 +75,12 @@ You can also download and deploy ELSER to an {infer} pipeline directly from the
 2. Select the index from the list that has an {infer} pipeline in which you want 
 to use ELSER.
 3. Navigate to the **Pipelines** tab.
-4. Under **{ml-app} {infer-cap} Pipelines**, click the "Start single-threaded" 
-button to download and start the model with basic configuration or select the 
-"Fine-tune performance" option to navigate to the **Trained Models** page where 
-you can configure the model deployment.
+4. Under **{ml-app} {infer-cap} Pipelines**, click the **Deploy** button to 
+begin downloading the ELSER model. This may take a few minutes depending on your 
+network. Once it's downloaded, click the **Start single-threaded** button to 
+start the model with basic configuration or select the **Fine-tune performance** 
+option to navigate to the **Trained Models** page where you can configure the 
+model deployment.
 
 
 [discrete]
@@ -77,7 +89,8 @@ you can configure the model deployment.
 
 1. In {kib}, navigate to the **Dev Console**.
 2. Create the ELSER model configuration by running the following API call:
-
++
+--
 [source,console]
 ----------------------------------
 PUT _ml/trained_models/.elser_model_1
@@ -90,40 +103,19 @@ PUT _ml/trained_models/.elser_model_1
 
 The API call automatically initiates the model download if the model is not 
 downloaded yet.
-
-
-[discrete]
-[[deploy-elser]]
-== Deploy ELSER
-
-After you downloaded ELSER, you can use {kib} to view and manage its deployment 
-across your cluster under **{ml-app}** > **Trained Models** or **{ents}** > 
-**Indices** (covered in the previous section).
-
-[discrete]
-[[deploy-trained-models]]
-=== Using the Trained Models page or the API
-
-1. Start the deployment by clicking the Start deployment button.
-2. Provide a deployment ID, select priority, and set the number of allocations 
-and threads per allocation values.
-+
 --
-[role="screenshot"]
-image::images/ml-nlp-deploy-elser.png[alt="Deploying ELSER",align="center"]
---
-3. Click Start.
-
-Alternatively, you can deploy the model by using the 
+3. Deploy the model by using the 
 {ref}/start-trained-model-deployment.html[start trained model deployment API] 
 with a delpoyment ID:
-
++
+--
 [source,console]
 ----------------------------------
 POST _ml/trained_models/.elser_model_1/deployment/_start?deployment_id=for_search
 ----------------------------------
 
 You can deploy the model multiple times with different deployment IDs.
+--
 
 After the deployment is complete, ELSER is ready to use either in an ingest 
 pipeline or in a `text_expansion` query to perform semantic search.

--- a/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
@@ -1,5 +1,5 @@
 [[ml-nlp-elser]]
-= ELSER – Elastic Learned Sparse Encoder
+= ELSER – Elastic Learned Sparse EncodeR
 ++++
 <titleabbrev>ELSER</titleabbrev>
 ++++

--- a/docs/en/stack/ml/nlp/ml-nlp-limitations.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-limitations.asciidoc
@@ -9,9 +9,9 @@ the Elastic {nlp} trained models feature.
 
 [discrete]
 [[ml-nlp-elser-v1-limit-512]]
-== ELSER v1 semantic search is limited to 512 tokens per document
+== ELSER v1 semantic search is limited to 512 tokens per field that inference is applied to
 
 When you use ELSER v1 for semantic search, only the first 512 extracted tokens 
-from the ingested documents are taken into account for the search process. If 
+from the each field of the ingested documents that ELSER is applied to are taken into account for the search process. If 
 your data set contains long documents, divide them into smaller segments before 
 ingestion for an optimal search performance.

--- a/docs/en/stack/ml/nlp/ml-nlp-limitations.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-limitations.asciidoc
@@ -12,6 +12,7 @@ the Elastic {nlp} trained models feature.
 == ELSER v1 semantic search is limited to 512 tokens per field that inference is applied to
 
 When you use ELSER v1 for semantic search, only the first 512 extracted tokens 
-from the each field of the ingested documents that ELSER is applied to are taken into account for the search process. If 
-your data set contains long documents, divide them into smaller segments before 
-ingestion for an optimal search performance.
+from each field of the ingested documents that ELSER is applied to are taken 
+into account for the search process. If your data set contains long documents, 
+divide them into smaller segments before ingestion for an optimal search 
+performance.

--- a/docs/en/stack/ml/nlp/ml-nlp-limitations.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-limitations.asciidoc
@@ -12,6 +12,6 @@ the Elastic {nlp} trained models feature.
 == ELSER v1 semantic search is limited to 512 tokens per document
 
 When you use ELSER v1 for semantic search, only the first 512 extracted tokens 
-of the ingested docs are considered during the search. If you have long 
-documents in your data set, split them to smaller pieces before ingest for 
-optimal search performance.
+from the ingested documents are taken into account for the search process. If 
+your data set contains long documents, divide them into smaller segments before 
+ingestion for an optimal search performance.

--- a/docs/en/stack/ml/nlp/ml-nlp-limitations.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-limitations.asciidoc
@@ -1,0 +1,17 @@
+[[ml-nlp-limitations]]
+= Limitations
+
+:keywords: {ml-init}, {stack}, {nlp}, limitations,
+:description: List of limitations of the Elastic NLP features
+
+The following limitations and known problems apply to the {version} release of 
+the Elastic {nlp} trained models feature.
+
+[discrete]
+[[ml-nlp-elser-v1-limit-512]]
+== ELSER v1 semantic search is limited to 512 tokens per document
+
+When you use ELSER v1 for semantic search, only the first 512 extracted tokens 
+of the ingested docs are considered during the search. If you have long 
+documents in your data set, split them to smaller pieces before ingest for 
+optimal search performance.

--- a/docs/en/stack/ml/nlp/ml-nlp.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp.asciidoc
@@ -14,6 +14,7 @@ predictions.
 * <<ml-nlp-deploy-models>>
 * <<ml-nlp-inference>>
 * <<ml-nlp-apis>>
+* <<ml-nlp-elser>>
 * <<ml-nlp-examples>>
 
 --

--- a/docs/en/stack/ml/nlp/ml-nlp.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp.asciidoc
@@ -16,5 +16,6 @@ predictions.
 * <<ml-nlp-apis>>
 * <<ml-nlp-elser>>
 * <<ml-nlp-examples>>
+* <<ml-nlp-limitations>>
 
 --


### PR DESCRIPTION
## Overview

This PR:
* creates a limitation section under the NLP chapter,
* adds a limitation item about ELSER v1 and maximum token number,
* adds a link to the ELSER page to the NLP landing page.

### Preview

[NLP limitations](https://stack-docs_2396.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-nlp-limitations.html)