### PR TITLE
[DOCS] Update security breaking changes link from 8.8.0 to 8.8.1

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -67,7 +67,7 @@ the complete list, go to {ref}/breaking-changes.html[{es} breaking changes].
 ++++
 
 This list summarizes the most important breaking changes in {elastic-sec} {version}. For
-the complete list, go to {security-guide-all}/8.8/release-notes-header-8.8.0.html#breaking-changes-8.8.0[{elastic-sec} breaking changes].
+the complete list, go to {security-guide-all}/8.8/release-notes-header-8.8.1.html#breaking-changes-8.8.1[{elastic-sec} breaking changes].
 
 include::{security-repo-dir}/release-notes/8.8.asciidoc[tag=breaking-changes] 
 

--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -67,7 +67,7 @@ the complete list, go to {ref}/breaking-changes.html[{es} breaking changes].
 ++++
 
 This list summarizes the most important breaking changes in {elastic-sec} {version}. For
-the complete list, go to {security-guide-all}/8.8/release-notes-header-8.8.1.html#breaking-changes-8.8.1[{elastic-sec} breaking changes].
+the complete list, go to {security-guide-all}/8.8/release-notes-header-8.8.0.html#breaking-changes-8.8.1[{elastic-sec} breaking changes].
 
 include::{security-repo-dir}/release-notes/8.8.asciidoc[tag=breaking-changes] 
 


### PR DESCRIPTION
Fixes https://github.com/elastic/stack-docs/issues/2427.

### Notes
* The breaking changes page in the Install & Upgrade Guide is built using [includes of tagged regions](https://docs.asciidoctor.org/asciidoc/latest/directives/include-tagged-regions/), refer for example to https://github.com/elastic/security-docs/pull/2519.
* This PR's doc build will fail until the `8.8.1` release notes page is available on the public docsite. This means that, in order for this PR to successfully build, both of the following requirements need to be met:
  - The `8.8.1` Security release notes PR merged into main and backported to the `8.8` branch.
  - The `8.8.1` Security release notes page will need to be built/published on the `8.8` branch and available on the [public docsite](https://www.elastic.co/guide/en/security/current/index.html). 