### PR TITLE
Temporarily remove deep link to knn semantic search

### DIFF
--- a/docs/en/stack/ml/nlp/ml-nlp-text-emb-vector-search-example.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-text-emb-vector-search-example.asciidoc
@@ -265,7 +265,7 @@ After the reindexing is finished, the documents in the new index contain the
 == Semantic search
 
 After the dataset has been enriched with vector embeddings, you can query the
-data using {ref}/knn-search.html#semantic-search[semantic search]. Pass a
+data using {ref}/knn-search.html[semantic search]. Pass a
 `query_vector_builder` to the k-nearest neighbor (kNN) vector search API, and
 provide the query text and the model you have used to create vector embeddings.
 This example searches for "How is the weather in Jamaica?":


### PR DESCRIPTION
This PR temporarily changes the deep link to `knn-search.html#semantic-search` in the ES book into `knn-search.html`. The `semantic-search` ID is moved as part of https://github.com/elastic/elasticsearch/pull/97715 and that PR is failing a cross-book link CI check because of this cross-book link.

I'll restore the deep link after  https://github.com/elastic/elasticsearch/pull/97715 has been merged.