### PR TITLE
[DOCS] Adds link to technical blog to ELSER docs

### DIFF
--- a/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
@@ -18,7 +18,9 @@ meaning and user intent, rather than exact keyword matches.
 ELSER is an out-of-domain model that does not require fine-tuning, making it 
 adaptable for various use cases out of the box.
 
-// TO DO: Refer to this blog post, to learn more about ELSER.
+Refer to 
+https://www.elastic.co/blog/may-2023-launch-information-retrieval-elasticsearch-ai-model[this blog post], 
+to learn more about ELSER.
 
 
 [discrete]
@@ -228,4 +230,4 @@ master-eligible nodes one by one.
 == Further reading
 
 * {ref}/semantic-search-elser.html[Perform semantic search with ELSER]
-// TO DO * [Blog post about ELSER]
+* https://www.elastic.co/blog/may-2023-launch-information-retrieval-elasticsearch-ai-model[Improving information retrieval in the Elastic Stack: Introducing Elastic Learned Sparse Encoder, our new retrieval model]


### PR DESCRIPTION
## Overview

This PR updates the ELSER docs with a link that points to the technical blog about the model.