### PR TITLE
Updates NLP overview to list the semantic_text workflow

### DIFF
--- a/docs/en/stack/ml/nlp/ml-nlp-overview.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-overview.asciidoc
@@ -11,22 +11,17 @@ natural language in spoken word or written text.
 Elastic offers a wide range of possibilities to leverage natural language
 processing.
 
-You can **integrate NLP models from different providers** such as Cohere,
-HuggingFace, or OpenAI and use them as a service through the 
-{ref}/inference-apis.html[{infer} API]. You can also use <<ml-nlp-elser,ELSER>>
-(the retrieval model trained by Elastic) and <<ml-nlp-e5,E5>> in the same way.
-This {ref}/semantic-search-inference.html[tutorial] walks you through the
-process of using the various services with the {infer} API.
+You can **integrate NLP models from different providers** such as Cohere, HuggingFace, or OpenAI and use them as a service through the {ref}/semantic-search-semantic-text.html[semantic_text] workflow.
+You can also use <<ml-nlp-elser,ELSER>> (the retrieval model trained by Elastic) and <<ml-nlp-e5,E5>> in the same way.
 
-You can **upload and manage NLP models** using the Eland client and the
-<<ml-nlp-deploy-models,{stack}>>. Find the 
-<<ml-nlp-model-ref,list of recommended and compatible models here>>. Refer to 
-<<ml-nlp-examples>> to learn more about how to use {ml} models deployed in your 
-cluster.
+The {ref}/inference-apis.html[{infer} API] enables you to use the same services with a more complex workflow which - in turn - offers greater control over the configurations settings. 
+This {ref}/semantic-search-inference.html[tutorial] walks you through the process of using the various services with the {infer} API.
 
-You can **store embeddings in your {es} vector database** if you generate 
-{ref}/dense-vector.html[dense vector] or {ref}/sparse-vector.html[sparse vector]
-model embeddings outside of {es}.
+You can **upload and manage NLP models** using the Eland client and the <<ml-nlp-deploy-models,{stack}>>.
+Find the  <<ml-nlp-model-ref,list of recommended and compatible models here>>.
+Refer to <<ml-nlp-examples>> to learn more about how to use {ml} models deployed in your cluster.
+
+You can **store embeddings in your {es} vector database** if you generate {ref}/dense-vector.html[dense vector] or {ref}/sparse-vector.html[sparse vector] model embeddings outside of {es}.
 
 
 [discrete]


### PR DESCRIPTION
## Overview

This PR updates the list of semantic search methods on the NLP overview page to contain `semantic_text`.