### PR TITLE
Add Elastic Agent to stack installation instructions

### DIFF
--- a/docs/en/install-upgrade/installing-stack.asciidoc
+++ b/docs/en/install-upgrade/installing-stack.asciidoc
@@ -61,7 +61,7 @@ Install the Elastic Stack products you want to use in the following order:
 . Elasticsearch ({ref}/install-elasticsearch.html[install instructions])
 . Kibana ({kibana-ref}/install.html[install])
 . Logstash ({logstash-ref}/installing-logstash.html[install])
-. Beats ({beats-ref}/getting-started.html[install instructions])
+. Elastic Agent ({fleet-guide}/elastic-agent-installation.html[install instructions]) or Beats ({beats-ref}/getting-started.html[install instructions])
 . APM ({apm-guide-ref}/apm-quick-start.html[install instructions])
 . Elasticsearch Hadoop ({hadoop-ref}/install.html[install instructions])
 


### PR DESCRIPTION
When reviewing our new landing page design, I noticed that Elastic Agent is completely missing from this list. 

I'm not sure why we are hard coding the product names, but decided to leave this as-is in case there is a reason.

@kilfoyle I hope I am not overstepping, but opening a PR was faster than creating an issue. :-) 