### PR TITLE
Fix links to E5 optimized version

### DIFF
--- a/docs/en/stack/ml/nlp/ml-nlp-e5.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-e5.asciidoc
@@ -175,9 +175,9 @@ https://ml-models.elastic.co/multilingual-e5-small.vocab.json
 
 For the optimized version, you need the following files in your system:
 ```
-https://ml-models.elastic.co/multilingual-e5-small-linux-x86-64.metadata.json
-https://ml-models.elastic.co/multilingual-e5-small-linux-x86-64.pt
-https://ml-models.elastic.co/multilingual-e5-small-linux-x86-64.vocab.json
+https://ml-models.elastic.co/multilingual-e5-small_linux-x86_64.metadata.json
+https://ml-models.elastic.co/multilingual-e5-small_linux-x86_64.pt
+https://ml-models.elastic.co/multilingual-e5-small_linux-x86_64.vocab.json
 ```
 
 

--- a/docs/en/stack/ml/nlp/ml-nlp-e5.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-e5.asciidoc
@@ -156,7 +156,7 @@ If you want to install E5 in an air-gapped environment, you have the following
 options:
 * put the model artifacts into a directory inside the config directory on all 
 master-eligible nodes (for `multilingual-e5-small` and
-`multilingual-e5-small-optimized`)
+`multilingual-e5-small-linux-x86-64`)
 * install the model by using HuggingFace (for `multilingual-e5-small` model 
 only).
 
@@ -175,9 +175,9 @@ https://ml-models.elastic.co/multilingual-e5-small.vocab.json
 
 For the optimized version, you need the following files in your system:
 ```
-https://ml-models.elastic.co/multilingual-e5-small-optimized.metadata.json
-https://ml-models.elastic.co/multilingual-e5-small-optimized.pt
-https://ml-models.elastic.co/multilingual-e5-small-optimized.vocab.json
+https://ml-models.elastic.co/multilingual-e5-small-linux-x86-64.metadata.json
+https://ml-models.elastic.co/multilingual-e5-small-linux-x86-64.pt
+https://ml-models.elastic.co/multilingual-e5-small-linux-x86-64.vocab.json
 ```
 
 


### PR DESCRIPTION
We maybe should do more, such as explain that `linux-x86-64` is indeed the version optimized for "Intel® silicon".