### PR TITLE
Adds important callout about the possibility of multiple ELSER deployment

### DIFF
--- a/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
@@ -108,6 +108,14 @@ that walks through upgrading an index to ELSER V2.
 You can download and deploy ELSER either from **{ml-app}** > **Trained Models**, 
 from **Search** > **Indices**, or by using the Dev Console.
 
+IMPORTANT: You can deploy the model multiple times by assigning a unique
+deployment ID when starting the deployment. It enables you to have dedicated
+deployments for different purposes, such as search and ingest. By doing so, you
+ensure that the search speed remains unaffected by ingest workloads, and vice
+versa. Having separate deployments for search and ingest mitigates performance
+issues resulting from interactions between the two, which can be hard to
+diagnose.
+
 
 [discrete]
 [[trained-model]]


### PR DESCRIPTION
## Overview

It is possible to deploy ELSER multiple times by using different deployment IDs. The recommended behavior is to have different deployments with different purposes. This PR adds an `important` callout to the ELSER page to highlight these pieces of information.