### PR TITLE
[DOCS] Highlights how to switch to ELSER v2 from v1

### DIFF
--- a/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
@@ -68,7 +68,7 @@ deploy based on your cluster's hardware.
 
 ELSER v2 is not backward compatible. If you indexed your data with ELSER v1, you 
 need to reindex it with an ingest pipeline referencing ELSER v2 to be able to 
-use v2 for search. This {ref}semantic-search-elser.html[tutorial] shows you how 
+use v2 for search. This {ref}/semantic-search-elser.html[tutorial] shows you how 
 to create an ingest pipeline with an {infer} processor that uses ELSER v2, and 
 how to reindex your data through the pipeline.
 

--- a/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
@@ -61,9 +61,16 @@ one version which is optimized for Intel® silicon. The **Model Management** >
 **Trained Models** page shows you which version of ELSER v2 is recommended to 
 deploy based on your cluster's hardware.
 
-IMPORTANT: ELSER v2 is not backward compatible. If you indexed your data with 
-ELSER v1, you need to reindex it with an ingest pipeline referencing ELSER v2 to 
-be able to use v2 for search.
+
+[discrete]
+[[upgrade-elser-v2]]
+=== Upgrading to ELSER v2
+
+ELSER v2 is not backward compatible. If you indexed your data with ELSER v1, you 
+need to reindex it with an ingest pipeline referencing ELSER v2 to be able to 
+use v2 for search. This {ref}semantic-search-elser.html[tutorial] shows you how 
+to create an ingest pipeline with an {infer} processor that uses ELSER v2, and 
+how to reindex your data through the pipeline.
 
 // TO DO
 // If you want to learn more about the ELSER v2 improvements, refer to this blog 


### PR DESCRIPTION
## Overview

This PR adds a subsection to the ELSER v2 section about how to upgrade from v1 to v2. It also adds a link that points to the tutorial which shows how to create an index pipeline and how to reindex using that pipeline.

### Preview

[ESLER v2]()