### PR TITLE
Adds release notes placeholders for Security 9.0.0-beta1

### DIFF
--- a/docs/en/install-upgrade/index.asciidoc
+++ b/docs/en/install-upgrade/index.asciidoc
@@ -44,4 +44,6 @@ include::release-notes/release-notes-kibana.asciidoc[leveloffset=+2]
 
 include::release-notes/release-notes-logstash.asciidoc[leveloffset=+2]
 
+include::release-notes/release-notes-security.asciidoc[leveloffset=+2]
+
 include::redirects.asciidoc[]

--- a/docs/en/install-upgrade/release-notes/release-notes-security.asciidoc
+++ b/docs/en/install-upgrade/release-notes/release-notes-security.asciidoc
@@ -1,0 +1,7 @@
+[[release-notes-security-9.0.0-beta1]]
+= {elastic-sec} version 9.0.0-beta1
+++++
+<titleabbrev>{es}</titleabbrev>
+++++
+
+coming::[9.0.0-beta1]

--- a/docs/en/install-upgrade/release-notes/release-notes-security.asciidoc
+++ b/docs/en/install-upgrade/release-notes/release-notes-security.asciidoc
@@ -1,7 +1,7 @@
 [[release-notes-security-9.0.0-beta1]]
 = {elastic-sec} version 9.0.0-beta1
 ++++
-<titleabbrev>{es}</titleabbrev>
+<titleabbrev>{elastic-sec}</titleabbrev>
 ++++
 
 coming::[9.0.0-beta1]

--- a/docs/en/install-upgrade/release-notes/release-notes.asciidoc
+++ b/docs/en/install-upgrade/release-notes/release-notes.asciidoc
@@ -3,5 +3,8 @@
 
 This section summarizes the changes in the {stack} releases.
 
-coming::[9.0.0-beta1]
+* <<release-notes-security-9.0.0-beta1>>
+* <<release-notes-elasticsearch-9.0.0-beta1>>
+* <<release-notes-kibana-9.0.0-beta1>>
+* <<release-notes-logstash-9.0.0-beta1>>
 


### PR DESCRIPTION
This PR adds an empty page for the Security 9.0.0-beta1 release notes.