### PR TITLE
[ML] Fix `welcome-to-elastic` link

### DIFF
--- a/docs/en/stack/ml/index-custom-title-page.html
+++ b/docs/en/stack/ml/index-custom-title-page.html
@@ -2,24 +2,24 @@
     * {
       box-sizing: border-box;
     }
-  
+
     .card {
       cursor: pointer;
       padding: 16px;
       text-align: left;
       color: #000;
     }
-  
+
     .card:hover {
       box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2);
       padding: 16px;
       text-align: left;
     }
-  
+
     #guide a.no-text-decoration:hover {
       text-decoration: none!important;
     }
-  
+
     .icon {
       width: 24px;
       height: 24px;
@@ -27,13 +27,13 @@
       background-size: contain;
       background-repeat: no-repeat;
     }
-  
+
     .ul-col-1 {
       columns: 1;
       -webkit-columns: 1;
       -moz-columns: 1;
     }
-  
+
     @media (min-width:769px) {
       .ul-col-md-2 {
         columns: 2;
@@ -50,9 +50,9 @@
     margin-bottom: 0!important;
   }
   </style>
-  
+
   <div class="legalnotice"></div>
-  
+
   <div class="row my-4">
     <div class="col-md-6 col-12">
       <p></p>
@@ -73,9 +73,9 @@
       <img class="w-100" src="https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/bltdd4cccf507615a8b/63e62da759036b11199d0f6b/ML_cover.jpg" />
     </div>
   </div>
-  
+
   <h3 class="gtk">Get to know Elastic machine learning</h3>
-  
+
   <div class="my-5">
     <div class="d-flex align-items-center mb-3">
       <h4 class="mt-3">
@@ -104,7 +104,7 @@
       </li>
     </ul>
   </div>
-  
+
   <div class="my-5">
     <div class="d-flex align-items-center mb-3">
       <h4 class="mt-3">
@@ -130,7 +130,7 @@
       </li>
     </ul>
   </div>
-  
+
   <div class="my-5">
     <div class="d-flex align-items-center mb-3">
       <h4 class="mt-3">
@@ -159,7 +159,7 @@
       </li>
     </ul>
   </div>
-  
+
   <div class="my-5">
     <div class="d-flex align-items-center mb-3">
       <h4 class="mt-3">
@@ -182,9 +182,9 @@
       </li>
     </ul>
   </div>
-  
+
   <h3 class="explore">Explore by use case</h3>
-  
+
   <div class="row my-4">
     <div class="col-md-4 col-12 mb-2">
       <a class="no-text-decoration" href="https://www.elastic.co/guide/en/enterprise-search/current/start.html">
@@ -198,7 +198,7 @@
       </a>
     </div>
     <div class="col-md-4 col-12 mb-2">
-      <a class="no-text-decoration" href="https://www.elastic.co/guide/en/welcome-to-elastic/current/getting-started-observability.html">
+      <a class="no-text-decoration" href="https://www.elastic.co/guide/en/starting-with-the-elasticsearch-platform-and-its-solutions/current/getting-started-observability.html">
         <div class="card h-100">
           <h4 class="mt-3">
             <span class="inline-block float-left icon mr-2" style="background-image: url('https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/bltaa08b370a00bbecc/634d9da14e565f1cdce27f7c/observability-logo-color-32px.png');"></span>
@@ -220,5 +220,5 @@
       </a>
     </div>
   </div>
-  
+
   <p class="my-4"><a href="https://www.elastic.co/guide/index.html">View all Elastic docs</a></p>


### PR DESCRIPTION
**Problem:** In https://github.com/elastic/docs/pull/2752, we updated the URL prefix (`welcome-to-elastic`) and name for the "Welcome to Elastic Docs" docs. However, we still have some stray links that use the old `/welcome-to-elastic` URL prefix

**Solution:** Update an outdated link.