### PR TITLE
Adds adaptive allocations feature description to conceptual docs

### DIFF
--- a/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
@@ -188,7 +188,8 @@ nodes. Model allocations are independent units of work for NLP tasks. To
 influence model performance, you can configure the number of allocations and the 
 number of threads used by each allocation of your deployment. Alternatively, you
 can enable <<nlp-model-adaptive-allocations>> to automatically create and remove
-model allocations based on the current workload of the model.
+model allocations based on the current workload of the model (you still need to 
+manually set the number of threads).
 
 IMPORTANT: If your deployed trained model has only one allocation, it's likely 
 that you will experience downtime in the service your trained model performs. 

--- a/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
@@ -186,7 +186,9 @@ NOTE: Since eland uses APIs to deploy the models, you cannot see the models in
 When you deploy the model, its allocations are distributed across available {ml} 
 nodes. Model allocations are independent units of work for NLP tasks. To 
 influence model performance, you can configure the number of allocations and the 
-number of threads used by each allocation of your deployment.
+number of threads used by each allocation of your deployment. Alternatively, you
+can enable <<nlp-model-adaptive-allocations>> to automatically create and remove
+model allocations based on the current workload of the model.
 
 IMPORTANT: If your deployed trained model has only one allocation, it's likely 
 that you will experience downtime in the service your trained model performs. 
@@ -211,7 +213,9 @@ You can view the allocation status in {kib} or by using the
 {ref}/get-trained-models-stats.html[get trained model stats API]. If you want to
 change the number of allocations, you can use the
 {ref}/update-trained-model-deployment.html[update trained model stats API] after
-the allocation status is `started`.
+the allocation status is `started`. You can also enable
+<<nlp-model-adaptive-allocations>> to automatically create and remove model
+allocations based on the current workload of the model.
 
 [discrete]
 [[nlp-model-adaptive-allocations]]

--- a/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
@@ -214,6 +214,13 @@ change the number of allocations, you can use the
 the allocation status is `started`.
 
 [discrete]
+[[nlp-model-adaptive-allocations]]
+=== Adaptive allocations
+
+include::ml-nlp-shared.asciidoc[tag=ml-nlp-adaptive-allocations]
+
+
+[discrete]
 [[infer-request-queues]]
 === Request queues and search priority
 

--- a/docs/en/stack/ml/nlp/ml-nlp-e5.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-e5.asciidoc
@@ -269,6 +269,12 @@ Once it's uploaded to {es}, the model will have the ID specified by
 underscores `__`.
 --
 
+[discrete]
+[[e5-adaptive-allocations]]
+== Adaptive allocations
+
+include::ml-nlp-shared.asciidoc[tag=ml-nlp-adaptive-allocations]
+
 
 [discrete]
 [[terms-of-use-e5]]

--- a/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
@@ -434,6 +434,13 @@ To learn more about ELSER performance, refer to the <<elser-benchmarks>>.
 
 
 [discrete]
+[[elser-adaptive-allocations]]
+== Adaptive allocations
+
+include::ml-nlp-shared.asciidoc[tag=ml-nlp-adaptive-allocations]
+
+
+[discrete]
 [[further-readings]]
 == Further reading
 

--- a/docs/en/stack/ml/nlp/ml-nlp-shared.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-shared.asciidoc
@@ -1,7 +1,7 @@
 tag::ml-nlp-adaptive-allocations[]
 The numbers of threads and allocations you can set manually for a model remain constant even when not all the available resources are fully used or when the load on the model requires more resources.
 Adaptive allocations, however, provide full control and flexibility over the model allocations, and help you to manage performance and cost more easily.
-When adaptive allocations is enabled, the number of allocations of the model is set automatically based on the current load.
+When adaptive allocations are enabled, the number of allocations of the model is set automatically based on the current load.
 When the load is high, a new model allocation is automatically created.
 When the load is low, a model allocation is automatically removed.
 

--- a/docs/en/stack/ml/nlp/ml-nlp-shared.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-shared.asciidoc
@@ -1,3 +1,22 @@
+tag::ml-nlp-adaptive-allocations[]
+The numbers of threads and allocations you can set manually for a model remain constant even when not all the available resources are fully used or when the load on the model requires more resources.
+Adaptive allocations, however, provide full control and flexibility over the model allocations, and helps you to manage performance and cost more easily.
+When adaptive allocations is enabled, the number of allocations of the model is set automatically based on the current load.
+When the load is high, a new model allocation is automatically created.
+When the load is low, a model allocation is automatically removed.
+
+You can enable adaptive allocations by using:
+
+* the Create inference endpoint API for {ref}/infer-service-elser.html[ELSER], {ref}/infer-service-elasticsearch.html[E5 and models uploaded through Eland] that are used as {infer} services.
+* the {ref}/start-trained-model-deployment.html[start trained model deployment] or {ref}/update-trained-model-deployment.html[update trained model deployment] APIs for trained models that are uploaded to and managed on {ml} nodes.
+
+If the new allocations fit on the current {ml} nodes, they are immediately started.
+If more resource capacity is needed for creating new model allocations, then your {ml} node will be scaled up if {ml} autoscaling is enabled to provide enough resources for the new allocation.
+The number of model allocations cannot be scaled down to less than 1.
+And they cannot be scaled up to more than 32 allocations, unless you explicitly set the maximum number of allocations to more.
+Adaptive allocations must set up independently for each deployment and {infer} endpoint.
+end::ml-nlp-adaptive-allocations[]
+
 tag::nlp-eland-clone-docker-build[]
 You can use the {eland-docs}[Eland client] to install the {nlp} model. Use the prebuilt  
 Docker image to run the Eland install model commands. Pull the latest image with:

--- a/docs/en/stack/ml/nlp/ml-nlp-shared.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-shared.asciidoc
@@ -1,6 +1,6 @@
 tag::ml-nlp-adaptive-allocations[]
 The numbers of threads and allocations you can set manually for a model remain constant even when not all the available resources are fully used or when the load on the model requires more resources.
-Adaptive allocations, however, provide full control and flexibility over the model allocations, and help you to manage performance and cost more easily.
+Instead of setting the number of allocations manually, you can enable adaptive allocations to set the number of allocations based on the load on the process. This can help you to manage performance and cost more easily.
 When adaptive allocations are enabled, the number of allocations of the model is set automatically based on the current load.
 When the load is high, a new model allocation is automatically created.
 When the load is low, a model allocation is automatically removed.
@@ -8,13 +8,13 @@ When the load is low, a model allocation is automatically removed.
 You can enable adaptive allocations by using:
 
 * the Create inference endpoint API for {ref}/infer-service-elser.html[ELSER], {ref}/infer-service-elasticsearch.html[E5 and models uploaded through Eland] that are used as {infer} services.
-* the {ref}/start-trained-model-deployment.html[start trained model deployment] or {ref}/update-trained-model-deployment.html[update trained model deployment] APIs for trained models that are uploaded to and managed on {ml} nodes.
+* the {ref}/start-trained-model-deployment.html[start trained model deployment] or {ref}/update-trained-model-deployment.html[update trained model deployment] APIs for trained models that are deployed on {ml} nodes.
 
 If the new allocations fit on the current {ml} nodes, they are immediately started.
 If more resource capacity is needed for creating new model allocations, then your {ml} node will be scaled up if {ml} autoscaling is enabled to provide enough resources for the new allocation.
 The number of model allocations cannot be scaled down to less than 1.
 And they cannot be scaled up to more than 32 allocations, unless you explicitly set the maximum number of allocations to more.
-Adaptive allocations must set up independently for each deployment and {infer} endpoint.
+Adaptive allocations must be set up independently for each deployment and {infer} endpoint.
 end::ml-nlp-adaptive-allocations[]
 
 tag::nlp-eland-clone-docker-build[]

--- a/docs/en/stack/ml/nlp/ml-nlp-shared.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-shared.asciidoc
@@ -1,6 +1,6 @@
 tag::ml-nlp-adaptive-allocations[]
 The numbers of threads and allocations you can set manually for a model remain constant even when not all the available resources are fully used or when the load on the model requires more resources.
-Adaptive allocations, however, provide full control and flexibility over the model allocations, and helps you to manage performance and cost more easily.
+Adaptive allocations, however, provide full control and flexibility over the model allocations, and help you to manage performance and cost more easily.
 When adaptive allocations is enabled, the number of allocations of the model is set automatically based on the current load.
 When the load is high, a new model allocation is automatically created.
 When the load is low, a model allocation is automatically removed.


### PR DESCRIPTION
## Overview

This PR describes adaptive allocations in the `ml-nlp-shared.asciidoc` file. The feature description is then single-sourced from there in the ELSER, E5, and deploy trained model conceptual docs.

### Preview

* [ELSER](https://stack-docs_bk_2763.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-nlp-elser.html#elser-adaptive-allocations)
* [E5](https://stack-docs_bk_2763.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-nlp-e5.html#e5-adaptive-allocations)
* [Deploy trained models](https://stack-docs_bk_2763.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-nlp-deploy-model.html#nlp-model-adaptive-allocations)