### PR TITLE
Adds inference API links to the NLP APIs page

### DIFF
--- a/docs/en/stack/ml/nlp/ml-nlp-apis.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-apis.asciidoc
@@ -26,3 +26,20 @@ All the trained models endpoints have the following base:
 * {ref}/stop-trained-model-deployment.html[Stop trained model deployment]
 // UPDATE
 * {ref}/put-trained-models-aliases.html[Update trained model aliases]
+
+
+You can also integrate NLP models from different providers such as Cohere,
+HuggingFace, or OpenAI and use them as a service through the {infer} API.
+
+The {infer} APIs have the following base:
+
+[source,js]
+----
+/_inference/
+----
+// NOTCONSOLE
+
+* {ref}/put-inference-api.html[Create inference endpoint]
+* {ref}/delete-inference-api.html[Delete inference endpoint]
+* {ref}/get-inference-api.html[Get inference endpoint]
+* {ref}/post-inference-api.html[Perform inference]


### PR DESCRIPTION
## Overview

This PR adds the inference API reference docs pages to the ML NLP API page for better discoverability.