### PR TITLE
Updates link text on Metrics configuration page

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-metrics-ui.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ootb-ml-jobs-metrics-ui.asciidoc
@@ -1,10 +1,8 @@
 ["appendix",role="exclude",id="ootb-ml-jobs-metrics-ui"]
 = Metrics {anomaly-detect} configurations
 
-These {anomaly-jobs} can be created in the
-{observability-guide}/analyze-metrics.html[{metrics-app}] in {kib}. For more
-information about their usage, refer to
-{observability-guide}/inspect-metric-anomalies.html[Inspect metric anomalies].
+These {anomaly-jobs} can be created in the {observability-guide}/analyze-metrics.html[{infrastructure-app}] in {kib}.
+For more information about their usage, refer to {observability-guide}/inspect-metric-anomalies.html[Inspect metric anomalies].
 
 // tag::metrics-jobs[]
 [discrete]


### PR DESCRIPTION
## Overview

Related to https://github.com/elastic/search-docs-team/issues/174
The `Metrics` app has been renamed to `Infrastructure` app. This PR updates the link text on the Metrics OOTB jobs page pointing to the Infrastructure app's docs to represent this change. It does not change the `metrics job` terminology as it remained unchanged. The Infrastructure documentation on the O11y side uses it, too.