### PR TITLE
[8.5] Revert "docs: temp comment out include (#2629)"

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -33,7 +33,7 @@ Upgrade Assistant provides information about which {dfeeds} need to be updated.
 This list summarizes the most important breaking changes in APM.
 For the complete list, go to {apm-guide-ref}/apm-breaking.html[APM breaking changes].
 
-include::{apm-repo-dir}/all-breaking-changes.asciidoc[tag=notable-v8-breaking-changes]
+There are no breaking changes in APM.
 
 [[beats-breaking-changes]]
 === Beats breaking changes

--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -33,7 +33,7 @@ Upgrade Assistant provides information about which {dfeeds} need to be updated.
 This list summarizes the most important breaking changes in APM.
 For the complete list, go to {apm-guide-ref}/apm-breaking.html[APM breaking changes].
 
-// include::{apm-repo-dir}/apm-breaking.asciidoc[tag=notable-v8-breaking-changes]
+include::{apm-repo-dir}/apm-breaking.asciidoc[tag=notable-v8-breaking-changes]
 
 [[beats-breaking-changes]]
 === Beats breaking changes

--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -33,7 +33,7 @@ Upgrade Assistant provides information about which {dfeeds} need to be updated.
 This list summarizes the most important breaking changes in APM.
 For the complete list, go to {apm-guide-ref}/apm-breaking.html[APM breaking changes].
 
-include::{apm-repo-dir}/apm-breaking.asciidoc[tag=notable-v8-breaking-changes]
+include::{apm-repo-dir}/all-breaking-changes.asciidoc[tag=notable-v8-breaking-changes]
 
 [[beats-breaking-changes]]
 === Beats breaking changes


### PR DESCRIPTION
This reverts commit ba72bddef3684a3d7e1451d78de51680d6a2b6d6.