### PR TITLE
Removes E5 limitation that no longer applicable

### DIFF
--- a/docs/en/stack/ml/nlp/ml-nlp-e5.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-e5.asciidoc
@@ -23,9 +23,6 @@ and one version which is optimized for Intel® silicon. The
 **Model Management** > **Trained Models** page shows you which version of E5 is 
 recommended to deploy based on your cluster's hardware.
 
-The supported model version of E5 is `multilingual-e5-small`, refer to 
-<<ml-nlp-e5-limit, this page>> for more information.
-
 Refer to the model cards of the 
 https://huggingface.co/elastic/multilingual-e5-small[multilingual-e5-small] and 
 the 

--- a/docs/en/stack/ml/nlp/ml-nlp-limitations.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-limitations.asciidoc
@@ -18,11 +18,3 @@ each field of the ingested documents that ELSER is applied to are taken into
 account for the search process. If your data set contains long documents, divide 
 them into smaller segments before ingestion if you need the full text to be 
 searchable.
-
-
-[discrete]
-[[ml-nlp-e5-limit]]
-== The `multilingual-e5-small` model is supported
-
-From the list of E5 models, currently only the `multilingual-e5-small` is 
-supported.


### PR DESCRIPTION
## Overview

This PR removes an item from the NLP limitations sections that refer to the E5 model. The limitation is not applicable anymore starting from 8.12.