### PR TITLE
Fixes typo on the "ELSER – Elastic Learned Sparse EncodeR" page

### DIFF
--- a/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
@@ -228,7 +228,7 @@ image::images/ml-nlp-start-elser-v2-es.png[alt="Start ELSER in Elasticsearch",al
 --
 =====
 
-.Using the traned models API in Dev Console
+.Using the trained models API in Dev Console
 [%collapsible%closed]
 =====
 [discrete]


### PR DESCRIPTION
### Overview

This PR fixes a typo on the [ELSER – Elastic Learned Sparse EncodeR](https://www.elastic.co/guide/en/machine-learning/current/ml-nlp-elser.html) page.

### Related issue

https://github.com/elastic/stack-docs/issues/2869