### PR TITLE
[DOCS] Adds air-gapped install instructions to E5 docs

### DIFF
--- a/docs/en/stack/ml/index-custom-title-page.html
+++ b/docs/en/stack/ml/index-custom-title-page.html
@@ -152,6 +152,9 @@
         <a href="ml-nlp-elser.html">ELSER - Elastic Learned Sparse EncodeR</a>
       </li>
       <li>
+        <a href="ml-nlp-e5.html">E5</a>
+      </li>
+      <li>
         <a href="ml-nlp-model-ref.html">Supported third-party models</a>
       </li>
       <li>

--- a/docs/en/stack/ml/nlp/ml-nlp-e5.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-e5.asciidoc
@@ -155,8 +155,72 @@ POST _ml/trained_models/.multilingual-e5-small/deployment/_start?deployment_id=f
 [[air-gapped-install-e5]]
 == Deploy the E5 model in an air-gapped environment
 
-You can install the E5 model in a restricted or closed network by pointing the 
-`eland_import_hub_model` script to the model's local files.
+If you want to install E5 in an air-gapped environment, you have the following 
+options:
+* put the model artifacts into a directory inside the config directory on all 
+master-eligible nodes (for `multilingual-e5-small` and
+`multilingual-e5-small-optimized`)
+* install the model by using HuggingFace (for `multilingual-e5-small` model 
+only).
+
+
+[discrete]
+[[e5-model-artifacts]]
+=== Model artifact files
+
+For the `multilingual-e5-small` model, you need the following files in your
+system:
+```
+https://ml-models.elastic.co/multilingual-e5-small.metadata.json
+https://ml-models.elastic.co/multilingual-e5-small.pt
+https://ml-models.elastic.co/multilingual-e5-small.vocab.json
+```
+
+For the optimized version, you need the following files in your system:
+```
+https://ml-models.elastic.co/multilingual-e5-small-optimized.metadata.json
+https://ml-models.elastic.co/multilingual-e5-small-optimized.pt
+https://ml-models.elastic.co/multilingual-e5-small-optimized.vocab.json
+```
+
+
+[discrete]
+=== Using file-based access
+
+For a file-based access, follow these steps:
+
+. Download the <<e5-model-artifacts,model artifact files>>. 
+. Put the files into a `models` subdirectory inside the `config` directory of 
+your {es} deployment.
+. Point your {es} deployment to the model directory by adding the following line
+to the `config/elasticsearch.yml` file:
++
+--
+```
+xpack.ml.model_repository: file://${path.home}/config/models/`
+```
+--
+. Repeat step 2 and step 3 on all master-eligible nodes.
+. {ref}/restart-cluster.html#restart-cluster-rolling[Restart] the 
+master-eligible nodes one by one.
+. Navigate to the **Trained Models** page in {kib}, E5 can be found in the 
+list of trained models.
+. Click the **Add trained model** button, select the E5 model version you 
+downloaded in step 1 and want to deploy and click **Download**. The selected 
+model will be downloaded from the model directory where you put in step 2.
+. After the download is finished, start the deployment by clicking the 
+**Start deployment** button.
+. Provide a deployment ID, select the priority, and set the number of 
+allocations and threads per allocation values.
+. Click **Start**.
+
+
+[discrete]
+=== Using the HuggingFace repository
+
+You can install the `multilingual-e5-small` model in a restricted or closed
+network by pointing the `eland_import_hub_model` script to the model's local
+files.
 
 For an offline install, the model first needs to be cloned locally, Git and 
 https://git-lfs.com/[Git Large File Storage] are required to be installed in 

--- a/docs/en/stack/ml/nlp/ml-nlp-e5.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-e5.asciidoc
@@ -150,6 +150,7 @@ POST _ml/trained_models/.multilingual-e5-small/deployment/_start?deployment_id=f
 ----------------------------------
 --
 
+
 [discrete]
 [[air-gapped-install-e5]]
 == Deploy the E5 model in an air-gapped environment
@@ -164,27 +165,18 @@ your system.
 1. Clone the E5 model from Hugging Face by using the model URL. 
 +
 --
-Use this command for `multilingual-e5-small`:
 [source,bash]
 ----
 git clone https://huggingface.co/elastic/multilingual-e5-small
 ----
-
-Use this command for `multilingual-e5-small-optimized`:
-[source,bash]
-----
-git clone https://huggingface.co/elastic/multilingual-e5-small-optimized
-----
-Both commands result in a local copy of the respective model in the directory 
-named after the model: `multilingual-e5-small` or 
-`multilingual-e5-small-optimized`.
+The command results in a local copy of the model in the `multilingual-e5-small`
+directory.
 --
 
 2. Use the `eland_import_hub_model` script with the `--hub-model-id` set to the 
 directory of the cloned model to install it:
 +
 --
-For `multilingual-e5-small`:
 [source,bash]
 ----
 eland_import_hub_model \
@@ -195,20 +187,8 @@ eland_import_hub_model \
       --es-model-id multilingual-e5-small
 ----
 
-For `multilingual-e5-small-optimized`:
-[source,bash]
-----
-eland_import_hub_model \
-      --url 'XXXX' \
-      --hub-model-id /PATH/TO/MODEL \
-      --task-type text_embedding \
-      --es-username elastic --es-password XXX \
-      --es-model-id multilingual-e5-small-optimized
-----
-
 If you use the Docker image to run `eland_import_hub_model` you must bind mount 
 the model directory, so the container can read the files.
-For `multilingual-e5-small` run the following:
 [source,bash]
 ----
 docker run --mount type=bind,source=/PATH/TO/MODELS,destination=/models,readonly -it --rm docker.elastic.co/eland/eland \
@@ -219,25 +199,11 @@ docker run --mount type=bind,source=/PATH/TO/MODELS,destination=/models,readonly
       --es-username elastic --es-password XXX \
       --es-model-id multilingual-e5-small
 ----
-
-For `multilingual-e5-small-optimized` run the following:
-[source,bash]
-----
-docker run --mount type=bind,source=/PATH/TO/MODELS,destination=/models,readonly -it --rm docker.elastic.co/eland/eland \
-    eland_import_hub_model \
-      --url 'XXXX' \
-      --hub-model-id /models/multilingual-e5-small-optimized \
-      --task-type text_embedding \
-      --es-username elastic --es-password XXX \
-      --es-model-id multilingual-e5-small-optimized
-----
-
 Once it's uploaded to {es}, the model will have the ID specified by 
 `--es-model-id`. If it is not set, the model ID is derived from 
 `--hub-model-id`; spaces and path delimiters are converted to double 
 underscores `__`.
 --
-
 
 
 [discrete]

--- a/docs/en/stack/ml/nlp/ml-nlp-e5.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-e5.asciidoc
@@ -154,9 +154,90 @@ POST _ml/trained_models/.multilingual-e5-small/deployment/_start?deployment_id=f
 [[air-gapped-install-e5]]
 == Deploy the E5 model in an air-gapped environment
 
-If you want to deploy the E5 model in a restricted or closed network, follow the 
-instructions 
-https://www.elastic.co/guide/en/elasticsearch/client/eland/current/machine-learning.html#ml-nlp-pytorch-air-gapped[in the Eland client documentation].
+You can install the E5 model in a restricted or closed network by pointing the 
+`eland_import_hub_model` script to the model's local files.
+
+For an offline install, the model first needs to be cloned locally, Git and 
+https://git-lfs.com/[Git Large File Storage] are required to be installed in 
+your system.
+
+1. Clone the E5 model from Hugging Face by using the model URL. 
++
+--
+Use this command for `multilingual-e5-small`:
+[source,bash]
+----
+git clone https://huggingface.co/elastic/multilingual-e5-small
+----
+
+Use this command for `multilingual-e5-small-optimized`:
+[source,bash]
+----
+git clone https://huggingface.co/elastic/multilingual-e5-small-optimized
+----
+Both commands result in a local copy of the respective model in the directory 
+named after the model: `multilingual-e5-small` or 
+`multilingual-e5-small-optimized`.
+--
+
+2. Use the `eland_import_hub_model` script with the `--hub-model-id` set to the 
+directory of the cloned model to install it:
++
+--
+For `multilingual-e5-small`:
+[source,bash]
+----
+eland_import_hub_model \
+      --url 'XXXX' \
+      --hub-model-id /PATH/TO/MODEL \
+      --task-type text_embedding \
+      --es-username elastic --es-password XXX \
+      --es-model-id multilingual-e5-small
+----
+
+For `multilingual-e5-small-optimized`:
+[source,bash]
+----
+eland_import_hub_model \
+      --url 'XXXX' \
+      --hub-model-id /PATH/TO/MODEL \
+      --task-type text_embedding \
+      --es-username elastic --es-password XXX \
+      --es-model-id multilingual-e5-small-optimized
+----
+
+If you use the Docker image to run `eland_import_hub_model` you must bind mount 
+the model directory, so the container can read the files.
+For `multilingual-e5-small` run the following:
+[source,bash]
+----
+docker run --mount type=bind,source=/PATH/TO/MODELS,destination=/models,readonly -it --rm docker.elastic.co/eland/eland \
+    eland_import_hub_model \
+      --url 'XXXX' \
+      --hub-model-id /models/multilingual-e5-small \
+      --task-type text_embedding \
+      --es-username elastic --es-password XXX \
+      --es-model-id multilingual-e5-small
+----
+
+For `multilingual-e5-small-optimized` run the following:
+[source,bash]
+----
+docker run --mount type=bind,source=/PATH/TO/MODELS,destination=/models,readonly -it --rm docker.elastic.co/eland/eland \
+    eland_import_hub_model \
+      --url 'XXXX' \
+      --hub-model-id /models/multilingual-e5-small-optimized \
+      --task-type text_embedding \
+      --es-username elastic --es-password XXX \
+      --es-model-id multilingual-e5-small-optimized
+----
+
+Once it's uploaded to {es}, the model will have the ID specified by 
+`--es-model-id`. If it is not set, the model ID is derived from 
+`--hub-model-id`; spaces and path delimiters are converted to double 
+underscores `__`.
+--
+
 
 
 [discrete]


### PR DESCRIPTION
## Overview

Related issue: https://github.com/elastic/stack-docs/issues/2665
This PR adds air-gapped installation instructions to the E5 model page.
It also references the E5 conceptual docs page on the ML custom landing page.

### Preview

[E5- air-gapped install](https://stack-docs_bk_2666.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-nlp-e5.html#air-gapped-install-e5)
[ML landing page](https://stack-docs_bk_2666.docs-preview.app.elstc.co/guide/en/machine-learning/master/index.html)