### PR TITLE
[DOCS] Fixes field type in ELSER conceptual

### DIFF
--- a/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
@@ -25,8 +25,8 @@ are learned to co-occur frequently within a diverse set of training data. The
 terms that the text is expanded into by the model _are not_ synonyms for the 
 search terms; they are learned associations. These expanded terms are weighted 
 as some of them are more significant than others. Then the {es} 
-{ref}/rank-feature.html[rank-feature field type] is used to store the terms and 
-weights at index time, and to search against later. 
+{ref}/rank-features.html[rank features field type] is used to store the terms 
+and weights at index time, and to search against later. 
 
 
 [discrete]


### PR DESCRIPTION
## Overview

This PR changes the reference to the `rank_feature` field type to `rank_features` as that's the correct field type that needs to be used for ELSER. Other references to the field type – for example in the end-to-end example – are correct.

Closes https://github.com/elastic/platform-docs-team/issues/176