### PR TITLE
[8.14] Updates legal disclaimer for E5 (#2687)

### DIFF
--- a/docs/en/stack/ml/nlp/ml-nlp-e5.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-e5.asciidoc
@@ -274,8 +274,8 @@ underscores `__`.
 [[terms-of-use-e5]]
 == Disclaimer
 
-Customers may add third party trained models for management in Elastic. These 
-models are not owned by Elastic. Customers must contract separately with the 
-third party model owner for the use of the model, and such use will be governed 
-by the applicable terms and conditions. You understand and agree that Elastic 
-has no control over, or liability for, the third party models.
+Customers may add third party trained models for management in Elastic. These
+models are not owned by Elastic. While Elastic will support the integration with
+these models in the performance according to the documentation, you understand
+and agree that Elastic has no control over, or liability for, the third party
+models or the underlying training data they may utilize. 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.14`:
 - [Updates legal disclaimer for E5 (#2687)](https://github.com/elastic/stack-docs/pull/2687)

<!--- Backport version: 9.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)