### PR TITLE
[DOCS] Adds Docker install option to model deployment

### DIFF
--- a/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
@@ -96,7 +96,7 @@ For more details, refer to https://github.com/elastic/eland#nlp-with-pytorch.
 IMPORTANT: To use the Docker container, you need to clone the Eland repository: 
 https://github.com/elastic/eland
 
-If you want to use Eland without installing it, clone the Eland repository and from the root directory run the following to build the Docker container:
+If you want to use Eland without installing it, clone the Eland repository and from the root directory run the following to build the Docker image:
 
 ```bash
 $ docker build -t elastic/eland .

--- a/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
@@ -50,7 +50,7 @@ NOTE: Trained models must be in a TorchScript representation for use with
 Eland encapsulates both the conversion of Hugging Face transformer models to
 their TorchScript representations and the chunking process in a single Python
 method; it is therefore the recommended import method. You can either install 
-the Python Eland client on your machine or use a Docker image to built Eland.
+the Python Eland client on your machine or use a Docker image to build Eland.
 
 [discrete]
 [[ml-nlp-import-script]]
@@ -96,8 +96,7 @@ For more details, refer to https://github.com/elastic/eland#nlp-with-pytorch.
 IMPORTANT: To use the Docker container, you need to clone the Eland repository: 
 https://github.com/elastic/eland
 
-If you want to use Eland without installing it, build the Docker container to 
-run the available scripts:
+If you want to use Eland without installing it, clone the Eland repository and from the root directory run the following to build the Docker container:
 
 ```bash
 $ docker build -t elastic/eland .
@@ -109,7 +108,7 @@ You can now use the container interactively:
 $ docker run -it --rm --network host elastic/eland
 ```
 
-Running installed scripts is also possible without an interactive shell:
+The `eland_import_hub_model` script can be run directly in the docker command:
 
 ```bash
 docker run -it --rm elastic/eland \

--- a/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
@@ -118,9 +118,8 @@ docker run -it --rm elastic/eland \
       --start
 ```
 
-Replace the `$ELASTICSEARCH_URL` with the URL for your {es} cluster. For 
-authentication purposes, include an administrator username and password in the 
-URL in the following format: `https://username:password@host:port`.
+Replace the `$ELASTICSEARCH_URL` with the URL for your {es} cluster. Refer to 
+<<ml-nlp-authentication>> to learn more.
 
 
 [[ml-nlp-authentication]]

--- a/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
@@ -130,7 +130,7 @@ The following authentication options are available when using the import script:
 * username/password authentication (specified with the `-u` and `-p` options):
 +
 --  
-[source, shell]
+[source, bash]
 --------------------------------------------------
 eland_import_hub_model --url https://<hostname>:<port> -u <username> -p <password> ...
 --------------------------------------------------
@@ -139,7 +139,7 @@ eland_import_hub_model --url https://<hostname>:<port> -u <username> -p <passwor
 * username/password authentication (embedded in the URL):
 +
 --
-[source, shell]
+[source, bash]
 --------------------------------------------------
 eland_import_hub_model --url https://<user>:<password>@<hostname>:<port> ...
 --------------------------------------------------
@@ -147,7 +147,7 @@ eland_import_hub_model --url https://<user>:<password>@<hostname>:<port> ...
 * API key authentication:
 +
 --
-[source, shell]
+[source, bash]
 --------------------------------------------------
 eland_import_hub_model --url https://<hostname>:<port> --es-api-key <api-key> ...
 --------------------------------------------------

--- a/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
@@ -40,6 +40,10 @@ model. You can skip to using the model in
 [[ml-nlp-import-model]]
 == Import the trained model and vocabulary
 
+IMPORTANT: If you want to install a trained model in a restricted or closed 
+network, refer to 
+https://www.elastic.co/guide/en/elasticsearch/client/eland/current/machine-learning.html#ml-nlp-pytorch-air-gapped[these instructions].
+
 After you choose a model, you must import it and its tokenizer vocabulary to
 your cluster. When you import the model, it must be chunked and imported one
 chunk at a time for storage in parts due to its size.
@@ -47,10 +51,13 @@ chunk at a time for storage in parts due to its size.
 NOTE: Trained models must be in a TorchScript representation for use with
 {stack-ml-features}.
 
-Eland encapsulates both the conversion of Hugging Face transformer models to
-their TorchScript representations and the chunking process in a single Python
-method; it is therefore the recommended import method. You can either install 
-the Python Eland client on your machine or use a Docker image to build Eland.
+https://github.com/elastic/eland[Eland] is an {es} Python client that provides a 
+simple script to perform the conversion of Hugging Face transformer models to 
+their TorchScript representations, the chunking process, and upload to {es}; it 
+is therefore the recommended import method. You can either install the Python 
+Eland client on your machine or use a Docker image to build Eland and run the 
+model import script.
+
 
 [discrete]
 [[ml-nlp-import-script]]
@@ -67,7 +74,9 @@ python -m pip install 'eland[pytorch]'
 // NOTCONSOLE
 --
 
-. Run the `eland_import_hub_model` script. For example:
+. Run the `eland_import_hub_model` script to download the model from Hugging 
+Face, convert it to TorchScript format, and upload to the {es} cluster. For 
+example:
 +
 --
 [source, shell]
@@ -87,7 +96,8 @@ eland_import_hub_model
 <4> Specify the type of NLP task. Supported values are `fill_mask`, `ner`,
 `text_classification`, `text_embedding`, and `zero_shot_classification`.
 
-For more details, refer to https://github.com/elastic/eland#nlp-with-pytorch.
+For more details, refer to 
+https://www.elastic.co/guide/en/elasticsearch/client/eland/current/machine-learning.html#ml-nlp-pytorch.
 
 [discrete]
 [[ml-nlp-import-docker]]
@@ -96,7 +106,8 @@ For more details, refer to https://github.com/elastic/eland#nlp-with-pytorch.
 IMPORTANT: To use the Docker container, you need to clone the Eland repository: 
 https://github.com/elastic/eland
 
-If you want to use Eland without installing it, clone the Eland repository and from the root directory run the following to build the Docker image:
+If you want to use Eland without installing it, clone the Eland repository and 
+from the root directory run the following to build the Docker image:
 
 ```bash
 $ docker build -t elastic/eland .

--- a/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
@@ -49,7 +49,12 @@ NOTE: Trained models must be in a TorchScript representation for use with
 
 Eland encapsulates both the conversion of Hugging Face transformer models to
 their TorchScript representations and the chunking process in a single Python
-method; it is therefore the recommended import method.
+method; it is therefore the recommended import method. You can either install 
+the Python Eland client on your machine or use a Docker image to built Eland.
+
+[discrete]
+[[ml-nlp-import-script]]
+=== Import with the Eland client installed
 
 . Install the {eland-docs}/installation.html[Eland Python client] with PyTorch 
 extra dependencies.
@@ -83,6 +88,40 @@ eland_import_hub_model
 `text_classification`, `text_embedding`, and `zero_shot_classification`.
 
 For more details, refer to https://github.com/elastic/eland#nlp-with-pytorch.
+
+[discrete]
+[[ml-nlp-import-docker]]
+=== Import with Docker
+
+IMPORTANT: To use the Docker container, you need to clone the Eland repository: 
+https://github.com/elastic/eland
+
+If you want to use Eland without installing it, build the Docker container to 
+run the available scripts:
+
+```bash
+$ docker build -t elastic/eland .
+```
+
+You can now use the container interactively:
+
+```bash
+$ docker run -it --rm --network host elastic/eland
+```
+
+Running installed scripts is also possible without an interactive shell:
+
+```bash
+docker run -it --rm elastic/eland \
+    eland_import_hub_model \
+      --url $ELASTICSEARCH_URL \
+      --hub-model-id elastic/distilbert-base-uncased-finetuned-conll03-english \
+      --start
+```
+
+Replace the `$ELASTICSEARCH_URL` with the URL for your {es} cluster. For 
+authentication purposes, include an administrator username and password in the 
+URL in the following format: `https://username:password@host:port`.
 
 
 [[ml-nlp-authentication]]


### PR DESCRIPTION
## Overview

This PR adds the instructions for installing models by using Docker to the model deployment page.

### Preview

[Deploy NLP model](https://stack-docs_2418.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-nlp-import-model.html)