### PR TITLE
[8.6] [Install/Upgrade] Fix Beats 8.8 breaking changes (#2502)

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -44,7 +44,7 @@ include::{apm-repo-dir}/apm-breaking.asciidoc[tag=notable-v8-breaking-changes]
 This list summarizes the most important breaking changes in Beats.
 For the complete list, go to {beats-ref}/breaking-changes.html[Beats breaking changes].
 
-include::{beats-repo-dir}/release-notes/breaking/breaking-8.0.asciidoc[tag=notable-breaking-changes]
+// include::{beats-repo-dir}/release-notes/breaking/breaking-8.0.asciidoc[tag=notable-breaking-changes]
 
 
 [[elasticsearch-breaking-changes]]


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.8` to `8.6`:
 - [[Install/Upgrade] Fix Beats 8.8 breaking changes (#2502)](https://github.com/elastic/stack-docs/pull/2502)

<!--- Backport version: 8.9.8 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)