### PR TITLE
[8.14] Fixed typo (#2678)

### DIFF
--- a/docs/en/stack/ml/nlp/ml-nlp-overview.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-overview.asciidoc
@@ -61,6 +61,6 @@ data. You can perform the following NLP operations:
 * <<ml-nlp-classify-text>> 
 * <<ml-nlp-search-compare>>
 
-To delve deeper into Elastic's {ml} research and development, eplore the
+To delve deeper into Elastic's {ml} research and development, explore the
 https://www.elastic.co/search-labs/blog/categories/ml-research[ML research]
 section within Search Labs.


### PR DESCRIPTION
# Backport

This will backport the following commits from `8.12` to `8.14`:
 - [Fixed typo (#2678)](https://github.com/elastic/stack-docs/pull/2678)

<!--- Backport version: 9.5.1 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)