### PR TITLE
[DOCS] Amends ML landing page to include ELSER

### DIFF
--- a/docs/en/stack/ml/index-custom-title-page.html
+++ b/docs/en/stack/ml/index-custom-title-page.html
@@ -149,6 +149,9 @@
         <a href="ml-nlp-inference.html">Use NLP inference</a>
       </li>
       <li>
+        <a href="ml-nlp-elser.html">Elastic Learned Sparse EncodeR</a>
+      </li>
+      <li>
         <a href="ml-nlp-model-ref.html">Supported third-party models</a>
       </li>
       <li>

--- a/docs/en/stack/ml/index-custom-title-page.html
+++ b/docs/en/stack/ml/index-custom-title-page.html
@@ -149,7 +149,7 @@
         <a href="ml-nlp-inference.html">Use NLP inference</a>
       </li>
       <li>
-        <a href="ml-nlp-elser.html">Elastic Learned Sparse EncodeR</a>
+        <a href="ml-nlp-elser.html">ELSER - Elastic Learned Sparse EncodeR</a>
       </li>
       <li>
         <a href="ml-nlp-model-ref.html">Supported third-party models</a>


### PR DESCRIPTION
## Overview

This PR adds a new item under the NLP section of the ML landing page that leads to the ELSER conceptual documentation.

### Preview

[ML landing page](https://stack-docs_2423.docs-preview.app.elstc.co/guide/en/machine-learning/master/index.html)