### PR TITLE
Update ml-limitations.asciidoc

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/ml-limitations.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-limitations.asciidoc
@@ -47,11 +47,12 @@ Windows environments.
 
 [discrete]
 [[ml-license-ccs-limitations]]
-=== Basic License Limitations for ML Jobs with CCS
+=== License limitations for {ml-jobs} with CCS
 
-Under a basic license, machine learning jobs cannot be initiated on datasets from remote clusters accessed through Cross-Cluster Search (CCS). To use ML jobs with CCS datasets, an upgrade to a Platinum license or higher is required.
-Refer to the [Subscriptions](https://www.elastic.co/subscriptions) page for details on features available with different subscription levels.
-
+You must have an appropriate license to initiate {ml-jobs-cap} on datasets from remote clusters
+accessed through Cross-Cluster Search (CCS). Refer to the 
+[Subscriptions](https://www.elastic.co/subscriptions) page for details on features available with
+different subscription levels.
 
 [discrete]
 [[ad-config-limitations]]

--- a/docs/en/stack/ml/anomaly-detection/ml-limitations.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-limitations.asciidoc
@@ -45,6 +45,13 @@ Linux and MacOS environments, the CPU scheduling priority of native analysis
 processes is reduced to favor the {es} JVM. This improvement does not apply to 
 Windows environments.
 
+[discrete]
+[[ml-license-ccs-limitations]]
+=== Basic License Limitations for ML Jobs with CCS
+
+Under a basic license, machine learning jobs cannot be initiated on datasets from remote clusters accessed through Cross-Cluster Search (CCS). To use ML jobs with CCS datasets, an upgrade to a Platinum license or higher is required.
+Refer to the [Subscriptions](https://www.elastic.co/subscriptions) page for details on features available with different subscription levels.
+
 
 [discrete]
 [[ad-config-limitations]]


### PR DESCRIPTION
The documentation should reflect that it's not possible to run ML jobs on dataset that are located on remote cluster with basic license

If a customer tries to activate ML job on remote indices, they can get the error
```
cannot start datafeed [xxxxx] as it is configured to use indices on remote cluster [cluster2] that is not licensed for ml; the license mode [BASIC] on cluster [cluster2] does not enable [api]

```