### PR TITLE
Renames Terms of Use section to Disclaimer in E5 docs

### DIFF
--- a/docs/en/stack/ml/nlp/ml-nlp-e5.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-e5.asciidoc
@@ -161,7 +161,7 @@ https://www.elastic.co/guide/en/elasticsearch/client/eland/current/machine-learn
 
 [discrete]
 [[terms-of-use-e5]]
-== Terms of use
+== Disclaimer
 
 Customers may add third party trained models for management in Elastic. These 
 models are not owned by Elastic. Customers must contract separately with the 


### PR DESCRIPTION
## Overview

As title states.