### PR TITLE
[DOCS] Makes section title more descriptive on NLP model deployment page

### DIFF
--- a/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
@@ -220,7 +220,7 @@ the allocation status is `started`.
 
 [discrete]
 [[infer-request-queues]]
-=== {infer-cap} request queues
+=== Request queues and search priority
 
 Each allocation of a model deployment has a dedicated queue to buffer {infer} 
 requests. The size of this queue is determined by the `queue_capacity` parameter


### PR DESCRIPTION
## Overview

This PR changes the section title `Inference request queues` to `Request queues and search priority`.

### Preview

[Request queue and search priority](https://stack-docs_2425.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-nlp-deploy-model.html#infer-request-queues)