### PR TITLE
Agent upgrade order

### DIFF
--- a/docs/en/install-upgrade/air-gapped-install.asciidoc
+++ b/docs/en/install-upgrade/air-gapped-install.asciidoc
@@ -90,11 +90,11 @@ Elastic {beats} are light-weight data shippers. They do not require any unique s
 [[air-gapped-elastic-agent]]
 ==== 1.5. {agent}
 
-Air-gapped install of {agent} depends on the <<air-gapped-elastic-package-registry,{package-registry}>> and the <<air-gapped-elastic-artifact-registry,{artifact-registry}>> for most use-cases. The agent itself is fairly lightweight and installs dependencies only as required by its configuration. In terms of connections to these dependencies, {agents} need to be able to connect to the {artifact-registry} directly, but {package-registry} connections are handled through <<air-gapped-kibana,{kib}>>.
+Air-gapped install of {agent} depends on the <<air-gapped-elastic-package-registry,{package-registry}>> and the <<air-gapped-elastic-artifact-registry,{artifact-registry}>> for most use-cases. The agent itself is fairly lightweight and installs dependencies only as required by its configuration. In terms of connections to these dependencies, {agents} need to be able to connect to the {artifact-registry} directly, but {package-registry} connections are handled through <<air-gapped-kibana,{kib}>>. 
 
 Additionally, if the {agent} {elastic-defend} integration is used, then access to the <<air-gapped-elastic-endpoint-artifact-repository,Elastic Endpoint Artifact Repository>> is necessary in order to deploy updates for some of the detection and prevention capabilities.
 
-To learn more about install and configuration, refer to the {fleet-guide}/elastic-agent-installation.html[{agent} install documentation].
+To learn more about install and configuration, refer to the {fleet-guide}/elastic-agent-installation.html[{agent} install documentation]. Make sure to check the requirements specific to running {agents} in an {fleet-guide}/air-gapped.html[air-gapped environment]. 
 
 To get a better understanding of how to work with {agent} configuration settings and policies, refer to <<air-gapped-agent-integration-guide>>.
 

--- a/docs/en/install-upgrade/air-gapped-install.asciidoc
+++ b/docs/en/install-upgrade/air-gapped-install.asciidoc
@@ -90,7 +90,7 @@ Elastic {beats} are light-weight data shippers. They do not require any unique s
 [[air-gapped-elastic-agent]]
 ==== 1.5. {agent}
 
-Air-gapped install of {agent} depends on the <<air-gapped-elastic-package-registry,{package-registry}>> and the <<air-gapped-elastic-artifact-registry,{artifact-registry}>> for most use-cases. The agent itself is fairly lightweight and installs dependencies only as required by its configuration. In terms of connections to these dependencies, {agents} need to be able to connect to the {artifact-registry} directly, but {package-registry} connections are handled through <<air-gapped-kibana,{kib}>>. 
+Air-gapped install of {agent} depends on the <<air-gapped-elastic-package-registry,{package-registry}>> and the <<air-gapped-elastic-artifact-registry,{artifact-registry}>> for most use-cases. The agent itself is fairly lightweight and installs dependencies only as required by its configuration. In terms of connections to these dependencies, {agents} need to be able to connect to the {artifact-registry} directly, but {package-registry} connections are handled through <<air-gapped-kibana,{kib}>>.
 
 Additionally, if the {agent} {elastic-defend} integration is used, then access to the <<air-gapped-elastic-endpoint-artifact-repository,Elastic Endpoint Artifact Repository>> is necessary in order to deploy updates for some of the detection and prevention capabilities.
 


### PR DESCRIPTION
In air-gapped environments Fleet Server, Elastic Agent, and the stack need to be upgraded in a set order. This adds a link in the [Elastic agent section](https://www.elastic.co/guide/en/elastic-stack/current/air-gapped-install.html#air-gapped-elastic-agent) of the air-gapped install docs to the [specific air-gapped requirements](https://www.elastic.co/guide/en/fleet/current/air-gapped.html) in the Fleet & Agent Guide.