### PR TITLE
Remove outdated Anomaly Detection video

### DIFF
--- a/docs/en/stack/ml/get-started/ml-getting-started.asciidoc
+++ b/docs/en/stack/ml/get-started/ml-getting-started.asciidoc
@@ -18,21 +18,6 @@ Ready to take {anomaly-detect} for a test drive? Follow this tutorial to:
 At the end of this tutorial, you should have a good idea of what {ml} is and
 will hopefully be inspired to use it to detect anomalies in your own data.
 
-The following video provides a quick overview of some of the tasks we'll perform in this tutorial:
-
-++++
-<script type="text/javascript" async src="https://play.vidyard.com/embed/v4.js"></script>
-<img
-  style="width: 100%; margin: auto; display: block;"
-  class="vidyard-player-embed"
-  src="https://play.vidyard.com/eVQoHfHNgGxBeuAZ5rCtXq.jpg"
-  data-uuid="qAiTxhZSXKQVQF5aFMp1s3"
-  data-v="4"
-  data-type="inline"
-/>
-</br>
-++++
-
 Need more context? Check out the
 {ref}/elasticsearch-intro.html[{es} introduction] to learn the lingo and
 understand the basics of how {es} works.


### PR DESCRIPTION
Removes an outdated video from [Getting started with anomaly detection](https://www.elastic.co/guide/en/machine-learning/current/ml-getting-started.html).

The video's UI is outdated. There are no current plans to update the video.

Closes https://github.com/elastic/platform-docs-team/issues/130