### PR TITLE
Adds reference to E5 model in ELSER docs

### DIFF
--- a/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
@@ -18,6 +18,10 @@ meaning and user intent, rather than exact keyword matches.
 ELSER is an out-of-domain model which means it does not require fine-tuning on 
 your own data, making it adaptable for various use cases out of the box.
 
+This model is recommended for English language documents and queries. If you 
+want to perform semantic search on non-English language documents, use the 
+<<ml-nlp-e5>> model.
+
 IMPORTANT: While ELSER V2 is generally available, ELSER V1 is in experimental:[]
 and will remain in technical preview.
 


### PR DESCRIPTION
## Overview

This PR adds a note to the ELSER docs that ELSER is an English language model, so if the user would like to perform semantic search on non-English documents, use E5 instead.

### Preview

[ELSER](https://stack-docs_2624.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-nlp-elser.html)