### PR TITLE
Removes 206313 from the Feb 3, 2025 Serverless changelog

### DIFF
--- a/docs/en/install-upgrade/serverless-changelog.asciidoc
+++ b/docs/en/install-upgrade/serverless-changelog.asciidoc
@@ -33,7 +33,6 @@ For serverless changes in Cloud Console, refer to https://www.elastic.co/guide/e
 * Adds in-text citations to security solution AI assistant responses ({kibana-pull}206683[#206683]).
 * Remove Tech preview badge for GA ({kibana-pull}208523[#208523]).
 * Adds new View job detail flyouts for Anomaly detection and Data Frame Analytics ({kibana-pull}207141[#207141]).
-* Rule gaps ({kibana-pull}206313[#206313]).
 * Adds a default "All logs" temporary data view in the Observability Solution view ({kibana-pull}205991[#205991]).
 * Adds Knowledge Base entries API ({kibana-pull}206407[#206407]).
 * Adds Kibana Support for Security AI Prompts Integration ({kibana-pull}207138[#207138]).


### PR DESCRIPTION
Removes 206313 since the gap feature hasn't been released in Serverless yet.