### PR TITLE
Add release notes placeholders for 9.0.0-beta1

### DIFF
--- a/docs/en/install-upgrade/index.asciidoc
+++ b/docs/en/install-upgrade/index.asciidoc
@@ -32,8 +32,16 @@ include::upgrading-kibana.asciidoc[]
 
 // include::upgrading-agent.asciidoc[]
 
+include::serverless-changelog.asciidoc[]
+
 include::breaking.asciidoc[]
 
-include::serverless-changelog.asciidoc[]
+include::release-notes/release-notes.asciidoc[leveloffset=+1]
+
+include::release-notes/release-notes-elasticsearch.asciidoc[leveloffset=+2]
+
+include::release-notes/release-notes-kibana.asciidoc[leveloffset=+2]
+
+include::release-notes/release-notes-logstash.asciidoc[leveloffset=+2]
 
 include::redirects.asciidoc[]

--- a/docs/en/install-upgrade/release-notes/release-notes-elasticsearch.asciidoc
+++ b/docs/en/install-upgrade/release-notes/release-notes-elasticsearch.asciidoc
@@ -1,0 +1,8 @@
+[[release-notes-elasticsearch-9.0.0-beta1]]
+= {es} version 9.0.0-beta1
+++++
+<titleabbrev>{es}</titleabbrev>
+++++
+
+coming::[9.0.0-beta1]
+

--- a/docs/en/install-upgrade/release-notes/release-notes-kibana.asciidoc
+++ b/docs/en/install-upgrade/release-notes/release-notes-kibana.asciidoc
@@ -1,0 +1,8 @@
+[[release-notes-kibana-9.0.0-beta1]]
+= {kib} version 9.0.0-beta1
+++++
+<titleabbrev>{kib}</titleabbrev>
+++++
+
+coming::[9.0.0-beta1]
+

--- a/docs/en/install-upgrade/release-notes/release-notes-logstash.asciidoc
+++ b/docs/en/install-upgrade/release-notes/release-notes-logstash.asciidoc
@@ -1,0 +1,8 @@
+[[release-notes-logstash-9.0.0-beta1]]
+= {ls} version 9.0.0-beta1
+++++
+<titleabbrev>{ls}</titleabbrev>
+++++
+
+coming::[9.0.0-beta1]
+

--- a/docs/en/install-upgrade/release-notes/release-notes.asciidoc
+++ b/docs/en/install-upgrade/release-notes/release-notes.asciidoc
@@ -1,0 +1,7 @@
+[[elastic-stack-release-notes]]
+= Release notes
+
+This section summarizes the changes in the {stack} releases.
+
+coming::[9.0.0-beta1]
+


### PR DESCRIPTION
This PR adds a release notes section to the Installation and Upgrade Guide. It also adds some empty pages for the Elasticsearch, Kibana, and Logstash 9.0.0-beta1 release notes as a stop-gap location for this information during the content migration.