### PR TITLE
[DOCS] Add frontmatter for migration

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/ml-ad-explain.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-ad-explain.asciidoc
@@ -1,9 +1,10 @@
 [[ml-ad-explain]]
 = Anomaly score explanation
-:keywords: {ml-init}, {stack}, {anomaly-detect}, anomaly score, typical value, \
-actual value
-:description: An explanation of how the anomaly score is calculated for \
-{ml} {anomaly-detect}.
+
+:frontmatter-description: An explanation of how the anomaly score is calculated for {ml} {anomaly-detect}.
+:frontmatter-tags-products: [ml] 
+:frontmatter-tags-content-type: [overview] 
+:frontmatter-tags-user-goals: [analyze]
 
 Every anomaly has an anomaly score assigned to it. That score indicates how 
 anomalous the data point is, which makes it possible to define its severity 

--- a/docs/en/stack/ml/anomaly-detection/ml-ad-finding-anomalies.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-ad-finding-anomalies.asciidoc
@@ -4,9 +4,10 @@
 <titleabbrev>Finding anomalies</titleabbrev>
 ++++
 
-:keywords: {ml-init}, {stack}, {anomaly-detect}
-:description: An introduction to {ml} {anomaly-detect}, which analyzes time \
-series data to identify and predict anomalous patterns in your data.
+:frontmatter-description: An introduction to {ml} {anomaly-detect}, which analyzes time series data to identify and predict anomalous patterns in your data.
+:frontmatter-tags-products: [ml] 
+:frontmatter-tags-content-type: [overview] 
+:frontmatter-tags-user-goals: [analyze]
 
 The {ml} {anomaly-detect} features automate the analysis of time series data by
 creating accurate baselines of normal behavior in your data. These baselines

--- a/docs/en/stack/ml/anomaly-detection/ml-ad-job-types.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-ad-job-types.asciidoc
@@ -4,9 +4,10 @@
 <titleabbrev>Job types</titleabbrev>
 ++++
 
-:keywords: {ml-init}, {stack}, {anomaly-detect}
-
-:description: The description of the different anomaly detection job types. 
+:frontmatter-description: A description of the different anomaly detection job types.
+:frontmatter-tags-products: [ml] 
+:frontmatter-tags-content-type: [overview] 
+:frontmatter-tags-user-goals: [analyze]
 
 {anomaly-jobs-cap} have many possible configuration options which enable you to 
 fine-tune the jobs and cover your use case as much as possible. This page 

--- a/docs/en/stack/ml/df-analytics/ml-dfa-classification.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-classification.asciidoc
@@ -1,9 +1,10 @@
 [[ml-dfa-classification]]
 = Predicting classes with {classification}
 
-:keywords: {ml-init}, {stack}, {dfanalytics}, {classification}
-:description: An introduction to {ml} {classification}, which enables you to \
-predict classes of data points in a data set.
+:frontmatter-description: An introduction to {ml} {classification}, which enables you to predict classes of data points in a data set.
+:frontmatter-tags-products: [ml] 
+:frontmatter-tags-content-type: [how-to] 
+:frontmatter-tags-user-goals: [analyze]
 
 {classification-cap} is a {ml} process that predicts the class or category of a 
 data point in a data set. For a simple example, consider how the shapes in the 

--- a/docs/en/stack/ml/df-analytics/ml-dfa-outlier-detection.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-outlier-detection.asciidoc
@@ -1,9 +1,10 @@
 [[ml-dfa-finding-outliers]]
 = Finding outliers
 
-:keywords: {ml-init}, {stack}, {dfanalytics}, {oldetection}
-:description: An introduction to {ml} {oldetection}, which enables you to  \
-find unusual data points in a data set compared to the normal data points.
+:frontmatter-description: An introduction to {ml} {oldetection}, which enables you to find unusual data points in a data set compared to the normal data points.
+:frontmatter-tags-products: [ml] 
+:frontmatter-tags-content-type: [how-to] 
+:frontmatter-tags-user-goals: [analyze]
 
 {oldetection-cap} is identification of data points that are significantly 
 different from other values in the data set. For example, outliers could be 

--- a/docs/en/stack/ml/df-analytics/ml-dfa-overview.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-overview.asciidoc
@@ -5,10 +5,11 @@
 ++++
 <titleabbrev>Overview</titleabbrev>
 ++++
-:keywords: {ml-init}, {stack}, {dfanalytics}, overview
-:description: An introduction to {ml} {dfanalytics}, which enables you to  \
-analyze your data using classification, regression, and outlier detection \
-algorithms and to generate trained models for predictions on new data.
+
+:frontmatter-description: An introduction to {ml} {dfanalytics}, which enables you to analyze your data using classification, regression, and outlier detection algorithms and to generate trained models for predictions on new data.
+:frontmatter-tags-products: [ml] 
+:frontmatter-tags-content-type: [overview] 
+:frontmatter-tags-user-goals: [analyze]
 
 {dfanalytics-cap} enable you to perform different analyses of your data and 
 annotate it with the results. By doing this, it provides additional insights 

--- a/docs/en/stack/ml/df-analytics/ml-dfa-regression.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-regression.asciidoc
@@ -1,10 +1,10 @@
 [[ml-dfa-regression]]
 = Predicting numerical values with {regression}
 
-:keywords: {ml-init}, {stack}, {dfanalytics}, {regression}
-:description: An introduction to {ml} {regression}, which enables you to  \
-predict numerical values in a data set.
-
+:frontmatter-description: An introduction to {ml} {regression}, which enables you to predict numerical values in a data set.
+:frontmatter-tags-products: [ml] 
+:frontmatter-tags-content-type: [how-to] 
+:frontmatter-tags-user-goals: [analyze]
 
 {reganalysis-cap} is a supervised {ml} process for estimating the relationships 
 among different fields in your data, then making further predictions on 

--- a/docs/en/stack/ml/df-analytics/ml-how-dfa-works.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-how-dfa-works.asciidoc
@@ -5,10 +5,11 @@
 ++++
 <titleabbrev>How {dfanalytics-jobs} work</titleabbrev>
 ++++
-:keywords: {ml-init}, {stack}, {dfanalytics}, advanced,
-:description: An explanation of how the {dfanalytics-jobs} work. Every job has \
- four or five main phases depending on its analysis type.
 
+:frontmatter-description: An explanation of how the {dfanalytics-jobs} work. Every job has four or five main phases depending on its analysis type.
+:frontmatter-tags-products: [ml] 
+:frontmatter-tags-content-type: [overview] 
+:frontmatter-tags-user-goals: [analyze]
 
 A {dfanalytics-job} is essentially a persistent {es} task. During its life 
 cycle, it goes through four or five main phases depending on the analysis type:

--- a/docs/en/stack/ml/get-started/ml-getting-started.asciidoc
+++ b/docs/en/stack/ml/get-started/ml-getting-started.asciidoc
@@ -3,9 +3,11 @@
 ++++
 <titleabbrev>Tutorial: Getting started with {anomaly-detect}</titleabbrev>
 ++++
-:keywords: {ml-init}, {stack}, {anomaly-detect}, tutorial
-:description: This tutorial shows you how to create {anomaly-jobs}, \
-interpret the results, and forecast future behavior in {kib}. 
+
+:frontmatter-description: This tutorial shows you how to create {anomaly-jobs}, interpret the results, and forecast future behavior in {kib}.
+:frontmatter-tags-products: [ml] 
+:frontmatter-tags-content-type: [tutorial] 
+:frontmatter-tags-user-goals: [get-started]
 
 Ready to take {anomaly-detect} for a test drive? Follow this tutorial to:
 

--- a/docs/en/stack/ml/machine-learning-intro.asciidoc
+++ b/docs/en/stack/ml/machine-learning-intro.asciidoc
@@ -1,8 +1,11 @@
 [chapter,role="xpack"]
 [[machine-learning-intro]]
 = What is Elastic {ml-app}?
-:keywords: {ml-init}, {stack}
-:description: An introduction to the breadth of Elastic {ml-features}.
+
+:frontmatter-description: An introduction to the breadth of Elastic {ml-features}
+:frontmatter-tags-products: [ml] 
+:frontmatter-tags-content-type: [overview] 
+:frontmatter-tags-user-goals: [analyze]
 
 {ml-cap} features analyze your data and generate models for its patterns of
 behavior. The type of analysis that you choose depends on the questions or

--- a/docs/en/stack/ml/nlp/ml-nlp-classify-text.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-classify-text.asciidoc
@@ -1,11 +1,10 @@
 [[ml-nlp-classify-text]]
 = Classify text
 
-:keywords: {ml-init}, {stack}, {nlp}, {lang-ident}, text classification, \
-zero-shot text classification
-
-:description: NLP tasks that classify input text or determine \
-the language of text. 
+:frontmatter-description: NLP tasks that classify input text or determine the language of text. 
+:frontmatter-tags-products: [ml] 
+:frontmatter-tags-content-type: [overview] 
+:frontmatter-tags-user-goals: [analyze]
 
 These NLP tasks enable you to identify the language of text and classify or 
 label unstructured input text:

--- a/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
@@ -1,10 +1,10 @@
 [[ml-nlp-deploy-models]]
 = Deploy trained models
 
-:keywords: {ml-init}, {stack}, {nlp}
-:description: You can import trained models into your cluster and configure them \
-for specific NLP tasks.
-
+:frontmatter-description: You can import trained models into your cluster and configure them for specific NLP tasks.
+:frontmatter-tags-products: [ml] 
+:frontmatter-tags-content-type: [how-to] 
+:frontmatter-tags-user-goals: [analyze]
 
 If you want to perform {nlp} tasks in your cluster, you must deploy an
 appropriate trained model. There is tooling support in

--- a/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
@@ -4,8 +4,10 @@
 <titleabbrev>ELSER</titleabbrev>
 ++++
 
-:keywords: {ml-init}, {stack}, {nlp}, ELSER
-:description: ELSER is a learned sparse ranking model trained by Elastic.
+:frontmatter-description: ELSER is a learned sparse ranking model trained by Elastic.
+:frontmatter-tags-products: [ml] 
+:frontmatter-tags-content-type: [how-to] 
+:frontmatter-tags-user-goals: [analyze]
 
 experimental[]
 

--- a/docs/en/stack/ml/nlp/ml-nlp-extract-info.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-extract-info.asciidoc
@@ -1,8 +1,10 @@
 [[ml-nlp-extract-info]]
 = Extract information
 
-:keywords: {ml-init}, {stack}, {nlp}, named entity recognition, fill mask, question answering
-:description: NLP tasks that extract information from unstructured text. 
+:frontmatter-description:  NLP tasks that extract information from unstructured text.
+:frontmatter-tags-products: [ml] 
+:frontmatter-tags-content-type: [overview] 
+:frontmatter-tags-user-goals: [analyze]
 
 These NLP tasks enable you to extract information from your unstructured text:
 

--- a/docs/en/stack/ml/nlp/ml-nlp-limitations.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-limitations.asciidoc
@@ -1,8 +1,10 @@
 [[ml-nlp-limitations]]
 = Limitations
 
-:keywords: {ml-init}, {stack}, {nlp}, limitations,
-:description: List of limitations of the Elastic NLP features
+:frontmatter-description: List of limitations of the Elastic NLP features.
+:frontmatter-tags-products: [ml] 
+:frontmatter-tags-content-type: [troubleshooting] 
+:frontmatter-tags-user-goals: [analyze]
 
 The following limitations and known problems apply to the {version} release of 
 the Elastic {nlp} trained models feature.

--- a/docs/en/stack/ml/nlp/ml-nlp-model-ref.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-model-ref.asciidoc
@@ -3,8 +3,11 @@
 ++++
 <titleabbrev>Compatible third party models</titleabbrev>
 ++++
-:keywords: {ml-init}, {stack}, {nlp}
-:description: The list of compatible third party NLP models.
+
+:frontmatter-description: The list of compatible third party NLP models.
+:frontmatter-tags-products: [ml] 
+:frontmatter-tags-content-type: [reference] 
+:frontmatter-tags-user-goals: [analyze]
 
 The {stack-ml-features} support transformer models that conform to the standard
 BERT model interface and use the WordPiece tokenization algorithm.

--- a/docs/en/stack/ml/nlp/ml-nlp.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp.asciidoc
@@ -1,8 +1,10 @@
 [[ml-nlp]]
 = {nlp-cap}
 
-:keywords: {ml-init}, {stack}, {nlp}, overview
-:description: An introduction to {ml} {nlp} features.
+:frontmatter-description: An introduction to {ml} {nlp} features.
+:frontmatter-tags-products: [ml] 
+:frontmatter-tags-content-type: [overview] 
+:frontmatter-tags-user-goals: [analyze]
 
 [partintro]	
 --


### PR DESCRIPTION
This PR updates source files that contain `:description:` attributes to use `:frontmatter-description:` instead. It also adds the other frontmatter necessary for migration to the new docs system.