### PR TITLE
[DOCS] Adjusts intro docs for ELSER

### DIFF
--- a/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
@@ -11,14 +11,14 @@
 
 experimental[]
 
-Elastic Learned Sparse EncodeR - or ELSER - is a representational model trained 
-by Elastic that enables you to perform 
-{ref}/semantic-search-elser.html[semantic search] to improve search relevance. 
-With this search type you can retrieve search results based on contextual 
+Elastic Learned Sparse EncodeR - or ELSER - is a retrieval model trained by 
+Elastic that enables you to perform 
+{ref}/semantic-search-elser.html[semantic search] to retrieve more relevant 
+search results. This search type provides you search results based on contextual 
 meaning and user intent, rather than exact keyword matches.
 
-ELSER is an out-of-domain model that does not require fine-tuning, making it 
-adaptable for various use cases out of the box.
+ELSER is an out-of-domain model which means it does not require fine-tuning on 
+your own data, making it adaptable for various use cases out of the box.
 
 Refer to 
 https://www.elastic.co/blog/may-2023-launch-information-retrieval-elasticsearch-ai-model[this blog post], 


### PR DESCRIPTION
## Overview

This PR adjusts slightly the introductory paragraph of the ELSER docs to be more in line with the [blog post](https://www.elastic.co/blog/may-2023-launch-information-retrieval-elasticsearch-ai-model) and to make the first statement stronger.