### PR TITLE
[DOCS] [ML] Fixes broken links in ELSER documentation

### DIFF
--- a/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
@@ -90,7 +90,7 @@ to download and deploy the model and you don't need to select from different
 versions. 
 
 If you want to learn more about the ELSER V2 improvements, refer to 
-https://www.elastic.co/search-labs/introducing-elser-v2-part-1[this blog post].
+https://www.elastic.co/search-labs/blog/introducing-elser-v2-part-1[this blog post].
 
 
 [discrete]
@@ -560,7 +560,7 @@ IMPORTANT: The length of the documents in your particular dataset will have a
 significant impact on your throughput numbers.
 
 Refer to 
-https://www.elastic.co/search-labs/introducing-elser-v2-part-1[this blog post] 
+https://www.elastic.co/search-labs/blog/introducing-elser-v2-part-1[this blog post] 
 to learn more about ELSER V2 improved performance.
 
 image::images/ml-nlp-elser-bm-summary.png[alt="Summary of ELSER V1 and V2 benchmark reports",align="center"]


### PR DESCRIPTION
### Overview

On the ELSER page, there are two broken links pointing to the same blog post. This PR fixes both links.

### Related issue

https://github.com/elastic/stack-docs/issues/2885