### PR TITLE
[8.10] [DOCS] Fixes field type in ELSER conceptual. (#2527)

### DIFF
--- a/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
@@ -25,8 +25,8 @@ are learned to co-occur frequently within a diverse set of training data. The
 terms that the text is expanded into by the model _are not_ synonyms for the 
 search terms; they are learned associations. These expanded terms are weighted 
 as some of them are more significant than others. Then the {es} 
-{ref}/rank-feature.html[rank-feature field type] is used to store the terms and 
-weights at index time, and to search against later. 
+{ref}/rank-features.html[rank features field type] is used to store the terms 
+and weights at index time, and to search against later. 
 
 
 [discrete]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.10`:
 - [[DOCS] Fixes field type in ELSER conceptual. (#2527)](https://github.com/elastic/stack-docs/pull/2527)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)