### PR TITLE
[DOCS] Adjusts note on minimum node size for ELSER and third-party models

### DIFF
--- a/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
@@ -37,10 +37,13 @@ To use ELSER, you must have the {subscriptions}[appropriate subscription] level
 for semantic search or the trial period activated.
 
 NOTE: The minimum dedicated ML node size for deploying and using the ELSER model 
-is 4 GB in Elasticsearch Service with 
-{cloud}/ec-autoscaling.html[deployment autoscaling] turned on. Autoscaling 
-allows your deployment to automatically adjust its available resources when 
-required. Better performance can be achieved by using bigger ML nodes.
+is 4 GB in Elasticsearch Service if 
+{cloud}/ec-autoscaling.html[deployment autoscaling] is turned off. Turning on 
+autoscaling is recommended because it allows your deployment to dinamically 
+adjust resources based on demand. Better performance can be achieved by using 
+more allocations or more threads per allocation, which requires bigger ML nodes. 
+Autoscaling provide bigger nodes when required. If autoscaling is turned off, 
+you must provide suitably sized nodes yourself.
 
 
 [discrete]

--- a/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
@@ -39,10 +39,10 @@ for semantic search or the trial period activated.
 NOTE: The minimum dedicated ML node size for deploying and using the ELSER model 
 is 4 GB in Elasticsearch Service if 
 {cloud}/ec-autoscaling.html[deployment autoscaling] is turned off. Turning on 
-autoscaling is recommended because it allows your deployment to dinamically 
+autoscaling is recommended because it allows your deployment to dynamically 
 adjust resources based on demand. Better performance can be achieved by using 
 more allocations or more threads per allocation, which requires bigger ML nodes. 
-Autoscaling provide bigger nodes when required. If autoscaling is turned off, 
+Autoscaling provides bigger nodes when required. If autoscaling is turned off, 
 you must provide suitably sized nodes yourself.
 
 

--- a/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
@@ -36,9 +36,11 @@ weights at index time, and to search against later.
 To use ELSER, you must have the {subscriptions}[appropriate subscription] level 
 for semantic search or the trial period activated.
 
-NOTE: The minimum dedicated ML node size for deploying and using 
-the ELSER model is 4 GB. This is a minimum and better performance
-can be achieved by using bigger ML nodes.
+NOTE: The minimum dedicated ML node size for deploying and using the ELSER model 
+is 4 GB in Elasticsearch Service with 
+{cloud}/ec-autoscaling.html[deployment autoscaling] turned on. Autoscaling 
+allows your deployment to automatically adjust its available resources when 
+required. Better performance can be achieved by using bigger ML nodes.
 
 
 [discrete]

--- a/docs/en/stack/ml/nlp/ml-nlp-model-ref.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-model-ref.asciidoc
@@ -10,7 +10,7 @@
 :frontmatter-tags-user-goals: [analyze]
 
 NOTE: The minimum dedicated ML node size for deploying and using {nlp} models is 
-4 GB in Elasticsearch Service with 
+16 GB in Elasticsearch Service with 
 {cloud}/ec-autoscaling.html[deployment autoscaling] turned on. Autoscaling 
 allows your deployment to automatically adjust its available resources when 
 required. Better performance can be achieved by using bigger ML nodes.

--- a/docs/en/stack/ml/nlp/ml-nlp-model-ref.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-model-ref.asciidoc
@@ -9,6 +9,12 @@
 :frontmatter-tags-content-type: [reference] 
 :frontmatter-tags-user-goals: [analyze]
 
+NOTE: The minimum dedicated ML node size for deploying and using {nlp} models is 
+4 GB in Elasticsearch Service with 
+{cloud}/ec-autoscaling.html[deployment autoscaling] turned on. Autoscaling 
+allows your deployment to automatically adjust its available resources when 
+required. Better performance can be achieved by using bigger ML nodes.
+
 The {stack-ml-features} support transformer models that conform to the standard
 BERT model interface and use the WordPiece tokenization algorithm.
 

--- a/docs/en/stack/ml/nlp/ml-nlp-model-ref.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-model-ref.asciidoc
@@ -9,11 +9,14 @@
 :frontmatter-tags-content-type: [reference] 
 :frontmatter-tags-user-goals: [analyze]
 
-NOTE: The minimum dedicated ML node size for deploying and using {nlp} models is 
-16 GB in Elasticsearch Service with 
-{cloud}/ec-autoscaling.html[deployment autoscaling] turned on. Autoscaling 
-allows your deployment to automatically adjust its available resources when 
-required. Better performance can be achieved by using bigger ML nodes.
+The minimum dedicated ML node size for deploying and using the ELSER model 
+is 16 GB in Elasticsearch Service if 
+{cloud}/ec-autoscaling.html[deployment autoscaling] is turned off. Turning on 
+autoscaling is recommended because it allows your deployment to dinamically 
+adjust resources based on demand. Better performance can be achieved by using 
+more allocations or more threads per allocation, which requires bigger ML nodes. 
+Autoscaling provide bigger nodes when required. If autoscaling is turned off, 
+you must provide suitably sized nodes yourself.
 
 The {stack-ml-features} support transformer models that conform to the standard
 BERT model interface and use the WordPiece tokenization algorithm.

--- a/docs/en/stack/ml/nlp/ml-nlp-model-ref.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-model-ref.asciidoc
@@ -12,10 +12,10 @@
 The minimum dedicated ML node size for deploying and using the ELSER model 
 is 16 GB in Elasticsearch Service if 
 {cloud}/ec-autoscaling.html[deployment autoscaling] is turned off. Turning on 
-autoscaling is recommended because it allows your deployment to dinamically 
+autoscaling is recommended because it allows your deployment to dynamically 
 adjust resources based on demand. Better performance can be achieved by using 
 more allocations or more threads per allocation, which requires bigger ML nodes. 
-Autoscaling provide bigger nodes when required. If autoscaling is turned off, 
+Autoscaling provides bigger nodes when required. If autoscaling is turned off, 
 you must provide suitably sized nodes yourself.
 
 The {stack-ml-features} support transformer models that conform to the standard


### PR DESCRIPTION
## Overview

This PR:
* adjusts the note on the minimum ML node size on the ELSER page to include reference to ESS and autoscaling,
* adds the same note to the third-party models page.

### Preview

* [ELSER requirements](https://stack-docs_2447.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-nlp-elser.html#elser-req)
* [Third-party models](https://stack-docs_2447.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-nlp-model-ref.html#ml-nlp-model-ref)