### PR TITLE
Adds Search Lab links to the ML book

### DIFF
--- a/docs/en/stack/ml/index-custom-title-page.html
+++ b/docs/en/stack/ml/index-custom-title-page.html
@@ -157,6 +157,9 @@
       <li>
         <a href="ml-nlp-examples.html">Examples</a>
       </li>
+      <li>
+        <a href="https://www.elastic.co/search-labs/tutorials/search-tutorial/welcome">Search Labs tutorial</a>
+      </li>
     </ul>
   </div>
 
@@ -180,6 +183,9 @@
       <li>
         <a href="ml-functions.html">Anomaly detection function reference</a>
       </li>
+      <li>
+        <a href="https://www.elastic.co/search-labs">Search Labs</a>
+      </li>
     </ul>
   </div>
 
@@ -187,7 +193,7 @@
 
   <div class="row my-4">
     <div class="col-md-4 col-12 mb-2">
-      <a class="no-text-decoration" href="https://www.elastic.co/guide/en/enterprise-search/current/start.html">
+      <a class="no-text-decoration" href="https://www.elastic.co/search-labs">
         <div class="card h-100">
           <h4 class="mt-3">
             <span class="inline-block float-left icon mr-2" style="background-image: url('https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/blt11200907c1c033aa/634d9da119d8652169cf9b2b/enterprise-search-logo-color-32px.png');"></span>

--- a/docs/en/stack/ml/nlp/ml-nlp-examples.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-examples.asciidoc
@@ -4,5 +4,6 @@
 The following pages contain end-to-end examples of how to use the different 
 {nlp} tasks in the {stack}.
 
+* https://colab.research.google.com/github/elastic/elasticsearch-labs/blob/main/notebooks/search/04-multilingual.ipynb[Multilingual semantic search - notebook example]
 * <<ml-nlp-ner-example>>
 * <<ml-nlp-text-emb-vector-search-example>>

--- a/docs/en/stack/ml/nlp/ml-nlp-overview.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-overview.asciidoc
@@ -32,6 +32,7 @@ data. You can perform the following NLP operations:
 * <<ml-nlp-classify-text>> 
 * <<ml-nlp-search-compare>>
 
+
 To delve deeper into Elastic's {ml} research and development, eplore the
 https://www.elastic.co/search-labs/blog/categories/ml-research[ML research]
 section within Search Labs.

--- a/docs/en/stack/ml/nlp/ml-nlp-overview.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-overview.asciidoc
@@ -32,7 +32,6 @@ data. You can perform the following NLP operations:
 * <<ml-nlp-classify-text>> 
 * <<ml-nlp-search-compare>>
 
-
 To delve deeper into Elastic's {ml} research and development, eplore the
 https://www.elastic.co/search-labs/blog/categories/ml-research[ML research]
 section within Search Labs.

--- a/docs/en/stack/ml/nlp/ml-nlp-overview.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-overview.asciidoc
@@ -30,5 +30,8 @@ data. You can perform the following NLP operations:
 
 * <<ml-nlp-extract-info>>
 * <<ml-nlp-classify-text>> 
-
 * <<ml-nlp-search-compare>>
+
+To delve deeper into Elastic's {ml} research and development, eplore the
+https://www.elastic.co/search-labs/blog/categories/ml-research[ML research]
+section within Search Labs.


### PR DESCRIPTION
## Overview

This PR:
* changes the link of the "Search my data" title on the landing page to point to Search Labs,
* adds a link to the *APIs and developer docs* section on the landing page that points to the Search Labs,
* adds a link to the *Analyze natural language data* section on the landing page that points to Search Labs tutorials,
* adds a link to the NLP examples section that points to the multilingual semantic search notebook,
* adds a link to the overview page that points to the ML research section of the Search Labs.