### PR TITLE
Add 'what's next' links to install guide

### DIFF
--- a/docs/en/install-upgrade/installing-stack-demo-secure.asciidoc
+++ b/docs/en/install-upgrade/installing-stack-demo-secure.asciidoc
@@ -901,8 +901,7 @@ Congratulations! You've successfully configured security for {es}, {kib}, {fleet
 
 * Do you have data ready to ingest into your newly set up {stack}? Learn how to {cloud}/ec-cloud-ingest-data.html[add data to Elasticsearch].
 
-* Now that data is streaming into the {stack}, take your investigation to a
-deeper level! Use https://www.elastic.co/observability[Elastic {observability}]
+* Use https://www.elastic.co/observability[Elastic {observability}]
 to unify your logs, infrastructure metrics, uptime, and application performance data.
 
 * Want to protect your endpoints from security threats? Try

--- a/docs/en/install-upgrade/installing-stack-demo-secure.asciidoc
+++ b/docs/en/install-upgrade/installing-stack-demo-secure.asciidoc
@@ -896,4 +896,15 @@ image::images/install-stack-metrics-dashboard.png["The System metrics host overv
 
 Congratulations! You've successfully configured security for {es}, {kib}, {fleet}, and {agent} using your own trusted CA-signed certificates.
 
-Now that you're all set up, visit our link:https://www.elastic.co/guide/index.html[Documentation landing page] to learn how to start using your new cluster.
+[discrete]
+== What's next?
+
+* Do you have data ready to ingest into your newly set up {stack}? Learn how to {cloud}/ec-cloud-ingest-data.html[add data to Elasticsearch].
+
+* Now that data is streaming into the {stack}, take your investigation to a
+deeper level! Use https://www.elastic.co/observability[Elastic {observability}]
+to unify your logs, infrastructure metrics, uptime, and application performance data.
+
+* Want to protect your endpoints from security threats? Try
+https://www.elastic.co/security[{elastic-sec}]. Adding endpoint protection is
+just another integration that you add to the agent policy!

--- a/docs/en/install-upgrade/installing-stack-demo-self.asciidoc
+++ b/docs/en/install-upgrade/installing-stack-demo-self.asciidoc
@@ -721,3 +721,14 @@ Congratulations! You've successfully set up a three node {es} cluster, with {kib
 == Next steps
 
 Now that you've successfully configured an on-premises {stack}, you can learn how to configure the {stack} in a production environment using trusted CA-signed certificates. Refer to <<install-stack-demo-secure>> to learn more.
+
+You can also start using your newly set up {stack} right away:
+
+* Do you have data ready to ingest? Learn how to {cloud}/ec-cloud-ingest-data.html[add data to Elasticsearch].
+
+* Use https://www.elastic.co/observability[Elastic {observability}]
+to unify your logs, infrastructure metrics, uptime, and application performance data.
+
+* Want to protect your endpoints from security threats? Try
+https://www.elastic.co/security[{elastic-sec}]. Adding endpoint protection is
+just another integration that you add to the agent policy!


### PR DESCRIPTION
Just a tiny update to add "what's next" links to the on-prem install tutorials.

![Screenshot 2024-04-12 at 11 05 12 AM](https://github.com/elastic/stack-docs/assets/41695641/e48280ec-baba-49ad-bc8a-3dc11f4ca9e5)
