### PR TITLE
[DOCS] Adds hardware benchmarks to ELSER docs

### DIFF
--- a/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
@@ -51,7 +51,7 @@ over 512 tokens, which provides insights into the performance implications
 of indexing and {infer} time for long documents. This is a subset of the 
 `msmarco-long` data set, which is part of 
 https://github.com/beir-cellar/beir[BEIR], and a widely used information 
-retrieval data set to evaulate retrieval techniques on long documents.
+retrieval data set to evaluate retrieval techniques on long documents.
 
 The `arguana` data set is also a BEIR data set. It consists of long queries with 
 an average of 200 tokens per query. It can represent an upper limit for query 

--- a/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
@@ -26,6 +26,45 @@ to learn more about ELSER.
 
 
 [discrete]
+[[elser-hw-benchamrks]]
+== Hardware benchmarks
+
+Two data sets were utilized to evaluate the performance of ELSER in different 
+hardware configurations: `msmarco-long-light` and `arguana`.
+
+|==============================================================================================================
+| **Data set**             ^| **Data set size**   ^| **Average count of tokens / query** ^| **Average count of tokens / document**
+| `msmarco-long-light`     ^| 37367 documents     ^| 9                                   ^| 1640                              
+| `arguana`                ^| 8674 documents      ^| 238                                 ^| 202                               
+|==============================================================================================================
+
+The `msmarco-long-light` data set contains long documents with an average of 
+over 512 tokens, which provides insights into the performance implications 
+of indexing and {infer} time for long documents. This is a subset of the 
+`msmarco-long` data set, which is part of 
+https://github.com/beir-cellar/beir[BEIR], and a widely used information 
+retrieval data set to evaulate retrieval techniques on long documents.
+
+The `arguana` data set is also a BEIR data set. It consists of long queries with 
+an average of 200 tokens per query. It can represent an upper limit for query 
+slowness.
+
+The table below present benchmarking results for ELSER using various hardware 
+configurations.
+
+|==================================================================================================================================================================================
+|                                                         3+^| `msmarco-long-light`                                     3+^| `arguana`                                             | 
+|                                                         ^.^| inference     ^.^| indexing         ^.^| query latency   ^.^| inference      ^.^| indexing      ^.^| query latency  |  
+| **ML node 4GB - 2 vCPUs (1 allocation * 1 thread)**     ^.^| 581   ms/call ^.^| 1.7   doc/sec    ^.^| 713   ms/query  ^.^| 1200   ms/call ^.^| 0.8   doc/sec ^.^| 169   ms/query |  
+| **ML node 16GB - 8 vCPUs (7 allocation * 1 thread)**    ^.^| 568   ms/call ^.^| 12    doc/sec    ^.^| 689   ms/query  ^.^| 1280   ms/call ^.^| 5.4   doc/sec ^.^| 159   ms/query |  
+| **ML node 16GB - 8 vCPUs (1 allocation * 8 thread)**    ^.^| 102   ms/call ^.^| 9.7   doc/sec    ^.^| 164   ms/query  ^.^| 220    ms/call ^.^| 4.5   doc/sec ^.^| 40    ms/query | 
+| **ML node 32 GB - 16 vCPUs (15 allocation * 1 thread)** ^.^| 565   ms/call ^.^| 25.2  doc/sec    ^.^| 608   ms/query  ^.^| 1260   ms/call ^.^| 11.4  doc/sec ^.^| 138   ms/query | 
+|==================================================================================================================================================================================
+
+
+
+
+[discrete]
 [[elser-req]]
 == Requirements
 

--- a/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
@@ -26,6 +26,14 @@ to learn more about ELSER.
 
 
 [discrete]
+[[elser-req]]
+== Requirements
+
+To use ELSER, you must have the {subscriptions}[appropriate subscription] level 
+for semantic search or the trial period activated.
+
+
+[discrete]
 [[elser-hw-benchamrks]]
 == Hardware benchmarks
 
@@ -60,16 +68,6 @@ configurations.
 | **ML node 16GB - 8 vCPUs (1 allocation * 8 thread)**    ^.^| 102   ms/call ^.^| 9.7   doc/sec    ^.^| 164   ms/query  ^.^| 220    ms/call ^.^| 4.5   doc/sec ^.^| 40    ms/query | 
 | **ML node 32 GB - 16 vCPUs (15 allocation * 1 thread)** ^.^| 565   ms/call ^.^| 25.2  doc/sec    ^.^| 608   ms/query  ^.^| 1260   ms/call ^.^| 11.4  doc/sec ^.^| 138   ms/query | 
 |==================================================================================================================================================================================
-
-
-
-
-[discrete]
-[[elser-req]]
-== Requirements
-
-To use ELSER, you must have the {subscriptions}[appropriate subscription] level 
-for semantic search or the trial period activated.
 
 
 [discrete]

--- a/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
@@ -49,13 +49,13 @@ hardware configurations: `msmarco-long-light` and `arguana`.
 The `msmarco-long-light` data set contains long documents with an average of 
 over 512 tokens, which provides insights into the performance implications 
 of indexing and {infer} time for long documents. This is a subset of the 
-`msmarco-long` data set, which is part of 
-https://github.com/beir-cellar/beir[BEIR], and a widely used information 
-retrieval data set to evaluate retrieval techniques on long documents.
+"msmarco" dataset specifically designed for document retrieval (it shouldn't be 
+confused with the "msmarco" dataset used for passage retrieval, which primarily 
+consists of shorter spans of text). 
 
-The `arguana` data set is also a BEIR data set. It consists of long queries with 
-an average of 200 tokens per query. It can represent an upper limit for query 
-slowness.
+The `arguana` data set is a https://github.com/beir-cellar/beir[BEIR] data set. 
+It consists of long queries with an average of 200 tokens per query. It can 
+represent an upper limit for query slowness.
 
 The table below present benchmarking results for ELSER using various hardware 
 configurations.


### PR DESCRIPTION
## Overview

This PR adds the following pieces of content to the ELSER conceptual docs:
* Hardware benchmarks section,
* information on the used data sets,
* table of the data sets,
* table of the benchmarking results.

### Preview

[Hardware benchmarks](https://stack-docs_2421.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-nlp-elser.html#elser-hw-benchamrks)