### PR TITLE
Restore deep link to knn semantic search

### DIFF
--- a/docs/en/stack/ml/nlp/ml-nlp-text-emb-vector-search-example.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-text-emb-vector-search-example.asciidoc
@@ -265,7 +265,7 @@ After the reindexing is finished, the documents in the new index contain the
 == Semantic search
 
 After the dataset has been enriched with vector embeddings, you can query the
-data using {ref}/knn-search.html[semantic search]. Pass a
+data using {ref}/knn-search.html#knn-semantic-search[semantic search]. Pass a
 `query_vector_builder` to the k-nearest neighbor (kNN) vector search API, and
 provide the query text and the model you have used to create vector embeddings.
 This example searches for "How is the weather in Jamaica?":


### PR DESCRIPTION
Restores the deep link to the semantic search section in the kNN docs, that was temporarily removed in https://github.com/elastic/stack-docs/pull/2474