### PR TITLE
[DOCS] Adds note about the recommended node size for ELSER

### DIFF
--- a/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
@@ -36,8 +36,9 @@ weights at index time, and to search against later.
 To use ELSER, you must have the {subscriptions}[appropriate subscription] level 
 for semantic search or the trial period activated.
 
-NOTE: It is recommended to use a minimum 4 GB ML node for deploying and using 
-the ELSER model.
+NOTE: The minimum dedicated ML node size for deploying and using 
+the ELSER model is 4 GB. This is a minimum and better performance
+can be achieved by using bigger ML nodes.
 
 
 [discrete]

--- a/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
@@ -36,6 +36,9 @@ weights at index time, and to search against later.
 To use ELSER, you must have the {subscriptions}[appropriate subscription] level 
 for semantic search or the trial period activated.
 
+NOTE: It is recommended to use a minimum 4 GB ML node for deploying and using 
+the ELSER model.
+
 
 [discrete]
 [[elser-hw-benchamrks]]


### PR DESCRIPTION
## Overview

This PR adds a note to the ELSER conceptual docs that contains a recommendation for the minimum size of the ML node.