### PR TITLE
Updates supported architectures list with DeBERTa

### DIFF
--- a/docs/en/stack/ml/nlp/ml-nlp-model-ref.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-model-ref.asciidoc
@@ -26,6 +26,7 @@ The current list of supported architectures is:
 * BERT
 * BART
 * DPR bi-encoders
+* DeBERTa
 * DistilBERT
 * ELECTRA
 * MobileBERT


### PR DESCRIPTION
## Overview

Related to https://github.com/elastic/ml-team/issues/1239
This PR adds `DeBERTa` to the list of supported architectures on the Compatible third-party NLP models page.