### PR TITLE
Adjust important admonition in Kibana security section of ML setup page

### DIFF
--- a/docs/en/stack/ml/setup.asciidoc
+++ b/docs/en/stack/ml/setup.asciidoc
@@ -80,10 +80,10 @@ that contain sensitive information from the source indices to the results.
 [[kib-security]]
 === {kib} security
 
-IMPORTANT: Granting a {kib} role the `Machine Learning: All` {kib} feature
-privilege will also grant the role `all` feature privileges to certain types of
-{kib} saved objects, namely index patterns, dashboards, saved searches and
-visualizations as well as {ml} job, trained model, and module saved objects.
+IMPORTANT: Granting `All` or `Read` {kib} feature privilege for {ml-app} will
+also grant the role the equivalent feature privileges to certain types of {kib}
+saved objects, namely index patterns, dashboards, saved searches, and
+visualizations as well as {ml} job, trained model and module saved objects.
 
 
 [discrete]


### PR DESCRIPTION
## Overview

This PR amends the text of the IMPORTANT admonition block about ML Kibana feature privileges on the ML setup page.

### Preview

[Kibana security](https://stack-docs_bk_2699.docs-preview.app.elstc.co/guide/en/machine-learning/master/setup.html#kib-security)