### PR TITLE
Fix link to Enterprise Search release notes

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -9,7 +9,7 @@ use and make the necessary changes so your code is compatible with {version}.
 ** {beats-ref}/breaking-changes.html[{beats} breaking changes]
 ** {ref}/breaking-changes.html[{es} migration guide]
 ** {security-guide}/release-notes.html[{elastic-sec} release notes]
-** {enterprise-search-ref}/release-notes-{version}.html[{ents} release notes]
+** {enterprise-search-ref}/changelog.html[{ents} release notes]
 ** {fleet-guide}/release-notes.html[{fleet} and {agent} release notes]
 ** {kibana-ref}/release-notes.html[{kib} release notes]
 ** {logstash-ref}/breaking-changes.html[{ls} breaking changes]


### PR DESCRIPTION
The current link points to a specific version of the release notes rather than the release notes landing page. Point to the landing page instead.

This makes it easier to bump the Elastic docs version, since it removes a dependency on a specific Enterprise Search page existing first.

It's also consistent with the other release notes links on this page.

Rel: https://github.com/elastic/stack-docs/pull/2495