### PR TITLE
[DOCS] Added missing quotations for "docs" post request

### DIFF
--- a/docs/en/stack/ml/nlp/ml-nlp-extract-info.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-extract-info.asciidoc
@@ -88,7 +88,7 @@ tell the model which word to predict.
 [source,js]
 ----------------------------------
 {
-    docs: [{"text_field": "The capital city of France is [MASK]."}]
+    "docs": [{"text_field": "The capital city of France is [MASK]."}]
 }
 ...
 ----------------------------------


### PR DESCRIPTION
The other JSON snippets have the correct code for pasting into the kibana console, so this section should as well.