### PR TITLE
[DOCS] Adds E5 terms of use to docs

### DIFF
--- a/docs/en/stack/ml/nlp/ml-nlp-e5.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-e5.asciidoc
@@ -157,3 +157,14 @@ POST _ml/trained_models/.multilingual-e5-small/deployment/_start?deployment_id=f
 If you want to deploy the E5 model in a restricted or closed network, follow the 
 instructions 
 https://www.elastic.co/guide/en/elasticsearch/client/eland/current/machine-learning.html#ml-nlp-pytorch-air-gapped[in the Eland client documentation].
+
+
+[discrete]
+[[terms-of-use-e5]]
+== Terms of use
+
+Customers may add third party trained models for management in Elastic. These 
+models are not owned by Elastic. Customers must contract separately with the 
+third party model owner for the use of the model, and such use will be governed 
+by the applicable terms and conditions. You understand and agree that Elastic 
+has no control over, or liability for, the third party models.


### PR DESCRIPTION
## Overview

This PR adds legal blurb to the end of the E5 model conceptual documentation page.


### Preview

[Terms of use](https://stack-docs_2622.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-nlp-e5.html#terms-of-use-e5)