### PR TITLE
Adds note on ELSER V2 is GA and V1 is in preview

### DIFF
--- a/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
@@ -9,8 +9,6 @@
 :frontmatter-tags-content-type: [how-to] 
 :frontmatter-tags-user-goals: [analyze]
 
-experimental[]
-
 Elastic Learned Sparse EncodeR - or ELSER - is a retrieval model trained by 
 Elastic that enables you to perform 
 {ref}/semantic-search-elser.html[semantic search] to retrieve more relevant 
@@ -19,6 +17,9 @@ meaning and user intent, rather than exact keyword matches.
 
 ELSER is an out-of-domain model which means it does not require fine-tuning on 
 your own data, making it adaptable for various use cases out of the box.
+
+IMPORTANT: While ELSER V2 is generally available, ELSER V1 is in experimental:[]
+and will remain in technical preview.
 
 
 [discrete]


### PR DESCRIPTION
## Overview

This PR adds an `IMPORTANT` note about the fact that ELSER V2 is generally available while ELSER V1 is in (and will be in) technical preview.

### Preview

[ELSER](https://stack-docs_2581.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-nlp-elser.html)