### PR TITLE
Updates legal disclaimer for E5

### DIFF
--- a/docs/en/stack/ml/nlp/ml-nlp-e5.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-e5.asciidoc
@@ -278,4 +278,4 @@ Customers may add third party trained models for management in Elastic. These
 models are not owned by Elastic. While Elastic will support the integration with
 these models in the performance according to the documentation, you understand
 and agree that Elastic has no control over, or liability for, the third party
-models or the underlying training data they may utilize.
+models or the underlying training data they may utilize. 

--- a/docs/en/stack/ml/nlp/ml-nlp-e5.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-e5.asciidoc
@@ -274,8 +274,8 @@ underscores `__`.
 [[terms-of-use-e5]]
 == Disclaimer
 
-Customers may add third party trained models for management in Elastic. These 
-models are not owned by Elastic. Customers must contract separately with the 
-third party model owner for the use of the model, and such use will be governed 
-by the applicable terms and conditions. You understand and agree that Elastic 
-has no control over, or liability for, the third party models.
+Customers may add third party trained models for management in Elastic. These
+models are not owned by Elastic. While Elastic will support the integration with
+these models in the performance according to the documentation, you understand
+and agree that Elastic has no control over, or liability for, the third party
+models or the underlying training data they may utilize.


### PR DESCRIPTION
## Overview

This PR updates the legal disclaimer on the E5 model documentation page. The source of the updated text is the [HuggingFace page of the model](https://huggingface.co/elastic/multilingual-e5-small-optimized#disclaimer).