### PR TITLE
Fixes typo in link text on AD how-to main page

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/anomaly-how-tos.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/anomaly-how-tos.asciidoc
@@ -10,7 +10,7 @@ The guides in this section describe some best practices for generating useful
 {ml} results and insights from your data.
 
 * <<ml-configuring-alerts, Generating alerts for {anomaly-jobs}>>
-* <<ml-configuring-aggregation, Aggregating data for fester performance>>
+* <<ml-configuring-aggregation, Aggregating data for faster performance>>
 * <<ml-configuring-transform, Using runtime fields in {dfeeds}>>
 * <<ml-configuring-detector-custom-rules>>
 * <<ml-reverting-model-snapshot>>


### PR DESCRIPTION
As title states.