### PR TITLE
Documents ELSER autoscale limitation

### DIFF
--- a/docs/en/stack/ml/nlp/ml-nlp-limitations.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-limitations.asciidoc
@@ -24,9 +24,9 @@ searchable.
 [[ml-nlp-elser-autoscale]]
 == ELSER deployments don't autoscale
 
-Currently, the ESLER deployments do not scale up and down automatically
-depending on the resource requirements of the ELSER processes. If you want to
-configure available resources for your ELSER deployments, you can manually set
-the number of allocations and threads per allocation by using the Trained Models
-UI in {kib} or the 
+Currently, ELSER deployments do not scale up and down automatically depending on
+the resource requirements of the ELSER processes. If you want to configure
+available resources for your ELSER deployments, you can manually set the number
+of allocations and threads per allocation by using the Trained Models UI in
+{kib} or the 
 {ref}/update-trained-model-deployment.html[Update trained model deployment API].

--- a/docs/en/stack/ml/nlp/ml-nlp-limitations.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-limitations.asciidoc
@@ -18,3 +18,15 @@ each field of the ingested documents that ELSER is applied to are taken into
 account for the search process. If your data set contains long documents, divide 
 them into smaller segments before ingestion if you need the full text to be 
 searchable.
+
+
+[discrete]
+[[ml-nlp-elser-autoscale]]
+== ELSER deployments don't autoscale
+
+Currently, the ESLER deployments do not scale up and down automatically
+depending on the resource requirements of the ELSER processes. If you want to
+configure available resources for your ELSER deployments, you can manually set
+the number of allocations and threads per allocation by using the Trained Models
+UI in {kib} or the 
+{ref}/update-trained-model-deployment.html[Update trained model deployment API].


### PR DESCRIPTION
## Overview

Currently, ELSER deployments don't autoscale. This PR adds an item to the NLP limitations section about it.

### Preview

[ELSER deployments don't autoscale](https://stack-docs_bk_2719.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-nlp-limitations.html#ml-nlp-elser-autoscale)
