### PR TITLE
[8.2] Revert "docs: temp comment out include (#2631)"

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -33,7 +33,7 @@ Upgrade Assistant provides information about which {dfeeds} need to be updated.
 This list summarizes the most important breaking changes in APM.
 For the complete list, go to {apm-guide-ref}/apm-breaking.html[APM breaking changes].
 
-include::{apm-repo-dir}/apm-breaking.asciidoc[tag=82-bc]
+include::{apm-repo-dir}/all-breaking-changes.asciidoc[tag=82-bc]
 
 [[beats-breaking-changes]]
 === Beats breaking changes

--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -33,7 +33,7 @@ Upgrade Assistant provides information about which {dfeeds} need to be updated.
 This list summarizes the most important breaking changes in APM.
 For the complete list, go to {apm-guide-ref}/apm-breaking.html[APM breaking changes].
 
-// include::{apm-repo-dir}/apm-breaking.asciidoc[tag=82-bc]
+include::{apm-repo-dir}/apm-breaking.asciidoc[tag=82-bc]
 
 [[beats-breaking-changes]]
 === Beats breaking changes


### PR DESCRIPTION
This reverts commit d16f81b58322845ec61476569c00caa98f4debb0.