### PR TITLE
[8.1][DOCS] Removes frozen indices limitation item from anomaly detection docs

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/ml-limitations.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-limitations.asciidoc
@@ -96,18 +96,6 @@ items of the array.
 
 
 [discrete]
-[[ml-frozen-limitations]]
-=== Frozen indices are not supported
-
-{ref}/frozen-indices.html[Frozen indices] cannot be used in {anomaly-jobs} or 
-{dfeeds}. This limitation applies irrespective of whether you create the jobs in 
-{kib} or by using APIs. This limitation exists because it's currently not
-possible to specify the `ignore_throttled` query parameter for search requests
-in {dfeeds} or jobs. See
-{ref}/searching_a_frozen_index.html[Searching a frozen index].
-
-
-[discrete]
 [[ml-forecast-config-limitations]]
 === Unsupported forecast configurations
 


### PR DESCRIPTION
## Overview

This PR backports the changes of the following commits to the `8.1` branch: 
[DOCS] Removes frozen indices limitation item from anomaly detection docs #2828