### PR TITLE
Updates the list of supported NLP task types

### DIFF
--- a/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-deploy-models.asciidoc
@@ -94,7 +94,8 @@ eland_import_hub_model \
 <<ml-nlp-authentication>> to learn more.
 <3> Specify the identifier for the model in the Hugging Face model hub.
 <4> Specify the type of NLP task. Supported values are `fill_mask`, `ner`,
-`text_classification`, `text_embedding`, and `zero_shot_classification`.
+`question_answering`, `text_classification`, `text_embedding`, `text_expansion`,
+`text_similarity`, and `zero_shot_classification`.
 
 For more details, refer to 
 https://www.elastic.co/guide/en/elasticsearch/client/eland/current/machine-learning.html#ml-nlp-pytorch.


### PR DESCRIPTION
## Overview

This PR updates the supported NLP task types on the `Import the trained model and vocabulary` page.

### Preview

[Import the trained model and vocabulary](https://stack-docs_bk_2775.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-nlp-import-model.html#ml-nlp-import-script)