### PR TITLE
Adds important callout about granting ML:all feature privilege to the setup page

### DIFF
--- a/docs/en/stack/ml/setup.asciidoc
+++ b/docs/en/stack/ml/setup.asciidoc
@@ -80,6 +80,12 @@ that contain sensitive information from the source indices to the results.
 [[kib-security]]
 === {kib} security
 
+IMPORTANT: Granting a {kib} role the `Machine Learning: All` {kib} feature
+privilege will also grant the role `all` feature privileges to certain types of
+{kib} saved objects, namely index patterns, dashboards, saved searches and
+visualizations as well as {ml} job, trained model, and module saved objects.
+
+
 [discrete]
 [[kib-visibility-spaces]]
 ==== Feature visibility in Spaces


### PR DESCRIPTION
## Overview

As title states.

### Preview

[Kibana security](https://stack-docs_bk_2696.docs-preview.app.elstc.co/guide/en/machine-learning/master/setup.html#kib-security)