### PR TITLE
Fixes URLs in OOTB security jobs and updates job IDs

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-siem.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-siem.asciidoc
@@ -437,22 +437,22 @@ To download, refer to the https://docs.elastic.co/integrations/problemchild[docu
 |Name |Description 
 
 |problem_child_rare_process_by_host
-|Looks for a process that has been classified as malicious on a host that does not commonly manifest malicious process activity (experimental).
+|Looks for a process that has been classified as malicious on a host that does not commonly manifest malicious process activity.
 
 |problem_child_high_sum_by_host
-|Looks for a set of one or more malicious child processes on a single host (experimental).
+|Looks for a set of one or more malicious child processes on a single host.
 
 |problem_child_rare_process_by_user
-|Looks for a process that has been classified as malicious where the user context is unusual and does not commonly manifest malicious process activity (experimental).
+|Looks for a process that has been classified as malicious where the user context is unusual and does not commonly manifest malicious process activity.
 
 |problem_child_rare_process_by_parent
-|Looks for rare malicious child processes spawned by a parent process (experimental).
+|Looks for rare malicious child processes spawned by a parent process.
 
 |problem_child_high_sum_by_user
-|Looks for a set of one or more malicious processes, started by the same user (experimental).
+|Looks for a set of one or more malicious processes, started by the same user.
 
 |problem_child_high_sum_by_parent
-|Looks for a set of one or more malicious child processes spawned by the same parent process (experimental).
+|Looks for a set of one or more malicious child processes spawned by the same parent process.
 
 |===
 

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-siem.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-siem.asciidoc
@@ -421,7 +421,7 @@ To download, refer to the https://docs.elastic.co/integrations/dga[documentation
 |===
 
 The job configurations and datafeeds can be found 
-[here](https://github.com/elastic/integrations/blob/main/packages/dga/kibana/ml_module/dga-ml.json).
+https://github.com/elastic/integrations/blob/main/packages/dga/kibana/ml_module/dga-ml.json[here].
 
 // LotL
 
@@ -457,7 +457,7 @@ To download, refer to the https://docs.elastic.co/integrations/problemchild[docu
 |===
 
 The job configurations and datafeeds can be found 
-[here](https://github.com/elastic/integrations/blob/main/packages/problemchild/kibana/ml_module/problemchild-ml.json).
+https://github.com/elastic/integrations/blob/main/packages/problemchild/kibana/ml_module/problemchild-ml.json[here].
 
 // ded
 
@@ -494,7 +494,7 @@ To download, refer to the https://docs.elastic.co/integrations/ded[documentation
 |===
 
 The job configurations and datafeeds can be found 
-[here](https://github.com/elastic/integrations/blob/main/packages/ded/kibana/ml_module/ded-ml.json).
+https://github.com/elastic/integrations/blob/main/packages/ded/kibana/ml_module/ded-ml.json[here].
 
 // lmd
 
@@ -545,7 +545,7 @@ To download, refer to the https://docs.elastic.co/integrations/lmd[documentation
 |===
 
 The job configurations and datafeeds can be found 
-[here](https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json).
+https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json[here].
 
 // end::security-windows-jobs[]
 // end::siem-jobs[]

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-siem.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-siem.asciidoc
@@ -411,8 +411,8 @@ To download, refer to the https://docs.elastic.co/integrations/dga[documentation
 
 |dga_high_sum_probability
 |Detect domain generation algorithm (DGA) activity in your network data.
-|https://github.com/elastic/integrations/blob/{branch}/packages/dga/kibana/ml_module/dga-ml.json#L23[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/{branch}/packages/dga/kibana/ml_module/dga-ml.json#L58[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/dga/kibana/ml_module/dga-ml.json#L23[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/dga/kibana/ml_module/dga-ml.json#L58[image:images/link.svg[A link icon]]
 
 |===
 
@@ -429,33 +429,33 @@ To download, refer to the https://docs.elastic.co/integrations/problemchild[docu
 
 |problem_child_rare_process_by_host
 |Looks for a process that has been classified as malicious on a host that does not commonly manifest malicious process activity (experimental).
-|https://github.com/elastic/integrations/blob/{branch}/packages/problemchild/kibana/ml_module/problemchild-ml.json#L29[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/{branch}/packages/problemchild/kibana/ml_module/problemchild-ml.json#262[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/problemchild/kibana/ml_module/problemchild-ml.json#L29[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/problemchild/kibana/ml_module/problemchild-ml.json#262[image:images/link.svg[A link icon]]
 
 |problem_child_high_sum_by_host
 |Looks for a set of one or more malicious child processes on a single host (experimental).
-|https://github.com/elastic/integrations/blob/{branch}/packages/problemchild/kibana/ml_module/problemchild-ml.json#L64[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/{branch}/packages/problemchild/kibana/ml_module/problemchild-ml.json#262[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/problemchild/kibana/ml_module/problemchild-ml.json#L64[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/problemchild/kibana/ml_module/problemchild-ml.json#262[image:images/link.svg[A link icon]]
 
 |problem_child_rare_process_by_user
 |Looks for a process that has been classified as malicious where the user context is unusual and does not commonly manifest malicious process activity (experimental).
-|https://github.com/elastic/integrations/blob/{branch}/packages/problemchild/kibana/ml_module/problemchild-ml.json#L106[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/{branch}/packages/problemchild/kibana/ml_module/problemchild-ml.json#262[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/problemchild/kibana/ml_module/problemchild-ml.json#L106[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/problemchild/kibana/ml_module/problemchild-ml.json#262[image:images/link.svg[A link icon]]
 
 |problem_child_rare_process_by_parent
 |Looks for rare malicious child processes spawned by a parent process (experimental).
-|https://github.com/elastic/integrations/blob/{branch}/packages/problemchild/kibana/ml_module/problemchild-ml.json#L141[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/{branch}/packages/problemchild/kibana/ml_module/problemchild-ml.json#262[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/problemchild/kibana/ml_module/problemchild-ml.json#L141[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/problemchild/kibana/ml_module/problemchild-ml.json#262[image:images/link.svg[A link icon]]
 
 |problem_child_high_sum_by_user
 |Looks for a set of one or more malicious processes, started by the same user (experimental).
-|https://github.com/elastic/integrations/blob/{branch}/packages/problemchild/kibana/ml_module/problemchild-ml.json#L177[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/{branch}/packages/problemchild/kibana/ml_module/problemchild-ml.json#262[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/problemchild/kibana/ml_module/problemchild-ml.json#L177[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/problemchild/kibana/ml_module/problemchild-ml.json#262[image:images/link.svg[A link icon]]
 
 |problem_child_high_sum_by_parent
 |Looks for a set of one or more malicious child processes spawned by the same parent process (experimental).
-|https://github.com/elastic/integrations/blob/{branch}/packages/problemchild/kibana/ml_module/problemchild-ml.json#L219[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/{branch}/packages/problemchild/kibana/ml_module/problemchild-ml.json#262[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/problemchild/kibana/ml_module/problemchild-ml.json#L219[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/problemchild/kibana/ml_module/problemchild-ml.json#262[image:images/link.svg[A link icon]]
 
 |===
 
@@ -472,38 +472,38 @@ To download, refer to the https://docs.elastic.co/integrations/ded[documentation
 
 |high-sent-bytes-destination-geo-country_iso_code
 |Detects data exfiltration to an unusual geo-location (by country iso code).
-|https://github.com/elastic/integrations/blob/{branch}/packages/ded/kibana/ml_module/ded-ml.json#L44[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/{branch}/packages/ded/kibana/ml_module/ded-ml.json#L304[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/ded/kibana/ml_module/ded-ml.json#L44[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/ded/kibana/ml_module/ded-ml.json#L304[image:images/link.svg[A link icon]]
 
 |high-sent-bytes-destination-ip
 |Detects data exfiltration to an unusual geo-location (by IP address).
-|https://github.com/elastic/integrations/blob/{branch}/packages/ded/kibana/ml_module/ded-ml.json#L83[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/{branch}/packages/ded/kibana/ml_module/ded-ml.json#L304[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/ded/kibana/ml_module/ded-ml.json#L83[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/ded/kibana/ml_module/ded-ml.json#L304[image:images/link.svg[A link icon]]
 
 |high-sent-bytes-destination-port
 |Detects data exfiltration to an unusual destination port.
-|https://github.com/elastic/integrations/blob/{branch}/packages/ded/kibana/ml_module/ded-ml.json#L119[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/{branch}/packages/ded/kibana/ml_module/ded-ml.json#L304[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/ded/kibana/ml_module/ded-ml.json#L119[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/ded/kibana/ml_module/ded-ml.json#L304[image:images/link.svg[A link icon]]
 
 |high-sent-bytes-destination-region_name
 |Detects data exfiltration to an unusual geo-location (by region name).
-|https://github.com/elastic/integrations/blob/{branch}/packages/ded/kibana/ml_module/ded-ml.json#L156[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/{branch}/packages/ded/kibana/ml_module/ded-ml.json#L304[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/ded/kibana/ml_module/ded-ml.json#L156[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/ded/kibana/ml_module/ded-ml.json#L304[image:images/link.svg[A link icon]]
 
 |high-bytes-written-to-external-device
 |Detects data exfiltration activity by identifying high bytes written to an external device.
-|https://github.com/elastic/integrations/blob/{branch}/packages/ded/kibana/ml_module/ded-ml.json#L194[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/{branch}/packages/ded/kibana/ml_module/ded-ml.json#L304[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/ded/kibana/ml_module/ded-ml.json#L194[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/ded/kibana/ml_module/ded-ml.json#L304[image:images/link.svg[A link icon]]
 
 |rare-process-writing-to-external-device
 |Detects data exfiltration activity by identifying a file write started by a rare process to an external device.
-|https://github.com/elastic/integrations/blob/{branch}/packages/ded/kibana/ml_module/ded-ml.json#L231[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/{branch}/packages/ded/kibana/ml_module/ded-ml.json#L304[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/ded/kibana/ml_module/ded-ml.json#L231[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/ded/kibana/ml_module/ded-ml.json#L304[image:images/link.svg[A link icon]]
 
 |high-bytes-written-to-external-device-airdrop
 |Detects data exfiltration activity by identifying high bytes written to an external device via Airdrop.
-|https://github.com/elastic/integrations/blob/{branch}/packages/ded/kibana/ml_module/ded-ml.json#L268[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/{branch}/packages/ded/kibana/ml_module/ded-ml.json#L304[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/ded/kibana/ml_module/ded-ml.json#L268[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/ded/kibana/ml_module/ded-ml.json#L304[image:images/link.svg[A link icon]]
 
 |===
 
@@ -520,58 +520,58 @@ To download, refer to the https://docs.elastic.co/integrations/lmd[documentation
 
 |high-count-remote-file-transfer
 |Detects unusually high file transfers to a remote host in the network.
-|https://github.com/elastic/integrations/blob/{branch}/packages/lmd/kibana/ml_module/lmd-ml.json#L24[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/{branch}/packages/lmd/kibana/ml_module/lmd-ml.json#L436[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json#L24[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json#L436[image:images/link.svg[A link icon]]
 
 |high-file-size-remote-file-transfer
 |Detects unusually high size of files shared with a remote host in the network.
 |https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json#L58[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/{branch}/packages/lmd/kibana/ml_module/lmd-ml.json#L436[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json#L436[image:images/link.svg[A link icon]]
 
 |rare-file-extension-remote-transfer
 |Detects data exfiltration to an unusual destination port.
 |https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json#L92[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/{branch}/packages/lmd/kibana/ml_module/lmd-ml.json#L436[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json#L436[image:images/link.svg[A link icon]]
 
 |rare-file-path-remote-transfer
 |Detects unusual folders and directories on which a file is transferred.
 |https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json#L126[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/{branch}/packages/lmd/kibana/ml_module/lmd-ml.json#L436[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json#L436[image:images/link.svg[A link icon]]
 
 |high-mean-rdp-session-duration
 |Detects unusually high mean of RDP session duration.
 |https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json#L160[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/{branch}/packages/lmd/kibana/ml_module/lmd-ml.json#L436[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json#L436[image:images/link.svg[A link icon]]
 
 |high-var-rdp-session-duration
 |Detects unusually high variance in RDP session duration.
 |https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json#L202[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/{branch}/packages/lmd/kibana/ml_module/lmd-ml.json#L436[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json#L436[image:images/link.svg[A link icon]]
 
 |high-sum-rdp-number-of-processes
 |Detects unusually high number of processes started in a single RDP session.
 |https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json#L244[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/{branch}/packages/lmd/kibana/ml_module/lmd-ml.json#L436[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json#L436[image:images/link.svg[A link icon]]
 
 |unusual-time-weekday-rdp-session-start
 |Detects an RDP session started at an usual time or weekday.
 |https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json#L286[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/{branch}/packages/lmd/kibana/ml_module/lmd-ml.json#L436[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json#L436[image:images/link.svg[A link icon]]
 
 |high-rdp-distinct-count-source-ip-for-destination
 |Detects a high count of source IPs making an RDP connection with a single destination IP.
 |https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json#L326[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/{branch}/packages/lmd/kibana/ml_module/lmd-ml.json#L436[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json#L436[image:images/link.svg[A link icon]]
 
 |high-rdp-distinct-count-destination-ip-for-source
 |Detects a high count of destination IPs establishing an RDP connection with a single source IP.
 |https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json#L360[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/{branch}/packages/lmd/kibana/ml_module/lmd-ml.json#L436[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json#L436[image:images/link.svg[A link icon]]
 
 |high-mean-rdp-process-args
 |Detects unusually high number of process arguments in an RDP session.
 |https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json#L394[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/{branch}/packages/lmd/kibana/ml_module/lmd-ml.json#L436[image:images/link.svg[A link icon]]
+|https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json#L436[image:images/link.svg[A link icon]]
 
 |===
 // end::security-windows-jobs[]

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-siem.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-siem.asciidoc
@@ -389,9 +389,13 @@ they are listed for each job.
 [[security-integrations-jobs]]
 == Security: Elastic Integrations
 
-https://docs.elastic.co/integrations[Elastic Integrations] are a streamlined way to add Elastic assets to your environment, such as data ingestion, {transforms}, and in this case, {ml} capabilities for Security.
+https://docs.elastic.co/integrations[Elastic Integrations] are a streamlined way 
+to add Elastic assets to your environment, such as data ingestion, {transforms}, 
+and in this case, {ml} capabilities for Security.
 
-The following Integrations use {ml} to analyze patterns of user and entity behavior, and help detect and alert when there is related suspicious activity in your environment.
+The following Integrations use {ml} to analyze patterns of user and entity 
+behavior, and help detect and alert when there is related suspicious activity in 
+your environment.
 
 * https://docs.elastic.co/integrations/ded[Data Exfiltration Detection]
 * https://docs.elastic.co/integrations/dga[Domain Generation Algorithm Detection]
@@ -402,62 +406,58 @@ The following Integrations use {ml} to analyze patterns of user and entity behav
 
 *Domain Generation Algorithm (DGA) Detection*
 
-{ml-cap} solution package to detect domain generation algorithm (DGA) activity in your network data. Refer to the {subscriptions}[subscription page] to learn more about the required subscription.
+{ml-cap} solution package to detect domain generation algorithm (DGA) activity 
+in your network data. Refer to the {subscriptions}[subscription page] to learn 
+more about the required subscription.
 
 To download, refer to the https://docs.elastic.co/integrations/dga[documentation].
 
 |===
-|Name |Description |Job |Datafeed
+|Name |Description 
 
 |dga_high_sum_probability
 |Detect domain generation algorithm (DGA) activity in your network data.
-|https://github.com/elastic/integrations/blob/main/packages/dga/kibana/ml_module/dga-ml.json#L23[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/main/packages/dga/kibana/ml_module/dga-ml.json#L58[image:images/link.svg[A link icon]]
 
 |===
+
+The job configurations and datafeeds can be found 
+[here](https://github.com/elastic/integrations/blob/main/packages/dga/kibana/ml_module/dga-ml.json).
 
 // LotL
 
 *Living off the Land Attack (LotL) Detection*
 
-{ml-cap} solution package to detect Living off the Land (LotL) attacks in your environment. Refer to the {subscriptions}[subscription page] to learn more about the required subscription. (Also known as ProblemChild).
+{ml-cap} solution package to detect Living off the Land (LotL) attacks in your 
+environment. Refer to the {subscriptions}[subscription page] to learn more about 
+the required subscription. (Also known as ProblemChild).
 
 To download, refer to the https://docs.elastic.co/integrations/problemchild[documentation].
 
 |===
-|Name |Description |Job |Datafeed
+|Name |Description 
 
 |problem_child_rare_process_by_host
 |Looks for a process that has been classified as malicious on a host that does not commonly manifest malicious process activity (experimental).
-|https://github.com/elastic/integrations/blob/main/packages/problemchild/kibana/ml_module/problemchild-ml.json#L29[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/main/packages/problemchild/kibana/ml_module/problemchild-ml.json#262[image:images/link.svg[A link icon]]
 
 |problem_child_high_sum_by_host
 |Looks for a set of one or more malicious child processes on a single host (experimental).
-|https://github.com/elastic/integrations/blob/main/packages/problemchild/kibana/ml_module/problemchild-ml.json#L64[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/main/packages/problemchild/kibana/ml_module/problemchild-ml.json#262[image:images/link.svg[A link icon]]
 
 |problem_child_rare_process_by_user
 |Looks for a process that has been classified as malicious where the user context is unusual and does not commonly manifest malicious process activity (experimental).
-|https://github.com/elastic/integrations/blob/main/packages/problemchild/kibana/ml_module/problemchild-ml.json#L106[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/main/packages/problemchild/kibana/ml_module/problemchild-ml.json#262[image:images/link.svg[A link icon]]
 
 |problem_child_rare_process_by_parent
 |Looks for rare malicious child processes spawned by a parent process (experimental).
-|https://github.com/elastic/integrations/blob/main/packages/problemchild/kibana/ml_module/problemchild-ml.json#L141[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/main/packages/problemchild/kibana/ml_module/problemchild-ml.json#262[image:images/link.svg[A link icon]]
 
 |problem_child_high_sum_by_user
 |Looks for a set of one or more malicious processes, started by the same user (experimental).
-|https://github.com/elastic/integrations/blob/main/packages/problemchild/kibana/ml_module/problemchild-ml.json#L177[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/main/packages/problemchild/kibana/ml_module/problemchild-ml.json#262[image:images/link.svg[A link icon]]
 
 |problem_child_high_sum_by_parent
 |Looks for a set of one or more malicious child processes spawned by the same parent process (experimental).
-|https://github.com/elastic/integrations/blob/main/packages/problemchild/kibana/ml_module/problemchild-ml.json#L219[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/main/packages/problemchild/kibana/ml_module/problemchild-ml.json#262[image:images/link.svg[A link icon]]
 
 |===
+
+The job configurations and datafeeds can be found 
+[here](https://github.com/elastic/integrations/blob/main/packages/problemchild/kibana/ml_module/problemchild-ml.json).
 
 // ded
 
@@ -468,111 +468,84 @@ To download, refer to the https://docs.elastic.co/integrations/problemchild[docu
 To download, refer to the https://docs.elastic.co/integrations/ded[documentation].
 
 |===
-|Name |Description |Job |Datafeed
+|Name |Description 
 
 |ded_high_sent_bytes_destination_geo_country_iso_code
 |Detects data exfiltration to an unusual geo-location (by country iso code).
-|https://github.com/elastic/integrations/blob/main/packages/ded/kibana/ml_module/ded-ml.json#L44[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/main/packages/ded/kibana/ml_module/ded-ml.json#L304[image:images/link.svg[A link icon]]
 
 |ded_high_sent_bytes_destination_ip
 |Detects data exfiltration to an unusual geo-location (by IP address).
-|https://github.com/elastic/integrations/blob/main/packages/ded/kibana/ml_module/ded-ml.json#L83[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/main/packages/ded/kibana/ml_module/ded-ml.json#L304[image:images/link.svg[A link icon]]
 
 |ded_high_sent_bytes_destination_port
 |Detects data exfiltration to an unusual destination port.
-|https://github.com/elastic/integrations/blob/main/packages/ded/kibana/ml_module/ded-ml.json#L119[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/main/packages/ded/kibana/ml_module/ded-ml.json#L304[image:images/link.svg[A link icon]]
 
 |ded_high_sent_bytes_destination_region_name
 |Detects data exfiltration to an unusual geo-location (by region name).
-|https://github.com/elastic/integrations/blob/main/packages/ded/kibana/ml_module/ded-ml.json#L156[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/main/packages/ded/kibana/ml_module/ded-ml.json#L304[image:images/link.svg[A link icon]]
 
 |ded_high_bytes_written_to_external_device
 |Detects data exfiltration activity by identifying high bytes written to an external device.
-|https://github.com/elastic/integrations/blob/main/packages/ded/kibana/ml_module/ded-ml.json#L194[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/main/packages/ded/kibana/ml_module/ded-ml.json#L304[image:images/link.svg[A link icon]]
 
 |ded_rare_process_writing_to_external_device
 |Detects data exfiltration activity by identifying a file write started by a rare process to an external device.
-|https://github.com/elastic/integrations/blob/main/packages/ded/kibana/ml_module/ded-ml.json#L231[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/main/packages/ded/kibana/ml_module/ded-ml.json#L304[image:images/link.svg[A link icon]]
 
 |ded_high_bytes_written_to_external_device_airdrop
 |Detects data exfiltration activity by identifying high bytes written to an external device via Airdrop.
-|https://github.com/elastic/integrations/blob/main/packages/ded/kibana/ml_module/ded-ml.json#L268[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/main/packages/ded/kibana/ml_module/ded-ml.json#L304[image:images/link.svg[A link icon]]
 
 |===
+
+The job configurations and datafeeds can be found 
+[here](https://github.com/elastic/integrations/blob/main/packages/ded/kibana/ml_module/ded-ml.json).
 
 // lmd
 
 *Lateral Movement Detection (LMD)*
 
-{ml-cap} package to detect lateral movement based on file transfer activity and Windows RDP events. Refer to the {subscriptions}[subscription page] to learn more about the required subscription.
+{ml-cap} package to detect lateral movement based on file transfer activity and 
+Windows RDP events. Refer to the {subscriptions}[subscription page] to learn 
+more about the required subscription.
 
 To download, refer to the https://docs.elastic.co/integrations/lmd[documentation].
 
 |===
-|Name |Description |Job |Datafeed
+|Name |Description 
 
 |lmd_high_count_remote_file_transfer
 |Detects unusually high file transfers to a remote host in the network.
-|https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json#L24[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json#L436[image:images/link.svg[A link icon]]
 
 |lmd_high_file_size_remote_file_transfer
 |Detects unusually high size of files shared with a remote host in the network.
-|https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json#L58[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json#L436[image:images/link.svg[A link icon]]
 
 |lmd_rare_file_extension_remote_transfer
 |Detects data exfiltration to an unusual destination port.
-|https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json#L92[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json#L436[image:images/link.svg[A link icon]]
 
 |lmd_rare_file_path_remote_transfer
 |Detects unusual folders and directories on which a file is transferred.
-|https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json#L126[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json#L436[image:images/link.svg[A link icon]]
 
 |lmd_high_mean_rdp_session_duration
 |Detects unusually high mean of RDP session duration.
-|https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json#L160[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json#L436[image:images/link.svg[A link icon]]
 
 |lmd_high_var_rdp_session_duration
 |Detects unusually high variance in RDP session duration.
-|https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json#L202[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json#L436[image:images/link.svg[A link icon]]
 
 |lmd_high_sum_rdp_number_of_processes
 |Detects unusually high number of processes started in a single RDP session.
-|https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json#L244[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json#L436[image:images/link.svg[A link icon]]
 
 |lmd_unusual_time_weekday_rdp_session_start
 |Detects an RDP session started at an usual time or weekday.
-|https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json#L286[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json#L436[image:images/link.svg[A link icon]]
 
 |lmd_high_rdp_distinct_count_source_ip_for_destination
 |Detects a high count of source IPs making an RDP connection with a single destination IP.
-|https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json#L326[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json#L436[image:images/link.svg[A link icon]]
 
 |lmd_high_rdp_distinct_count_destination_ip_for_source
 |Detects a high count of destination IPs establishing an RDP connection with a single source IP.
-|https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json#L360[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json#L436[image:images/link.svg[A link icon]]
 
 |lmd_high_mean_rdp_process_args
 |Detects unusually high number of process arguments in an RDP session.
-|https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json#L394[image:images/link.svg[A link icon]]
-|https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json#L436[image:images/link.svg[A link icon]]
 
 |===
+
+The job configurations and datafeeds can be found 
+[here](https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json).
+
 // end::security-windows-jobs[]
 // end::siem-jobs[]

--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-siem.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-siem.asciidoc
@@ -470,37 +470,37 @@ To download, refer to the https://docs.elastic.co/integrations/ded[documentation
 |===
 |Name |Description |Job |Datafeed
 
-|high-sent-bytes-destination-geo-country_iso_code
+|ded_high_sent_bytes_destination_geo_country_iso_code
 |Detects data exfiltration to an unusual geo-location (by country iso code).
 |https://github.com/elastic/integrations/blob/main/packages/ded/kibana/ml_module/ded-ml.json#L44[image:images/link.svg[A link icon]]
 |https://github.com/elastic/integrations/blob/main/packages/ded/kibana/ml_module/ded-ml.json#L304[image:images/link.svg[A link icon]]
 
-|high-sent-bytes-destination-ip
+|ded_high_sent_bytes_destination_ip
 |Detects data exfiltration to an unusual geo-location (by IP address).
 |https://github.com/elastic/integrations/blob/main/packages/ded/kibana/ml_module/ded-ml.json#L83[image:images/link.svg[A link icon]]
 |https://github.com/elastic/integrations/blob/main/packages/ded/kibana/ml_module/ded-ml.json#L304[image:images/link.svg[A link icon]]
 
-|high-sent-bytes-destination-port
+|ded_high_sent_bytes_destination_port
 |Detects data exfiltration to an unusual destination port.
 |https://github.com/elastic/integrations/blob/main/packages/ded/kibana/ml_module/ded-ml.json#L119[image:images/link.svg[A link icon]]
 |https://github.com/elastic/integrations/blob/main/packages/ded/kibana/ml_module/ded-ml.json#L304[image:images/link.svg[A link icon]]
 
-|high-sent-bytes-destination-region_name
+|ded_high_sent_bytes_destination_region_name
 |Detects data exfiltration to an unusual geo-location (by region name).
 |https://github.com/elastic/integrations/blob/main/packages/ded/kibana/ml_module/ded-ml.json#L156[image:images/link.svg[A link icon]]
 |https://github.com/elastic/integrations/blob/main/packages/ded/kibana/ml_module/ded-ml.json#L304[image:images/link.svg[A link icon]]
 
-|high-bytes-written-to-external-device
+|ded_high_bytes_written_to_external_device
 |Detects data exfiltration activity by identifying high bytes written to an external device.
 |https://github.com/elastic/integrations/blob/main/packages/ded/kibana/ml_module/ded-ml.json#L194[image:images/link.svg[A link icon]]
 |https://github.com/elastic/integrations/blob/main/packages/ded/kibana/ml_module/ded-ml.json#L304[image:images/link.svg[A link icon]]
 
-|rare-process-writing-to-external-device
+|ded_rare_process_writing_to_external_device
 |Detects data exfiltration activity by identifying a file write started by a rare process to an external device.
 |https://github.com/elastic/integrations/blob/main/packages/ded/kibana/ml_module/ded-ml.json#L231[image:images/link.svg[A link icon]]
 |https://github.com/elastic/integrations/blob/main/packages/ded/kibana/ml_module/ded-ml.json#L304[image:images/link.svg[A link icon]]
 
-|high-bytes-written-to-external-device-airdrop
+|ded_high_bytes_written_to_external_device_airdrop
 |Detects data exfiltration activity by identifying high bytes written to an external device via Airdrop.
 |https://github.com/elastic/integrations/blob/main/packages/ded/kibana/ml_module/ded-ml.json#L268[image:images/link.svg[A link icon]]
 |https://github.com/elastic/integrations/blob/main/packages/ded/kibana/ml_module/ded-ml.json#L304[image:images/link.svg[A link icon]]
@@ -518,57 +518,57 @@ To download, refer to the https://docs.elastic.co/integrations/lmd[documentation
 |===
 |Name |Description |Job |Datafeed
 
-|high-count-remote-file-transfer
+|lmd_high_count_remote_file_transfer
 |Detects unusually high file transfers to a remote host in the network.
 |https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json#L24[image:images/link.svg[A link icon]]
 |https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json#L436[image:images/link.svg[A link icon]]
 
-|high-file-size-remote-file-transfer
+|lmd_high_file_size_remote_file_transfer
 |Detects unusually high size of files shared with a remote host in the network.
 |https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json#L58[image:images/link.svg[A link icon]]
 |https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json#L436[image:images/link.svg[A link icon]]
 
-|rare-file-extension-remote-transfer
+|lmd_rare_file_extension_remote_transfer
 |Detects data exfiltration to an unusual destination port.
 |https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json#L92[image:images/link.svg[A link icon]]
 |https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json#L436[image:images/link.svg[A link icon]]
 
-|rare-file-path-remote-transfer
+|lmd_rare_file_path_remote_transfer
 |Detects unusual folders and directories on which a file is transferred.
 |https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json#L126[image:images/link.svg[A link icon]]
 |https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json#L436[image:images/link.svg[A link icon]]
 
-|high-mean-rdp-session-duration
+|lmd_high_mean_rdp_session_duration
 |Detects unusually high mean of RDP session duration.
 |https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json#L160[image:images/link.svg[A link icon]]
 |https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json#L436[image:images/link.svg[A link icon]]
 
-|high-var-rdp-session-duration
+|lmd_high_var_rdp_session_duration
 |Detects unusually high variance in RDP session duration.
 |https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json#L202[image:images/link.svg[A link icon]]
 |https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json#L436[image:images/link.svg[A link icon]]
 
-|high-sum-rdp-number-of-processes
+|lmd_high_sum_rdp_number_of_processes
 |Detects unusually high number of processes started in a single RDP session.
 |https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json#L244[image:images/link.svg[A link icon]]
 |https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json#L436[image:images/link.svg[A link icon]]
 
-|unusual-time-weekday-rdp-session-start
+|lmd_unusual_time_weekday_rdp_session_start
 |Detects an RDP session started at an usual time or weekday.
 |https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json#L286[image:images/link.svg[A link icon]]
 |https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json#L436[image:images/link.svg[A link icon]]
 
-|high-rdp-distinct-count-source-ip-for-destination
+|lmd_high_rdp_distinct_count_source_ip_for_destination
 |Detects a high count of source IPs making an RDP connection with a single destination IP.
 |https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json#L326[image:images/link.svg[A link icon]]
 |https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json#L436[image:images/link.svg[A link icon]]
 
-|high-rdp-distinct-count-destination-ip-for-source
+|lmd_high_rdp_distinct_count_destination_ip_for_source
 |Detects a high count of destination IPs establishing an RDP connection with a single source IP.
 |https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json#L360[image:images/link.svg[A link icon]]
 |https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json#L436[image:images/link.svg[A link icon]]
 
-|high-mean-rdp-process-args
+|lmd_high_mean_rdp_process_args
 |Detects unusually high number of process arguments in an RDP session.
 |https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json#L394[image:images/link.svg[A link icon]]
 |https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json#L436[image:images/link.svg[A link icon]]


### PR DESCRIPTION
## Overview

Related to https://github.com/elastic/stack-docs/issues/2562.

This PR:
* removes the Job and Datafeed columns from the tables under `Security: Elastic integrations` section. Reason: Updates to integration packages are frequent and hard to maintain the URLs.
* adds a link to the job and datafeed config files after each table.

Scope: `8.9` and above.

### Source of information

* [Domain Generation Algorithm Detection](https://github.com/elastic/integrations/blob/main/packages/dga/kibana/ml_module/dga-ml.json#L21)
* [Living off the Land Detection](https://github.com/elastic/integrations/blob/main/packages/problemchild/kibana/ml_module/problemchild-ml.json#L27)
* [Data Exfiltration Detection](https://github.com/elastic/integrations/blob/main/packages/ded/kibana/ml_module/ded-ml.json#L42)
* [Lateral Movement Detection](https://github.com/elastic/integrations/blob/main/packages/lmd/kibana/ml_module/lmd-ml.json#L22)