### PR TITLE
Add list of text similarity models to compatible NLP models

### DIFF
--- a/docs/en/stack/ml/nlp/ml-nlp-model-ref.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-model-ref.asciidoc
@@ -145,6 +145,11 @@ Using `DPREncoderWrapper`:
 * https://huggingface.co/ProsusAI/finbert[FinBERT]
 * https://huggingface.co/cardiffnlp/twitter-roberta-base-sentiment[Twitter roBERTa base for Sentiment Analysis]
 
+[discrete]
+[[ml-nlp-model-ref-text-similarity]]
+== Third party text similarity models
+* https://huggingface.co/cross-encoder/ms-marco-TinyBERT-L-2-v2[ms marco TinyBERT L2 v2]
+* https://huggingface.co/cross-encoder/ms-marco-MiniLM-L-6-v2[ms marco MiniLM L6 v2]
 
 [discrete]
 [[ml-nlp-model-ref-zero-shot]]


### PR DESCRIPTION
Text similarity must use a cross encoder model which has caused some confusion

For https://github.com/elastic/elasticsearch/issues/99211