### PR TITLE
[7.17] Revert "docs: temp comment out include (#2635)"

### DIFF
--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -31,7 +31,7 @@ Upgrade Assistant provides information about which {dfeeds} need to be updated.
 This list summarizes the most important breaking changes in APM.
 For the complete list, go to {apm-guide-ref}/apm-breaking.html[APM breaking changes].
 
-include::{apm-repo-dir}/apm-breaking.asciidoc[tag=717-bc]
+include::{apm-repo-dir}/all-breaking-changes.asciidoc[tag=717-bc]
 
 [[beats-breaking-changes]]
 === Beats breaking changes

--- a/docs/en/install-upgrade/breaking.asciidoc
+++ b/docs/en/install-upgrade/breaking.asciidoc
@@ -31,7 +31,7 @@ Upgrade Assistant provides information about which {dfeeds} need to be updated.
 This list summarizes the most important breaking changes in APM.
 For the complete list, go to {apm-guide-ref}/apm-breaking.html[APM breaking changes].
 
-// include::{apm-repo-dir}/apm-breaking.asciidoc[tag=717-bc]
+include::{apm-repo-dir}/apm-breaking.asciidoc[tag=717-bc]
 
 [[beats-breaking-changes]]
 === Beats breaking changes


### PR DESCRIPTION
This reverts commit 4a3226d0d5af7709bc9b25eb6149ed2e5db3e4e3.