### PR TITLE
Updates ELSER documentation to use 'elasticsearch' service

### DIFF
--- a/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
@@ -122,10 +122,11 @@ The easiest and recommended way to download and deploy ELSER is to use the {ref}
 ----------------------------------
 PUT _inference/sparse_embedding/my-elser-model
 {
-  "service": "elser",
+  "service": "elasticsearch",
   "service_settings": {
     "num_allocations": 1,
-    "num_threads": 1
+    "num_threads": 1,
+    "model_id": ".elser_model_2_linux-x86_64"
   }
 }
 ----------------------------------


### PR DESCRIPTION
### Overview

This PR updates the ELSER conceptual documentation to replace the deprecated `elser` service with the `elasticsearch` service in the deployment example. The `PUT` inference API call now specifies the `elasticsearch` service along with the `model_id` required for deployment.

### Related issue

https://github.com/elastic/search-docs-team/issues/216

### Preview
