### PR TITLE
[DOCS] Adds more conceptual info to ELSER

### DIFF
--- a/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
@@ -20,9 +20,9 @@ meaning and user intent, rather than exact keyword matches.
 ELSER is an out-of-domain model which means it does not require fine-tuning on 
 your own data, making it adaptable for various use cases out of the box.
 
-ELSER expands the indexed and searched terms into larger collections of terms 
-that are learned to co-occur frequently within a diverse set of training data. 
-The terms that the text is expanded into by the model _are not_ synonyms for the 
+ELSER expands the indexed and searched passages into collections of terms that 
+are learned to co-occur frequently within a diverse set of training data. The 
+terms that the text is expanded into by the model _are not_ synonyms for the 
 search terms; they are learned associations. These expanded terms are weighted 
 as some of them are more significant than others. Then the {es} 
 {ref}/rank-feature.html[rank-feature field type] is used to store the terms and 

--- a/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
@@ -20,6 +20,14 @@ meaning and user intent, rather than exact keyword matches.
 ELSER is an out-of-domain model which means it does not require fine-tuning on 
 your own data, making it adaptable for various use cases out of the box.
 
+ELSER expands the indexed and searched terms into larger collections of terms 
+that are learned to co-occur frequently within a diverse set of training data. 
+The terms that the text is expanded into by the model _are not_ synonyms for the 
+search terms; they are learned associations. These expanded terms are weighted 
+as some of them are more significant than others. Then the {es} 
+{ref}/rank-feature.html[rank-feature field type] is used to store the terms and 
+weights at index time, and to search against later. 
+
 Refer to 
 https://www.elastic.co/blog/may-2023-launch-information-retrieval-elasticsearch-ai-model[this blog post], 
 to learn more about ELSER.

--- a/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
@@ -28,10 +28,6 @@ as some of them are more significant than others. Then the {es}
 {ref}/rank-feature.html[rank-feature field type] is used to store the terms and 
 weights at index time, and to search against later. 
 
-Refer to 
-https://www.elastic.co/blog/may-2023-launch-information-retrieval-elasticsearch-ai-model[this blog post], 
-to learn more about ELSER.
-
 
 [discrete]
 [[elser-req]]


### PR DESCRIPTION
## Overview

This PR adds more conceptual information to the ELSER introduction about how the model works.

### Preview

[ELSER](https://stack-docs_2433.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-nlp-elser.html)