### PR TITLE
[DOCS] Amends text with embedding_size info

### DIFF
--- a/docs/en/stack/ml/nlp/ml-nlp-text-emb-vector-search-example.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-text-emb-vector-search-example.asciidoc
@@ -194,9 +194,13 @@ index failures into a different index.
 
 Before ingesting the data through the pipeline, create the mappings of the 
 destination index, in particular for the field `text_embedding.predicted_value` 
-where the ingest processor stores the embeddings. The msmarco-MiniLM-L-12-v3 model produces 
-embeddings with 384 dimensions; the `dense_vector` field must be configured 
-with the same number of dimensions as specified by the `dims` option.
+where the ingest processor stores the embeddings. The `dense_vector` field must 
+be configured with the same number of dimensions (`dims`) as the text embedding 
+produced by the model. That value can be found in the `embedding_size` option in 
+the model configuration either under the Trained Models page in {kib} or in the 
+response body of the {ref}get-trained-models.html[Get trained models API] call. 
+The msmarco-MiniLM-L-12-v3 model has embedding_size of 384, so `dims` is set to 
+384.
 
 [source,js]
 --------------------------------------------------

--- a/docs/en/stack/ml/nlp/ml-nlp-text-emb-vector-search-example.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-text-emb-vector-search-example.asciidoc
@@ -198,7 +198,7 @@ where the ingest processor stores the embeddings. The `dense_vector` field must
 be configured with the same number of dimensions (`dims`) as the text embedding 
 produced by the model. That value can be found in the `embedding_size` option in 
 the model configuration either under the Trained Models page in {kib} or in the 
-response body of the {ref}get-trained-models.html[Get trained models API] call. 
+response body of the {ref}/get-trained-models.html[Get trained models API] call. 
 The msmarco-MiniLM-L-12-v3 model has embedding_size of 384, so `dims` is set to 
 384.
 


### PR DESCRIPTION
## Overview

This PR amends the vector search end-to-end example to contain a reference about `embedding_size`.


### Preview

[Add the text embedding model to an inference ingest pipeline]()