### PR TITLE
Fix Eland Docker image name

### DIFF
--- a/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
@@ -112,7 +112,7 @@ $ docker run -it --rm --network host docker.elastic.co/eland/eland
 The `eland_import_hub_model` script can be run directly in the docker command:
 
 ```bash
-docker run -it --rm elastic/eland \
+docker run -it --rm docker.elastic.co/eland/eland \
     eland_import_hub_model \
       --url $ELASTICSEARCH_URL \
       --hub-model-id elastic/distilbert-base-uncased-finetuned-conll03-english \

--- a/docs/en/stack/ml/nlp/ml-nlp-ner-example.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-ner-example.asciidoc
@@ -35,7 +35,7 @@ image:
 
 [source,shell]
 --------------------------------------------------
-docker run -it --rm elastic/eland \
+docker run -it --rm docker.elastic.co/eland/eland \
     eland_import_hub_model \
       --cloud-id $CLOUD_ID \
       -u <username> -p <password> \

--- a/docs/en/stack/ml/nlp/ml-nlp-text-emb-vector-search-example.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-text-emb-vector-search-example.asciidoc
@@ -48,7 +48,7 @@ image:
 
 [source,shell]
 --------------------------------------------------
-docker run -it --rm elastic/eland \
+docker run -it --rm docker.elastic.co/eland/eland \
     eland_import_hub_model \
       --cloud-id $CLOUD_ID \
       -u <username> -p <password> \


### PR DESCRIPTION
When we instructed users to build the image, the tag was `elastic/eland`, but now we should refer to the docker.elastic.co image tag instead.

Thanks to @itay-ct for the report.