### PR TITLE
Add link to ELSER v2 upgrade notebook

### DIFF
--- a/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
@@ -89,10 +89,11 @@ use v2 for search. This {ref}/semantic-search-elser.html[tutorial] shows you how
 to create an ingest pipeline with an {infer} processor that uses ELSER v2, and 
 how to reindex your data through the pipeline.
 
+Additionally, the `elasticearch-labs` GitHub repository contains an interactive https://github.com/elastic/elasticsearch-labs/blob/main/notebooks/model-upgrades/upgrading-index-to-use-elser.ipynb[Python notebook] that walks through upgrading an index to ELSER v2.
+
 // TO DO
 // If you want to learn more about the ELSER v2 improvements, refer to this blog 
 // post.
-
 
 [discrete]
 [[download-deploy-elser]]


### PR DESCRIPTION
The Search Experiences team created a notebook for upgrading to v2. We could add a link here. :)