### PR TITLE
Adds size parameter to the reindex commands in the NLP examples

### DIFF
--- a/docs/en/stack/ml/nlp/ml-nlp-inference.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-inference.asciidoc
@@ -232,7 +232,7 @@ POST _reindex
 {
   "source": {
     "index": "kibana_sample_data_logs",
-    "size": 500
+    "size": 50
   },
   "dest": {
     "index": "lang-test",
@@ -245,9 +245,9 @@ POST _reindex
 However, those web log messages are unlikely to contain enough words for the
 model to accurately identify the language.
 
-TIP: Set the reindex `size` option to a value
-smaller than the `queue_capacity` for the trained model deployment. Otherwise, requests might be rejected
-with a "too many requests" 429 error code.
+TIP: Set the reindex `size` option to a value smaller than the `queue_capacity` 
+for the trained model deployment. Otherwise, requests might be rejected with a 
+"too many requests" 429 error code.
 
 [discrete]
 [[ml-nlp-inference-discover]]

--- a/docs/en/stack/ml/nlp/ml-nlp-ner-example.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-ner-example.asciidoc
@@ -216,7 +216,8 @@ you created:
 POST _reindex
 {
   "source": {
-    "index": "les-miserables"
+    "index": "les-miserables",
+    "size": 50 <1>
   },
   "dest": {
     "index": "les-miserables-infer",
@@ -224,6 +225,9 @@ POST _reindex
   }
 }
 --------------------------------------------------
+<1> The default batch size for reindexing is 1000. Reducing `size` to a smaller 
+number makes the update of the reindexing process quicker which enables you to 
+follow the progress closely and detect errors early.
 
 Take a random paragraph from the source document as an example:
 

--- a/docs/en/stack/ml/nlp/ml-nlp-text-emb-vector-search-example.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-text-emb-vector-search-example.asciidoc
@@ -227,7 +227,8 @@ ingest processor inserts the embedding vector into each document.
 POST _reindex?wait_for_completion=false
 {
   "source": {
-    "index": "collection"
+    "index": "collection",
+    "size": 50 <1>
   },
   "dest": {
     "index": "collection-with-embeddings",
@@ -235,6 +236,9 @@ POST _reindex?wait_for_completion=false
   }
 }
 --------------------------------------------------
+<1> The default batch size for reindexing is 1000. Reducing `size` to a smaller 
+number makes the update of the reindexing process quicker which enables you to 
+follow the progress closely and detect errors early.
 
 The API call returns a task ID that can be used to monitor the progress:
 


### PR DESCRIPTION
## Overview

This PR adds the `size` parameter to the reindex API calls in the NLP examples.