### PR TITLE
Updates model deployment commands using Eland and Docker

### DIFF
--- a/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
@@ -103,11 +103,7 @@ https://www.elastic.co/guide/en/elasticsearch/client/eland/current/machine-learn
 [[ml-nlp-import-docker]]
 === Import with Docker
 
-IMPORTANT: To use the Docker container, you need to clone the Eland repository: 
-https://github.com/elastic/eland
-
-If you want to use Eland without installing it, clone the Eland repository and 
-from the root directory run the following command:
+If you want to use Eland without installing it, run the following command:
 
 ```bash
 $ docker run -it --rm --network host docker.elastic.co/eland/eland

--- a/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
@@ -85,7 +85,7 @@ eland_import_hub_model
 --cloud-id <cloud-id> \ <1>
 -u <username> -p <password> \ <2>
 --hub-model-id elastic/distilbert-base-cased-finetuned-conll03-english \ <3>
---task-type ner \ <4>
+--task-type ner  <4>
 --------------------------------------------------
 // NOTCONSOLE
 --
@@ -107,16 +107,10 @@ IMPORTANT: To use the Docker container, you need to clone the Eland repository:
 https://github.com/elastic/eland
 
 If you want to use Eland without installing it, clone the Eland repository and 
-from the root directory run the following to build the Docker image:
+from the root directory run the following command:
 
 ```bash
-$ docker build -t elastic/eland .
-```
-
-You can now use the container interactively:
-
-```bash
-$ docker run -it --rm --network host elastic/eland
+$ docker run -it --rm --network host docker.elastic.co/eland/eland
 ```
 
 The `eland_import_hub_model` script can be run directly in the docker command:


### PR DESCRIPTION
## Overview

This PR updates the commands on the `Deploy trained models` page based on the latest Eland repo [README](https://github.com/elastic/eland#docker).