### PR TITLE
[DOCS] Removes // from start trained model deployment link

### DIFF
--- a/docs/en/stack/ml/nlp/ml-nlp-apis.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-apis.asciidoc
@@ -21,7 +21,7 @@ All the trained models endpoints have the following base:
 // INFER
 * {ref}/infer-trained-model.html[Infer trained model]
 // START
-* {ref}//start-trained-model-deployment.html[Start trained model deployment]
+* {ref}/start-trained-model-deployment.html[Start trained model deployment]
 // STOP
 * {ref}/stop-trained-model-deployment.html[Stop trained model deployment]
 // UPDATE


### PR DESCRIPTION
Changes `{ref}//start-trained-model-deployment.html` to `{ref}/start-trained-model-deployment.html`