### PR TITLE
[DOCS] Documents that models with one allocation might have downtime

### DIFF
--- a/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
@@ -198,6 +198,11 @@ nodes. Model allocations are independent units of work for NLP tasks. To
 influence model performance, you can configure the number of allocations and the 
 number of threads used by each allocation of your deployment.
 
+IMPORTANT: If your deployed trained model only has one allocation, it's very 
+likely that you will experience some downtime in the service your trained model 
+performs. You can reduce or eliminate downtime by adding more allocations to 
+your trained models.
+
 Throughput can be scaled by adding more allocations to the deployment; it 
 increases the number of {infer} requests that can be performed in parallel. All 
 allocations assigned to a node share the same copy of the model in memory. The 

--- a/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
@@ -198,10 +198,10 @@ nodes. Model allocations are independent units of work for NLP tasks. To
 influence model performance, you can configure the number of allocations and the 
 number of threads used by each allocation of your deployment.
 
-IMPORTANT: If your deployed trained model only has one allocation, it's very 
-likely that you will experience some downtime in the service your trained model 
-performs. You can reduce or eliminate downtime by adding more allocations to 
-your trained models.
+IMPORTANT: If your deployed trained model has only one allocation, it's likely 
+that you will experience downtime in the service your trained model performs. 
+You can reduce or eliminate downtime by adding more allocations to your trained 
+models.
 
 Throughput can be scaled by adding more allocations to the deployment; it 
 increases the number of {infer} requests that can be performed in parallel. All 


### PR DESCRIPTION
## Overview

This PR adds an `IMPORTANT` block to the trained model deployment section that explains that users will experience downtime in the service of their trained model if the model has only one allocation deployed. 

### Preview

[Deploy the model to your cluster](https://stack-docs_2567.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-nlp-deploy-model.html#ml-nlp-deploy-model)