### PR TITLE
[8.8] Revert "docs: temp comment out include (#2626)"

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -33,7 +33,7 @@ Upgrade Assistant provides information about which {dfeeds} need to be updated.
 This list summarizes the most important breaking changes in APM.
 For the complete list, go to {apm-guide-ref}/apm-breaking.html[APM breaking changes].
 
-// include::{apm-repo-dir}/apm-breaking.asciidoc[tag=notable-v8-breaking-changes]
+include::{apm-repo-dir}/apm-breaking.asciidoc[tag=notable-v8-breaking-changes]
 
 [[beats-breaking-changes]]
 === Beats breaking changes
@@ -69,7 +69,7 @@ the complete list, go to {ref}/breaking-changes.html[{es} breaking changes].
 This list summarizes the most important breaking changes in {elastic-sec} {version}. For
 the complete list, go to {security-guide-all}/8.8/release-notes-header-8.8.0.html#breaking-changes-8.8.2[{elastic-sec} breaking changes].
 
-include::{security-repo-dir}/release-notes/8.8.asciidoc[tag=breaking-changes]
+include::{security-repo-dir}/release-notes/8.8.asciidoc[tag=breaking-changes] 
 
 [[kibana-breaking-changes]]
 === {kib} breaking changes

--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -33,7 +33,7 @@ Upgrade Assistant provides information about which {dfeeds} need to be updated.
 This list summarizes the most important breaking changes in APM.
 For the complete list, go to {apm-guide-ref}/apm-breaking.html[APM breaking changes].
 
-include::{apm-repo-dir}/apm-breaking.asciidoc[tag=notable-v8-breaking-changes]
+No notable breaking changes.
 
 [[beats-breaking-changes]]
 === Beats breaking changes

--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -33,7 +33,7 @@ Upgrade Assistant provides information about which {dfeeds} need to be updated.
 This list summarizes the most important breaking changes in APM.
 For the complete list, go to {apm-guide-ref}/apm-breaking.html[APM breaking changes].
 
-No notable breaking changes.
+There are no breaking changes in APM.
 
 [[beats-breaking-changes]]
 === Beats breaking changes


### PR DESCRIPTION
This reverts commit 413a91f502c4d6fda5c5f841d86e72f3fb039de6.