### PR TITLE
[Install/Upgrade] Fix Beats 8.8 breaking changes

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -44,7 +44,7 @@ include::{apm-repo-dir}/apm-breaking.asciidoc[tag=notable-v8-breaking-changes]
 This list summarizes the most important breaking changes in Beats.
 For the complete list, go to {beats-ref}/breaking-changes.html[Beats breaking changes].
 
-include::{beats-repo-dir}/release-notes/breaking/breaking-8.0.asciidoc[tag=notable-breaking-changes]
+// include::{beats-repo-dir}/release-notes/breaking/breaking-8.0.asciidoc[tag=notable-breaking-changes]
 
 
 [[elasticsearch-breaking-changes]]


### PR DESCRIPTION
Hides the breaking changes for Beats in 8.8. Beats had no breaking changes in 8.8. The listed changes are from 8.0.