### PR TITLE
Edit github workflow for documentation previews

### DIFF
--- a/.github/workflows/docs-preview-links.yml
+++ b/.github/workflows/docs-preview-links.yml
@@ -1,26 +1,19 @@
-name: Docs Preview Links
+name: docs-preview
 
 on:
   pull_request_target:
     types: [opened]
-    paths:
-      - '**.asciidoc'
+
+permissions:
+  pull-requests: write
 
 jobs:
-  doc-preview:
+  doc-preview-pr:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v6
-        name: Add doc preview links
+      - uses: elastic/docs/.github/actions/docs-preview@master
         with:
-          script: |
-            const pr = context.payload.pull_request;
-            const comment = `Documentation preview:
-              - ✨ [Changed pages](https://${context.repo.repo}_${pr.number}.docs-preview.app.elstc.co/diff)`;
-            
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: comment,
-            });
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          repo: ${{ github.event.repository.name }}
+          preview-path: 'guide/index.html'
+          pr: ${{ github.event.pull_request.number }}

--- a/.github/workflows/docs-preview-links.yml
+++ b/.github/workflows/docs-preview-links.yml
@@ -3,7 +3,8 @@ name: docs-preview
 on:
   pull_request_target:
     types: [opened]
-
+    paths:
+      - '**.asciidoc'
 permissions:
   pull-requests: write
 


### PR DESCRIPTION
Relates to https://github.com/elastic/docs/pull/2848

Since this repo is used to generate multiple books, I set the `preview-path` to the top-level landing page instead of a particular book.

It seems that this change will need to be backported all the way to 8.4.