### PR TITLE
Add sparse embedding models to list of compatible models

### DIFF
--- a/docs/en/stack/ml/nlp/ml-nlp-model-ref.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-model-ref.asciidoc
@@ -86,7 +86,7 @@ Sparse embedding models should be configured with the `text_expansion` task type
 
 * https://huggingface.co/naver/splade-v3-distilbert[SPLADE-v3-DistilBERT]
 * https://huggingface.co/aken12/splade-japanese-v3[aken12/splade-japanese-v3]
-* https://huggingface.co/hotchpotch/japanese-splade-base-v1[hotchpotch/japanese-splade-base-v1]
+* https://huggingface.co/hotchpotch/japanese-splade-v2[hotchpotch/japanese-splade-v2]
 
 
 [discrete]

--- a/docs/en/stack/ml/nlp/ml-nlp-model-ref.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-model-ref.asciidoc
@@ -78,6 +78,16 @@ purposes and to get started with the Elastic {nlp} features.
 * https://huggingface.co/deepset/electra-base-squad2[Electra base squad2]
 * https://huggingface.co/deepset/tinyroberta-squad2[TinyRoBERTa squad2]
 
+[discrete]
+[[ml-nlp-model-ref-sparse-embedding]]
+== Third party sparse embedding models
+
+Sparse embedding models should be configured with the `text_expansion` task type.
+
+* https://huggingface.co/naver/splade-v3-distilbert[SPLADE-v3-DistilBERT]
+* https://huggingface.co/aken12/splade-japanese-v3[aken12/splade-japanese-v3]
+* https://huggingface.co/hotchpotch/japanese-splade-base-v1[hotchpotch/japanese-splade-base-v1]
+
 
 [discrete]
 [[ml-nlp-model-ref-text-embedding]]


### PR DESCRIPTION
With the change in https://github.com/elastic/eland/pull/740 Eland now supports uploading 3rd party sparse embedding models (other than ELSER). This PR adds some models to the list of known compatible models.

The Eland command to install one of these models must use the text_expansion task type
```
eland_import_hub_model \
      --url 'http://localhost:9200' \
      -u elastic-admin -p elastic-password \
      --hub-model-id 'hotchpotch/japanese-splade-base-v1' \
      --task-type text_expansion 
```