### PR TITLE
Link from NLP ELSER doc to Ent Search ELSER deployment section

### DIFF
--- a/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
@@ -65,7 +65,7 @@ image::images/ml-nlp-deploy-elser.png[alt="Deploying ELSER",align="center"]
 [[enterprise-search]]
 === Using the Indices page in {ents}
 
-You can also download and deploy ELSER to an {infer} pipeline directly from the 
+You can also {enterprise-search-ref}/elser-text-expansion.html#deploy-elser[download and deploy ELSER to an {infer} pipeline] directly from the 
 {ents} app.
 
 1. In {kib}, navigate to **{ents}** > **Indices**.


### PR DESCRIPTION
Adding link from NLP ELSER deployment page to Enterprise Search ELSER deployment instructions.