### PR TITLE
[8.0] Revert "docs: temp comment out include (#2634)"

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -34,7 +34,7 @@ Upgrade Assistant provides information about which {dfeeds} need to be updated.
 This list summarizes the most important breaking changes in APM.
 For the complete list, go to {apm-guide-ref}/apm-breaking.html[APM breaking changes].
 
-include::{apm-repo-dir}/apm-breaking.asciidoc[tag=80-bc]
+include::{apm-repo-dir}/all-breaking-changes.asciidoc[tag=80-bc]
 
 [[beats-breaking-changes]]
 === Beats breaking changes

--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -34,7 +34,7 @@ Upgrade Assistant provides information about which {dfeeds} need to be updated.
 This list summarizes the most important breaking changes in APM.
 For the complete list, go to {apm-guide-ref}/apm-breaking.html[APM breaking changes].
 
-// include::{apm-repo-dir}/apm-breaking.asciidoc[tag=80-bc]
+include::{apm-repo-dir}/apm-breaking.asciidoc[tag=80-bc]
 
 [[beats-breaking-changes]]
 === Beats breaking changes


### PR DESCRIPTION
This reverts commit 2291f0671e7710be594ed177989f58cb71a41673.