### PR TITLE
Adds Demi as codeowner to glossary terms

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
 * @elastic/platform-docs
 /docs/en/stack/ml/ @elastic/mlr-docs
+/docs/en/glossary/terms/ @demisperazza


### PR DESCRIPTION
To make sure the [Elastic Docs Terminology](https://www.elastic.co/guide/en/elastic-stack-glossary/current/terms.html) and [Elastic in Writing: Writing style guide](https://brand.elastic.co/302f66895/p/194a3b-writing-style-guide) are consistent, adding @demisperazza as codeowner to docs/en/glossary/terms/.