### PR TITLE
[DOCS] Adds pre-cleaning recommendation to ELSER docs

### DIFF
--- a/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
@@ -441,6 +441,17 @@ To learn more about ELSER performance, refer to the <<elser-benchmarks>>.
 
 
 [discrete]
+[[pre-cleaning]]
+== Pre-cleaning input text
+
+The quality of the input text significantly affects the quality of the embeddings.
+To achieve the best results, it's recommended to clean the input text before generating embeddings.
+The exact preprocessing you may need to do heavily depends on your text.
+For example, if your text contains HTML tags, use the {ref}/htmlstrip-processor.html[HTML strip processor] in an ingest pipeline to remove unnecessary elements.
+Always review and clean your input text before ingestion to eliminate any irrelevant entities that might affect the results.
+ 
+
+[discrete]
 [[elser-adaptive-allocations]]
 == Adaptive allocations
 


### PR DESCRIPTION
## Overview

This PR adds a new section to the ELSER conceptual page that recommends cleaning the input text before generating embeddings to achieve the best results.

### Preview

[ELSER - Pre-cleaning input text](https://stack-docs_bk_2796.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-nlp-elser.html#pre-cleaning)