### PR TITLE
Change base in mergify configuration

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -18,7 +18,7 @@ pull_request_rules:
   - name: backport patches to 8.18 branch
     conditions:
       - merged
-      - base=main
+      - base=8.x
       - label=backport-8.18
     actions:
       backport:
@@ -32,7 +32,7 @@ pull_request_rules:
   - name: backport patches to 8.17 branch
     conditions:
       - merged
-      - base=main
+      - base=8.x
       - label=backport-8.17
     actions:
       backport:
@@ -46,7 +46,7 @@ pull_request_rules:
   - name: backport patches to 8.16 branch
     conditions:
       - merged
-      - base=main
+      - base=8.x
       - label=backport-8.16
     actions:
       backport:
@@ -60,7 +60,7 @@ pull_request_rules:
   - name: backport patches to 8.15 branch
     conditions:
       - merged
-      - base=main
+      - base=8.x
       - label=backport-8.15
     actions:
       backport:
@@ -74,7 +74,7 @@ pull_request_rules:
   - name: backport patches to 8.14 branch
     conditions:
       - merged
-      - base=main
+      - base=8.x
       - label=backport-8.14
     actions:
       backport:
@@ -88,7 +88,7 @@ pull_request_rules:
   - name: backport patches to 8.13 branch
     conditions:
       - merged
-      - base=main
+      - base=8.x
       - label=backport-8.13
     actions:
       backport:
@@ -102,7 +102,7 @@ pull_request_rules:
   - name: backport patches to 8.12 branch
     conditions:
       - merged
-      - base=main
+      - base=8.x
       - label=backport-8.12
     actions:
       backport:
@@ -116,7 +116,7 @@ pull_request_rules:
   - name: backport patches to 8.11 branch
     conditions:
       - merged
-      - base=main
+      - base=8.x
       - label=backport-8.11
     actions:
       backport:
@@ -130,7 +130,7 @@ pull_request_rules:
   - name: backport patches to 8.10 branch
     conditions:
       - merged
-      - base=main
+      - base=8.x
       - label=backport-8.10
     actions:
       backport:
@@ -144,7 +144,7 @@ pull_request_rules:
   - name: backport patches to 8.9 branch
     conditions:
       - merged
-      - base=main
+      - base=8.x
       - label=backport-8.9
     actions:
       backport:
@@ -158,7 +158,7 @@ pull_request_rules:
   - name: backport patches to 8.8 branch
     conditions:
       - merged
-      - base=main
+      - base=8.x
       - label=backport-8.8
     actions:
       backport:
@@ -172,7 +172,7 @@ pull_request_rules:
   - name: backport patches to 8.7 branch
     conditions:
       - merged
-      - base=main
+      - base=8.x
       - label=backport-8.7
     actions:
       backport:
@@ -186,7 +186,7 @@ pull_request_rules:
   - name: backport patches to 8.6 branch
     conditions:
       - merged
-      - base=main
+      - base=8.x
       - label=backport-8.6
     actions:
       backport:
@@ -200,7 +200,7 @@ pull_request_rules:
   - name: backport patches to 8.5 branch
     conditions:
       - merged
-      - base=main
+      - base=8.x
       - label=backport-8.5
     actions:
       backport:
@@ -214,7 +214,7 @@ pull_request_rules:
   - name: backport patches to 8.4 branch
     conditions:
       - merged
-      - base=main
+      - base=8.x
       - label=backport-8.4
     actions:
       backport:
@@ -228,7 +228,7 @@ pull_request_rules:
   - name: backport patches to 8.3 branch
     conditions:
       - merged
-      - base=main
+      - base=8.x
       - label=backport-8.3
     actions:
       backport:
@@ -242,7 +242,7 @@ pull_request_rules:
   - name: backport patches to 8.2 branch
     conditions:
       - merged
-      - base=main
+      - base=8.x
       - label=backport-8.2
     actions:
       backport:
@@ -256,7 +256,7 @@ pull_request_rules:
   - name: backport patches to 8.1 branch
     conditions:
       - merged
-      - base=main
+      - base=8.x
       - label=backport-8.1
     actions:
       backport:
@@ -270,7 +270,7 @@ pull_request_rules:
   - name: backport patches to 8.0 branch
     conditions:
       - merged
-      - base=main
+      - base=8.x
       - label=backport-8.0
     actions:
       backport:
@@ -284,7 +284,7 @@ pull_request_rules:
   - name: backport patches to 7.17 branch
     conditions:
       - merged
-      - base=main
+      - base=8.x
       - label=backport-7.17
     actions:
       backport:


### PR DESCRIPTION
This PR aims to ensure that PRs merged in the 8.x branch can also be automatically backported, not just those that start in the main branch.