### PR TITLE
Changes blog URL on Rerank page

### DIFF
--- a/docs/en/stack/ml/nlp/ml-nlp-elastic-rerank.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-elastic-rerank.asciidoc
@@ -338,7 +338,7 @@ Elastic Rerank shows significant improvements in search quality across a wide ra
 * Climate-FEVER: 80% improvement
 * FiQA-2018: 76% improvement
 
-For detailed benchmark information, including complete dataset results and methodology, refer to the https://www.elastic.co/search-labs/introducing-elastic-rerank[Introducing Elastic Rerank blog].
+For detailed benchmark information, including complete dataset results and methodology, refer to the https://www.elastic.co/search-labs/blog/elastic-semantic-reranker-part-2[Introducing Elastic Rerank blog].
 
 // [discrete]
 // [[ml-nlp-rerank-benchmarks-hw]]


### PR DESCRIPTION
## Overview

This PR changes a URL that points to the Elastic Rerank intro blog post. The blog post URL has changed, so this PR updates the link on the page.