### PR TITLE
Updates the dense vector mappings in text embedding NLP example

### DIFF
--- a/docs/en/stack/ml/nlp/ml-nlp-text-emb-vector-search-example.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-text-emb-vector-search-example.asciidoc
@@ -210,9 +210,7 @@ PUT collection-with-embeddings
     "properties": {
       "text_embedding.predicted_value": {
         "type": "dense_vector",
-        "dims": 384,
-        "index": true,
-        "similarity": "cosine"
+        "dims": 384
       },
       "text": {
         "type": "text"


### PR DESCRIPTION
## Overview

In 8.11 the `dense vector` field type has been simplified and some of the settings now have sensible default values:
* `"index": true` is implicit,
* `similarity` defaults to `cosine`.

This PR adjusts the dense vector mapping example in the text embedding NLP example to reflect the changes mentioned above.

### Preview

* [Text embedding example](https://stack-docs_2593.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-nlp-text-emb-vector-search-example.html#ex-text-emb-ingest)