### PR TITLE
[DOCS] Removes sentence similarity models from QA list

### DIFF
--- a/docs/en/stack/ml/nlp/ml-nlp-model-ref.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-model-ref.asciidoc
@@ -71,11 +71,9 @@ purposes and to get started with the Elastic {nlp} features.
 [[ml-nlp-model-ref-question-answering]]
 == Third party question answering models
 
-* https://huggingface.co/sentence-transformers/all-mpnet-base-v2[**All MPNet base v2**]
 * https://huggingface.co/bert-large-uncased-whole-word-masking-finetuned-squad[BERT large model (uncased) whole word masking finetuned on SQuAD]
 * https://huggingface.co/distilbert-base-cased-distilled-squad[DistilBERT base cased distilled SQuAD]
 * https://huggingface.co/deepset/electra-base-squad2[Electra base squad2]
-* https://huggingface.co/sentence-transformers/multi-qa-mpnet-base-cos-v1[**Multi QA MPNet base cos v1**]
 * https://huggingface.co/deepset/tinyroberta-squad2[TinyRoBERTa squad2]
 
 


### PR DESCRIPTION
## Overview

Related to https://github.com/elastic/stack-docs/pull/2451.
This PR deletes two models from the question-answering model section as both models are sentence similarity models.