### PR TITLE
[DOCS] Fixes NLP size requirement on model reference page

### DIFF
--- a/docs/en/stack/ml/nlp/ml-nlp-model-ref.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-model-ref.asciidoc
@@ -9,7 +9,7 @@
 :frontmatter-tags-content-type: [reference] 
 :frontmatter-tags-user-goals: [analyze]
 
-The minimum dedicated ML node size for deploying and using the ELSER model 
+The minimum dedicated ML node size for deploying and using the {nlp} models 
 is 16 GB in Elasticsearch Service if 
 {cloud}/ec-autoscaling.html[deployment autoscaling] is turned off. Turning on 
 autoscaling is recommended because it allows your deployment to dynamically 

--- a/docs/en/stack/ml/nlp/ml-nlp-model-ref.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-model-ref.asciidoc
@@ -9,7 +9,7 @@
 :frontmatter-tags-content-type: [reference] 
 :frontmatter-tags-user-goals: [analyze]
 
-The minimum dedicated ML node size for deploying and using the {nlp} models 
+NOTE: The minimum dedicated ML node size for deploying and using the {nlp} models 
 is 16 GB in Elasticsearch Service if 
 {cloud}/ec-autoscaling.html[deployment autoscaling] is turned off. Turning on 
 autoscaling is recommended because it allows your deployment to dynamically 


### PR DESCRIPTION
## Overview

This PR changes the node size requirements on the third-party model page, so it doesn't refer to ELSER.

### Preview

[Model reference page](https://stack-docs_2517.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-nlp-model-ref.html)