### PR TITLE
Updates phrasing when referring to pages

### DIFF
--- a/docs/en/stack/ml/anomaly-detection/ml-ad-run-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-ad-run-jobs.asciidoc
@@ -35,7 +35,6 @@ You can create {anomaly-jobs} by using the
 wizards to simplify the process, which vary depending on whether you are using
 the {ml-app} app, {security-app} or {observability} apps. To open *Anomaly Detection*, 
 find *{ml-app}* in the main menu, or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search bar].
-In *{ml-app}* > *Anomaly Detection*:
 
 [role="screenshot"]
 image::images/ml-create-job.png[Create New Job]

--- a/docs/en/stack/ml/anomaly-detection/ml-ad-run-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-ad-run-jobs.asciidoc
@@ -33,8 +33,9 @@ a {dfeed} will be required.
 You can create {anomaly-jobs} by using the
 {ref}/ml-put-job.html[create {anomaly-jobs} API]. {kib} also provides
 wizards to simplify the process, which vary depending on whether you are using
-the {ml-app} app, {security-app} or {observability} apps. In *{ml-app}* >
-*Anomaly Detection*:
+the {ml-app} app, {security-app} or {observability} apps. To open *Anomaly Detection*, 
+find *{ml-app}* in the main menu, or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search bar].
+In *{ml-app}* > *Anomaly Detection*:
 
 [role="screenshot"]
 image::images/ml-create-job.png[Create New Job]

--- a/docs/en/stack/ml/anomaly-detection/ml-ad-run-jobs.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-ad-run-jobs.asciidoc
@@ -34,7 +34,7 @@ You can create {anomaly-jobs} by using the
 {ref}/ml-put-job.html[create {anomaly-jobs} API]. {kib} also provides
 wizards to simplify the process, which vary depending on whether you are using
 the {ml-app} app, {security-app} or {observability} apps. To open *Anomaly Detection*, 
-find *{ml-app}* in the main menu, or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search bar].
+find *{ml-app}* in the main menu, or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search field].
 
 [role="screenshot"]
 image::images/ml-create-job.png[Create New Job]

--- a/docs/en/stack/ml/anomaly-detection/ml-detect-categories.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-detect-categories.asciidoc
@@ -33,7 +33,7 @@ Avoid using human-generated data for categorization analysis.
 [[creating-categorization-jobs]]
 == Creating categorization jobs
 
-. In {kib}, navigate to **{ml-app} > Anomaly Detection > Jobs**.
+. In {kib}, navigate to *Jobs*. To open *Jobs*, find **{ml-app} > Anomaly Detection** in the main menu, or or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search bar].
 . Click **Create job**, select the {data-view} you want to analyze.
 . Select the **Categorization** wizard from the list.
 . Choose a categorization detector - it's the `count` function in this example - and the field you want to categorize - the `message` field in this example.

--- a/docs/en/stack/ml/anomaly-detection/ml-detect-categories.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-detect-categories.asciidoc
@@ -33,7 +33,7 @@ Avoid using human-generated data for categorization analysis.
 [[creating-categorization-jobs]]
 == Creating categorization jobs
 
-. In {kib}, navigate to *Jobs*. To open *Jobs*, find **{ml-app} > Anomaly Detection** in the main menu, or or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search bar].
+. In {kib}, navigate to *Jobs*. To open *Jobs*, find **{ml-app} > Anomaly Detection** in the main menu, or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search bar].
 . Click **Create job**, select the {data-view} you want to analyze.
 . Select the **Categorization** wizard from the list.
 . Choose a categorization detector - it's the `count` function in this example - and the field you want to categorize - the `message` field in this example.

--- a/docs/en/stack/ml/anomaly-detection/ml-detect-categories.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-detect-categories.asciidoc
@@ -33,7 +33,7 @@ Avoid using human-generated data for categorization analysis.
 [[creating-categorization-jobs]]
 == Creating categorization jobs
 
-. In {kib}, navigate to *Jobs*. To open *Jobs*, find **{ml-app} > Anomaly Detection** in the main menu, or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search bar].
+. In {kib}, navigate to *Jobs*. To open *Jobs*, find **{ml-app} > Anomaly Detection** in the main menu, or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search field].
 . Click **Create job**, select the {data-view} you want to analyze.
 . Select the **Categorization** wizard from the list.
 . Choose a categorization detector - it's the `count` function in this example - and the field you want to categorize - the `message` field in this example.

--- a/docs/en/stack/ml/anomaly-detection/ml-jobs-from-visuals.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-jobs-from-visuals.asciidoc
@@ -40,7 +40,7 @@ NOTE: You need to have a compatible visualization on **Dashboard** to create an
 which is based on the {kib} sample flight data set. Select the `Flight count` 
 visualization from the dashboard.
 
-. Go to **Analytics > Dashboard** from the main menu, or or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search bar]. Select a dashboard with a compatible 
+. Go to **Analytics > Dashboard** from the main menu, or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search bar]. Select a dashboard with a compatible 
 visualization.
 . Open the **Options (...) menu** for the panel, then select **More**.  
 . Select **Create {anomaly-job}**. The option is only displayed if the 

--- a/docs/en/stack/ml/anomaly-detection/ml-jobs-from-visuals.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-jobs-from-visuals.asciidoc
@@ -40,7 +40,7 @@ NOTE: You need to have a compatible visualization on **Dashboard** to create an
 which is based on the {kib} sample flight data set. Select the `Flight count` 
 visualization from the dashboard.
 
-. Go to **Analytics > Dashboard** from the main menu, or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search bar]. Select a dashboard with a compatible 
+. Go to **Analytics > Dashboard** from the main menu, or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search field]. Select a dashboard with a compatible 
 visualization.
 . Open the **Options (...) menu** for the panel, then select **More**.  
 . Select **Create {anomaly-job}**. The option is only displayed if the 

--- a/docs/en/stack/ml/anomaly-detection/ml-jobs-from-visuals.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-jobs-from-visuals.asciidoc
@@ -40,7 +40,7 @@ NOTE: You need to have a compatible visualization on **Dashboard** to create an
 which is based on the {kib} sample flight data set. Select the `Flight count` 
 visualization from the dashboard.
 
-. Go to **Analytics > Dashboard** and select a dashboard with a compatible 
+. Go to **Analytics > Dashboard** from the main menu, or or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search bar]. Select a dashboard with a compatible 
 visualization.
 . Open the **Options (...) menu** for the panel, then select **More**.  
 . Select **Create {anomaly-job}**. The option is only displayed if the 

--- a/docs/en/stack/ml/anomaly-detection/ml-population-analysis.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-population-analysis.asciidoc
@@ -27,7 +27,7 @@ Population analysis is resource-efficient and scales well, enabling the analysis
 [[creating-population-jobs]]
 == Creating population jobs
 
-. In {kib}, navigate to *Jobs*. To open *Jobs*, find **{ml-app} > Anomaly Detection** in the main menu, or or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search bar].
+. In {kib}, navigate to *Jobs*. To open *Jobs*, find **{ml-app} > Anomaly Detection** in the main menu, or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search bar].
 . Click **Create job**, select the {data-source} you want to analyze.
 . Select the **Population** wizard from the list.
 . Choose a population field - it's the `clientip` field in this example - and the metric you want to use for the analysis - `Mean(bytes)` in this example.

--- a/docs/en/stack/ml/anomaly-detection/ml-population-analysis.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-population-analysis.asciidoc
@@ -27,7 +27,7 @@ Population analysis is resource-efficient and scales well, enabling the analysis
 [[creating-population-jobs]]
 == Creating population jobs
 
-. In {kib}, navigate to **{ml-app} > Anomaly Detection > Jobs**.
+. In {kib}, navigate to *Jobs*. To open *Jobs*, find **{ml-app} > Anomaly Detection** in the main menu, or or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search bar].
 . Click **Create job**, select the {data-source} you want to analyze.
 . Select the **Population** wizard from the list.
 . Choose a population field - it's the `clientip` field in this example - and the metric you want to use for the analysis - `Mean(bytes)` in this example.

--- a/docs/en/stack/ml/anomaly-detection/ml-population-analysis.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-population-analysis.asciidoc
@@ -27,7 +27,7 @@ Population analysis is resource-efficient and scales well, enabling the analysis
 [[creating-population-jobs]]
 == Creating population jobs
 
-. In {kib}, navigate to *Jobs*. To open *Jobs*, find **{ml-app} > Anomaly Detection** in the main menu, or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search bar].
+. In {kib}, navigate to *Jobs*. To open *Jobs*, find **{ml-app} > Anomaly Detection** in the main menu, or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search field].
 . Click **Create job**, select the {data-source} you want to analyze.
 . Select the **Population** wizard from the list.
 . Choose a population field - it's the `clientip` field in this example - and the metric you want to use for the analysis - `Mean(bytes)` in this example.

--- a/docs/en/stack/ml/anomaly-detection/ml-revert-model-snapshot.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-revert-model-snapshot.asciidoc
@@ -7,7 +7,7 @@ resilience. It makes it possible to reset the model to a previous state in case
 of a system failure or if the model changed significantly due to a one-off 
 event.
 
-. In {kib}, navigate to **{ml-app} > Anomaly Detection > Jobs**.
+. In {kib}, navigate to *Jobs*. To open *Jobs*, find **{ml-app} > Anomaly Detection** in the main menu, or or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search bar].
 . Locate the {anomaly-job} whose model you want to revert in the job table.
 . Open the job details and navigate to the **Model Snapshots** tab.
 +

--- a/docs/en/stack/ml/anomaly-detection/ml-revert-model-snapshot.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-revert-model-snapshot.asciidoc
@@ -7,7 +7,7 @@ resilience. It makes it possible to reset the model to a previous state in case
 of a system failure or if the model changed significantly due to a one-off 
 event.
 
-. In {kib}, navigate to *Jobs*. To open *Jobs*, find **{ml-app} > Anomaly Detection** in the main menu, or or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search bar].
+. In {kib}, navigate to *Jobs*. To open *Jobs*, find **{ml-app} > Anomaly Detection** in the main menu, or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search bar].
 . Locate the {anomaly-job} whose model you want to revert in the job table.
 . Open the job details and navigate to the **Model Snapshots** tab.
 +

--- a/docs/en/stack/ml/anomaly-detection/ml-revert-model-snapshot.asciidoc
+++ b/docs/en/stack/ml/anomaly-detection/ml-revert-model-snapshot.asciidoc
@@ -7,7 +7,7 @@ resilience. It makes it possible to reset the model to a previous state in case
 of a system failure or if the model changed significantly due to a one-off 
 event.
 
-. In {kib}, navigate to *Jobs*. To open *Jobs*, find **{ml-app} > Anomaly Detection** in the main menu, or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search bar].
+. In {kib}, navigate to *Jobs*. To open *Jobs*, find **{ml-app} > Anomaly Detection** in the main menu, or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search field].
 . Locate the {anomaly-job} whose model you want to revert in the job table.
 . Open the job details and navigate to the **Model Snapshots** tab.
 +

--- a/docs/en/stack/ml/df-analytics/ml-dfa-shared.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-shared.asciidoc
@@ -1,6 +1,6 @@
 tag::dfa-deploy-model[]
 . To deploy {dfanalytics} model in a pipeline, navigate to  **Machine Learning** > 
-**Model Management** > **Trained models**, or or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search bar] in {kib}.
+**Model Management** > **Trained models** in the main menu, or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search bar] in {kib}.
 
 . Find the model you want to deploy in the list and click **Deploy model** in 
 the **Actions** menu.

--- a/docs/en/stack/ml/df-analytics/ml-dfa-shared.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-shared.asciidoc
@@ -1,6 +1,6 @@
 tag::dfa-deploy-model[]
 . To deploy {dfanalytics} model in a pipeline, navigate to  **Machine Learning** > 
-**Model Management** > **Trained models** in {kib}.
+**Model Management** > **Trained models**, or or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search bar] in {kib}.
 
 . Find the model you want to deploy in the list and click **Deploy model** in 
 the **Actions** menu.

--- a/docs/en/stack/ml/df-analytics/ml-dfa-shared.asciidoc
+++ b/docs/en/stack/ml/df-analytics/ml-dfa-shared.asciidoc
@@ -1,6 +1,6 @@
 tag::dfa-deploy-model[]
 . To deploy {dfanalytics} model in a pipeline, navigate to  **Machine Learning** > 
-**Model Management** > **Trained models** in the main menu, or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search bar] in {kib}.
+**Model Management** > **Trained models** in the main menu, or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search field] in {kib}.
 
 . Find the model you want to deploy in the list and click **Deploy model** in 
 the **Actions** menu.

--- a/docs/en/stack/ml/get-started/ml-gs-results.asciidoc
+++ b/docs/en/stack/ml/get-started/ml-gs-results.asciidoc
@@ -34,7 +34,7 @@ request rate on your web site drops significantly.
 
 Let's start by looking at this simple job in the **Single Metric Viewer**:
 
-. Select the *Anomaly Detection* tab in *{ml-app}* to see the list of your
+. Select the *Jobs* tab in *{ml-app}* to see the list of your
 {anomaly-jobs}.
 
 . Click the chart icon in the *Actions* column for your `low_request_rate` job
@@ -151,7 +151,7 @@ look at both high and low request rates partitioned by response code.
 Let's start by looking at the `response_code_rates` job in the
 **Anomaly Explorer**:
 
-. Select the *Anomaly Detection* tab in *{ml-app}* to see the list of your
+. Select the *Jobs* tab in *{ml-app}* to see the list of your
 {anomaly-jobs}.
 
 . Open the `response_code_rates` job in the Anomaly Explorer to view its results

--- a/docs/en/stack/ml/get-started/ml-gs-visualizer.asciidoc
+++ b/docs/en/stack/ml/get-started/ml-gs-visualizer.asciidoc
@@ -17,7 +17,7 @@ exception for your {kib} URL.
 
 --
 
-. Click *Machine Learning* in the {kib} main menu.
+. Open the *Machine Learning* page in {kib}. Find *Machine Learning* in the main menu, or or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search bar].
 
 . Select the *{data-viz}* tab.
 

--- a/docs/en/stack/ml/get-started/ml-gs-visualizer.asciidoc
+++ b/docs/en/stack/ml/get-started/ml-gs-visualizer.asciidoc
@@ -17,7 +17,7 @@ exception for your {kib} URL.
 
 --
 
-. Open the *Machine Learning* page in {kib}. Find *Machine Learning* in the main menu, or or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search bar].
+. Open *Machine Learning* from the main menu, or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search bar].
 
 . Select the *{data-viz}* tab.
 

--- a/docs/en/stack/ml/get-started/ml-gs-visualizer.asciidoc
+++ b/docs/en/stack/ml/get-started/ml-gs-visualizer.asciidoc
@@ -17,7 +17,7 @@ exception for your {kib} URL.
 
 --
 
-. Open *Machine Learning* from the main menu, or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search bar].
+. Open *Machine Learning* from the main menu, or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search field].
 
 . Select the *{data-viz}* tab.
 

--- a/docs/en/stack/ml/nlp/ml-nlp-e5.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-e5.asciidoc
@@ -92,7 +92,7 @@ NOTE: For most cases, the preferred version is the **Intel and Linux optimized**
 [[trained-model-e5]]
 ==== Using the Trained Models page
 
-1. In {kib}, navigate to **{ml-app}** > **Trained Models**. E5 can be found in 
+1. In {kib}, navigate to **{ml-app}** > **Trained Models** from the main menu, or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search bar]. E5 can be found in 
 the list of trained models. There are two versions available: one portable 
 version which runs on any hardware and one version which is optimized for Intel® 
 silicon. You can see which model is recommended to use based on your hardware 
@@ -250,7 +250,7 @@ xpack.ml.model_repository: file://${path.home}/config/models/`
 . Repeat step 2 and step 3 on all master-eligible nodes.
 . {ref}/restart-cluster.html#restart-cluster-rolling[Restart] the 
 master-eligible nodes one by one.
-. Navigate to the **Trained Models** page in {kib}, E5 can be found in the 
+. Navigate to the **Trained Models** page from the main menu, or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search bar] in {kib}. E5 can be found in the 
 list of trained models.
 . Click the **Add trained model** button, select the E5 model version you 
 downloaded in step 1 and want to deploy and click **Download**. The selected 

--- a/docs/en/stack/ml/nlp/ml-nlp-e5.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-e5.asciidoc
@@ -92,7 +92,7 @@ NOTE: For most cases, the preferred version is the **Intel and Linux optimized**
 [[trained-model-e5]]
 ==== Using the Trained Models page
 
-1. In {kib}, navigate to **{ml-app}** > **Trained Models** from the main menu, or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search bar]. E5 can be found in 
+1. In {kib}, navigate to **{ml-app}** > **Trained Models** from the main menu, or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search field]. E5 can be found in 
 the list of trained models. There are two versions available: one portable 
 version which runs on any hardware and one version which is optimized for Intel® 
 silicon. You can see which model is recommended to use based on your hardware 
@@ -250,7 +250,7 @@ xpack.ml.model_repository: file://${path.home}/config/models/`
 . Repeat step 2 and step 3 on all master-eligible nodes.
 . {ref}/restart-cluster.html#restart-cluster-rolling[Restart] the 
 master-eligible nodes one by one.
-. Navigate to the **Trained Models** page from the main menu, or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search bar] in {kib}. E5 can be found in the 
+. Navigate to the **Trained Models** page from the main menu, or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search field] in {kib}. E5 can be found in the 
 list of trained models.
 . Click the **Add trained model** button, select the E5 model version you 
 downloaded in step 1 and want to deploy and click **Download**. The selected 

--- a/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
@@ -350,7 +350,7 @@ master-eligible nodes can reach the server you specify.
 . Repeat step 5 on all master-eligible nodes.
 . {ref}/restart-cluster.html#restart-cluster-rolling[Restart] the 
 master-eligible nodes one by one.
-. Navigate to the **Trained Models** page in {kib}, ELSER can be found in the 
+. Navigate to the **Trained Models** page from the main menu, or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search bar] in {kib}. ELSER can be found in the 
 list of trained models.
 . Click the **Add trained model** button, select the ELSER model version you 
 downloaded in step 1 and want to deploy, and click **Download**. The selected 
@@ -390,7 +390,7 @@ xpack.ml.model_repository: file://${path.home}/config/models/`
 . Repeat step 2 and step 3 on all master-eligible nodes.
 . {ref}/restart-cluster.html#restart-cluster-rolling[Restart] the 
 master-eligible nodes one by one.
-. Navigate to the **Trained Models** page in {kib}, ELSER can be found in the 
+. Navigate to the **Trained Models** page from the main menu, or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search bar] in {kib}. ELSER can be found in the 
 list of trained models.
 . Click the **Add trained model** button, select the ELSER model version you 
 downloaded in step 1 and want to deploy and click **Download**. The selected 
@@ -406,7 +406,7 @@ allocations and threads per allocation values.
 == Testing ELSER
 
 You can test the deployed model in {kib}. Navigate to **Model Management** > 
-**Trained Models**, locate the deployed ELSER model in the list of trained 
+**Trained Models** from the main menu, or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search bar] in {kib}. Locate the deployed ELSER model in the list of trained 
 models, then select **Test model** from the Actions menu.
 
 You can use data from an existing index to test the model. Select the index, 

--- a/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
@@ -350,7 +350,7 @@ master-eligible nodes can reach the server you specify.
 . Repeat step 5 on all master-eligible nodes.
 . {ref}/restart-cluster.html#restart-cluster-rolling[Restart] the 
 master-eligible nodes one by one.
-. Navigate to the **Trained Models** page from the main menu, or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search bar] in {kib}. ELSER can be found in the 
+. Navigate to the **Trained Models** page from the main menu, or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search field] in {kib}. ELSER can be found in the 
 list of trained models.
 . Click the **Add trained model** button, select the ELSER model version you 
 downloaded in step 1 and want to deploy, and click **Download**. The selected 
@@ -390,7 +390,7 @@ xpack.ml.model_repository: file://${path.home}/config/models/`
 . Repeat step 2 and step 3 on all master-eligible nodes.
 . {ref}/restart-cluster.html#restart-cluster-rolling[Restart] the 
 master-eligible nodes one by one.
-. Navigate to the **Trained Models** page from the main menu, or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search bar] in {kib}. ELSER can be found in the 
+. Navigate to the **Trained Models** page from the main menu, or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search field] in {kib}. ELSER can be found in the 
 list of trained models.
 . Click the **Add trained model** button, select the ELSER model version you 
 downloaded in step 1 and want to deploy and click **Download**. The selected 
@@ -406,7 +406,7 @@ allocations and threads per allocation values.
 == Testing ELSER
 
 You can test the deployed model in {kib}. Navigate to **Model Management** > 
-**Trained Models** from the main menu, or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search bar] in {kib}. Locate the deployed ELSER model in the list of trained 
+**Trained Models** from the main menu, or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search field] in {kib}. Locate the deployed ELSER model in the list of trained 
 models, then select **Test model** from the Actions menu.
 
 You can use data from an existing index to test the model. Select the index, 

--- a/docs/en/stack/ml/nlp/ml-nlp-inference.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-inference.asciidoc
@@ -18,7 +18,7 @@ can use it to perform {nlp} tasks in ingest pipelines.
 == Add an {infer} processor to an ingest pipeline
 
 In {kib}, you can create and edit pipelines in **{stack-manage-app}** >
-**Ingest Pipelines**. To open **Ingest Pipelines**, find **{stack-manage-app}** in the main menu, or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search bar].
+**Ingest Pipelines**. To open **Ingest Pipelines**, find **{stack-manage-app}** in the main menu, or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search field].
 
 [role="screenshot"]
 image::images/ml-nlp-pipeline-lang.png[Creating a pipeline in the Stack Management app,align="center"]

--- a/docs/en/stack/ml/nlp/ml-nlp-inference.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-inference.asciidoc
@@ -18,7 +18,7 @@ can use it to perform {nlp} tasks in ingest pipelines.
 == Add an {infer} processor to an ingest pipeline
 
 In {kib}, you can create and edit pipelines in **{stack-manage-app}** >
-**Ingest Pipelines**.
+**Ingest Pipelines**. To open **Ingest Pipelines**, find **{stack-manage-app}** in the main menu, or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search bar].
 
 [role="screenshot"]
 image::images/ml-nlp-pipeline-lang.png[Creating a pipeline in the Stack Management app,align="center"]

--- a/docs/en/stack/ml/nlp/ml-nlp-ner-example.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-ner-example.asciidoc
@@ -294,7 +294,7 @@ You can create a tag cloud to visualize your data processed by the {infer}
 pipeline. A tag cloud is a visualization that scales words by the frequency at 
 which they occur. It is a handy tool for viewing the entities found in the data.
 
-In {kib}, open **Stack management** > **{data-sources-cap}** from the main menu, or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search bar], and create a new 
+In {kib}, open **Stack management** > **{data-sources-cap}** from the main menu, or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search field], and create a new 
 {data-source} from the `les-miserables-infer` index pattern. 
 
 Open **Dashboard** and create a new dashboard. Select the 

--- a/docs/en/stack/ml/nlp/ml-nlp-ner-example.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-ner-example.asciidoc
@@ -294,7 +294,7 @@ You can create a tag cloud to visualize your data processed by the {infer}
 pipeline. A tag cloud is a visualization that scales words by the frequency at 
 which they occur. It is a handy tool for viewing the entities found in the data.
 
-In {kib}, open **Stack management** > **{data-sources-cap}**, and create a new 
+In {kib}, open **Stack management** > **{data-sources-cap}** from the main menu, or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search bar], and create a new 
 {data-source} from the `les-miserables-infer` index pattern. 
 
 Open **Dashboard** and create a new dashboard. Select the 

--- a/docs/en/stack/ml/setup.asciidoc
+++ b/docs/en/stack/ml/setup.asciidoc
@@ -105,7 +105,7 @@ find **{stack-manage-app}** > **{kib}** in the main menu, or use the {kibana-ref
 
 
 Each {ml} job and trained model can be assigned to all, one, or multiple spaces.
-This can be configured in **Machine Learning**. To open **Machine Learning**, find **{stack-manage-app} > Alerts and Insights**,
+This can be configured in **Machine Learning**. To open **Machine Learning**, find **{stack-manage-app} > Alerts and Insights** in the main menu,
 or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search bar].
 You can edit the spaces that a job or model is assigned to by clicking the
 icons in the **Spaces** column.

--- a/docs/en/stack/ml/setup.asciidoc
+++ b/docs/en/stack/ml/setup.asciidoc
@@ -45,7 +45,7 @@ privileges are recommended if you control job level visibility via **Spaces**.
 You can configure these privileges
 
 - under **Security**. To open Security, find **{stack-manage-app}** in the main menu or
-use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search bar].
+use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search field].
 - via the respective {es} security APIs.
 
 
@@ -93,7 +93,7 @@ visualizations as well as {ml} job, trained model and module saved objects.
 In {kib}, the {ml-features} must be visible in your
 {kibana-ref}/xpack-spaces.html#spaces-control-feature-visibility[space]. To 
 manage which features are visible in your space, go to **{stack-manage-app}** > 
-**{kib}** > **Spaces** or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search bar]
+**{kib}** > **Spaces** or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search field]
 to locate **Spaces** directly.
 
 [role="screenshot"]
@@ -101,12 +101,12 @@ image::spaces.jpg["Manage spaces in {kib}"]
 
 In addition to index privileges, source {data-sources} must also exist in the 
 same space as your {ml} jobs. You can configure these under **{data-sources-caps}**. To open **{data-sources-caps}**,
-find **{stack-manage-app}** > **{kib}** in the main menu, or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search bar].
+find **{stack-manage-app}** > **{kib}** in the main menu, or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search field].
 
 
 Each {ml} job and trained model can be assigned to all, one, or multiple spaces.
 This can be configured in **Machine Learning**. To open **Machine Learning**, find **{stack-manage-app} > Alerts and Insights** in the main menu,
-or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search bar].
+or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search field].
 You can edit the spaces that a job or model is assigned to by clicking the
 icons in the **Spaces** column.
 

--- a/docs/en/stack/ml/setup.asciidoc
+++ b/docs/en/stack/ml/setup.asciidoc
@@ -11,17 +11,16 @@
 
 To use the {stack} {ml-features}, you must have:
 
-[%interactive]
-- [ ] the {subscriptions}[appropriate subscription] level or the free trial 
+- the {subscriptions}[appropriate subscription] level or the free trial 
   period activated
-- [ ] `xpack.ml.enabled` set to its default value of `true` on every node in the 
+- `xpack.ml.enabled` set to its default value of `true` on every node in the 
   cluster (refer to {ref}/ml-settings.html[{ml-cap} settings in {es}])
-- [ ] `ml` value defined in the list of `node.roles` on the 
+- `ml` value defined in the list of `node.roles` on the 
   {ref}/modules-node.html#ml-node[{ml} nodes]
-- [ ] {ml} features visible in the {kib} space
-- [ ] security privileges assigned to the user that:
-    * grant use of {ml-features}, and
-    * grant access to source and destination indices.
+- {ml} features visible in the {kib} space
+- security privileges assigned to the user that:
+  * grant use of {ml-features}, and
+  * grant access to source and destination indices.
 
 TIP: The fastest way to get started with {ml-features} is to
 {ess-trial}[start a free 14-day trial of {ess}] in the cloud.
@@ -39,12 +38,15 @@ the two main categories:
 * *<<kib-security-privileges>>*: uses the {ml-features} in {kib} and does not 
 use Dev Tools. It requires either {kib} feature privileges or {es} security 
 privileges and is granted the most permissive combination of both. {kib} feature 
-privileges are recommended if you control job level visibility via _Spaces_. 
+privileges are recommended if you control job level visibility via **Spaces**. 
 {ml-cap} features must be visible in the relevant space. Refer to 
 <<kib-visibility-spaces>> for configuration information.
 
-You can configure these privileges under **{stack-manage-app}** > _Security_ in 
-{kib} or via the respective {es} security APIs.
+You can configure these privileges
+
+- under **Security**. To open Security, find **{stack-manage-app}** in the main menu or
+use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search bar].
+- via the respective {es} security APIs.
 
 
 [discrete]
@@ -55,19 +57,17 @@ If you use {ml} APIs, you must have the following cluster and index privileges:
 
 For full access:
 
-[%interactive]
-* [ ] `machine_learning_admin` built-in role or the equivalent cluster 
+* `machine_learning_admin` built-in role or the equivalent cluster 
 privileges 
-* [ ] `read` and `view_index_metadata` on source indices
-* [ ] `read`, `manage`, and `index` on destination indices (for 
+* `read` and `view_index_metadata` on source indices
+* `read`, `manage`, and `index` on destination indices (for 
   {dfanalytics-jobs} only)
 
 For read-only access:
 
-[%interactive]
-* [ ] `machine_learning_user` built-in role or the equivalent cluster privileges
-* [ ] `read` index privileges on source indices
-* [ ] `read` index privileges on destination indices (for {dfanalytics-jobs}
+* `machine_learning_user` built-in role or the equivalent cluster privileges
+* `read` index privileges on source indices
+* `read` index privileges on destination indices (for {dfanalytics-jobs}
   only)
 
 IMPORTANT: The `machine_learning_admin` and `machine_learning_user` built-in
@@ -92,19 +92,21 @@ visualizations as well as {ml} job, trained model and module saved objects.
 
 In {kib}, the {ml-features} must be visible in your
 {kibana-ref}/xpack-spaces.html#spaces-control-feature-visibility[space]. To 
-control which features are visible in your space, use **{stack-manage-app}** > 
-_{kib}_ > _Spaces_.
+manage which features are visible in your space, go to **{stack-manage-app}** > 
+**{kib}** > **Spaces** or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search bar]
+to locate **Spaces** directly.
 
 [role="screenshot"]
 image::spaces.jpg["Manage spaces in {kib}"]
 
 In addition to index privileges, source {data-sources} must also exist in the 
-same space as your {ml} jobs. These can be configured in **{stack-manage-app}** 
-> _{kib}_ > _{data-sources-caps}_.
+same space as your {ml} jobs. You can configure these under **{data-sources-caps}**. To open **{data-sources-caps}**,
+find **{stack-manage-app}** > **{kib}** in the main menu, or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search bar].
 
 
 Each {ml} job and trained model can be assigned to all, one, or multiple spaces.
-This can be configured in **{stack-manage-app} > Alerts and Insights > Machine Learning**.
+This can be configured in **Machine Learning**. To open **Machine Learning**, find **{stack-manage-app} > Alerts and Insights**,
+or use the {kibana-ref}/kibana-concepts-analysts.html#_finding_your_apps_and_objects[global search bar].
 You can edit the spaces that a job or model is assigned to by clicking the
 icons in the **Spaces** column.
 
@@ -118,22 +120,20 @@ image::assign-job-spaces.jpg["Assign machine learning jobs to spaces"]
 
 Within a {kib} space, for full access to the {ml-features}, you must have:
 
-[%interactive]
-* [ ] `Machine Learning: All` {kib} privileges
-* [ ] `Data Views Management: All` {kib} feature privileges
-* [ ] `read`, and `view_index_metadata` index privileges on your source indices
-* [ ] {data-sources} for your source indices
-* [ ] {data-sources}, `read`, `manage`, and `index` index privileges on 
+* `Machine Learning: All` {kib} privileges
+* `Data Views Management: All` {kib} feature privileges
+* `read`, and `view_index_metadata` index privileges on your source indices
+* {data-sources} for your source indices
+* {data-sources}, `read`, `manage`, and `index` index privileges on 
   destination indices (for {dfanalytics-jobs} only)
 
 
 Within a {kib} space, for read-only access to the {ml-features}, you must have:
 
-[%interactive]
-* [ ] `Machine Learning: Read` {kib} privileges
-* [ ] {data-sources} for your source indices
-* [ ] `read` index privilege on your source indices
-* [ ] {data-sources} and `read` index privileges on destination indices (for 
+* `Machine Learning: Read` {kib} privileges
+* {data-sources} for your source indices
+* `read` index privilege on your source indices
+* {data-sources} and `read` index privileges on destination indices (for 
   {dfanalytics-jobs} only)
 
 IMPORTANT: A user who has full or read-only access to {ml-features} within
@@ -158,12 +158,11 @@ privileges and grant access to `machine_learning_admin` or
 Within a {kib} space, to upload and import files in the *{data-viz}*, you must 
 have:
 
-[%interactive]
-- [ ] `Machine Learning: Read` or `Discover: All` {kib} feature privileges
-- [ ] `Data Views Management: All` {kib} feature privileges
-- [ ] `ingest_admin` built-in role, or `manage_ingest_pipelines` cluster 
+- `Machine Learning: Read` or `Discover: All` {kib} feature privileges
+- `Data Views Management: All` {kib} feature privileges
+- `ingest_admin` built-in role, or `manage_ingest_pipelines` cluster 
   privilege
-- [ ] `create`, `create_index`, `manage` and `read` index privileges for
+- `create`, `create_index`, `manage` and `read` index privileges for
   destination indices
 
 For more information, see {ref}/security-privileges.html[Security privileges] 


### PR DESCRIPTION
### Overview
This PR updates app and page references to align with the new style guide guidelines, ensuring consistency across both the classic and solution views to help users locate pages regardless of their chosen view. Additionally, the update removes interactive checkboxes, replacing them with bullet points.

### Related issue
https://github.com/elastic/search-docs-team/issues/205