### PR TITLE
Changes to Beats and Logstash minimal version

### DIFF
--- a/docs/en/install-upgrade/upgrading-stack.asciidoc
+++ b/docs/en/install-upgrade/upgrading-stack.asciidoc
@@ -63,8 +63,9 @@ even if you opt to do a full-cluster restart of your {es} cluster.**
 Alternatively, you can create a new {version} deployment and reindex from remote.
 For more information, see <<upgrading-reindex, Reindex to upgrade>>.
 
-Beats and Logstash 7.n are compatible with {es} {version} 
-to give you flexibility in scheduling the upgrade.
+Beats and Logstash 7.17.x are compatible with {es} {version} 
+to give you flexibility in scheduling the upgrade. If your Beats or Logstash are running any version lower than
+7.17, they should first be upgraded to 7.17.x
 
 .Remote cluster compatibility
 [NOTE]


### PR DESCRIPTION
Support matrix for product compatibility indicates that only Beats and Logstash version 7.17.x are compatible with 8.x
See https://www.elastic.co/fr/support/matrix#matrix_compatibility

Aligning this to that as the matrix is the source of truth