### PR TITLE
[8.6] Revert "docs: temp comment out include (#2626)"

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -33,7 +33,7 @@ Upgrade Assistant provides information about which {dfeeds} need to be updated.
 This list summarizes the most important breaking changes in APM.
 For the complete list, go to {apm-guide-ref}/apm-breaking.html[APM breaking changes].
 
-// include::{apm-repo-dir}/apm-breaking.asciidoc[tag=notable-v8-breaking-changes]
+include::{apm-repo-dir}/apm-breaking.asciidoc[tag=notable-v8-breaking-changes]
 
 [[beats-breaking-changes]]
 === Beats breaking changes

--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -33,7 +33,7 @@ Upgrade Assistant provides information about which {dfeeds} need to be updated.
 This list summarizes the most important breaking changes in APM.
 For the complete list, go to {apm-guide-ref}/apm-breaking.html[APM breaking changes].
 
-include::{apm-repo-dir}/apm-breaking.asciidoc[tag=notable-v8-breaking-changes]
+include::{apm-repo-dir}/all-breaking-changes.asciidoc[tag=notable-v8-breaking-changes]
 
 [[beats-breaking-changes]]
 === Beats breaking changes

--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -33,7 +33,7 @@ Upgrade Assistant provides information about which {dfeeds} need to be updated.
 This list summarizes the most important breaking changes in APM.
 For the complete list, go to {apm-guide-ref}/apm-breaking.html[APM breaking changes].
 
-include::{apm-repo-dir}/all-breaking-changes.asciidoc[tag=notable-v8-breaking-changes]
+include::{apm-repo-dir}/all-breaking-changes.asciidoc[tag=86-bc]
 
 [[beats-breaking-changes]]
 === Beats breaking changes


### PR DESCRIPTION
This reverts commit 66f0fbf096469d4547ba270d6765c43ff56af23e.