### PR TITLE
[DOCS] Remove link to doc that will be removed

### DIFF
--- a/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
@@ -156,7 +156,7 @@ image::images/ml-nlp-deployment-id-elser.png[alt="Deploying ELSER",align="center
 [[enterprise-search]]
 === Using the Indices page in {ents}
 
-You can also {enterprise-search-ref}/elser-text-expansion.html#deploy-elser[download and deploy ELSER to an {infer} pipeline] directly from the 
+You can also download and deploy ELSER to an {infer} pipeline directly from the
 {ents} app.
 
 1. In {kib}, navigate to **{ents}** > **Indices**.


### PR DESCRIPTION
The Enterprise Search ELSER doc will be removed in the near future. Remove the link now to unblock link checking in PRs.