### PR TITLE
Remove coming tags, fix security release note levels

### DIFF
--- a/docs/en/install-upgrade/release-notes/release-notes-kibana.asciidoc
+++ b/docs/en/install-upgrade/release-notes/release-notes-kibana.asciidoc
@@ -4,8 +4,6 @@
 <titleabbrev>{kib}</titleabbrev>
 ++++
 
-coming::[9.0.0-beta1]
-
 For information about the {kib} 9.0.0 release, review the following information.
 
 [float]

--- a/docs/en/install-upgrade/release-notes/release-notes-security.asciidoc
+++ b/docs/en/install-upgrade/release-notes/release-notes-security.asciidoc
@@ -4,25 +4,16 @@
 <titleabbrev>{elastic-sec}</titleabbrev>
 ++++
 
-coming::[9.0.0-beta1]
-
-[[release-notes-header-9.0.0]]
-== 9.0
-
-[discrete]
-[[release-notes-9.0.0-beta]]
-=== 9.0.0-beta
-
 [discrete]
 [[breaking-changes-9.0.0-beta]]
-==== Breaking changes
+== Breaking changes
 * Refactors the Timeline HTTP API endpoints ({kibana-pull}200633[#200633]).
 * Removes deprecated API endpoints for {elastic-defend} ({kibana-pull}199598[#199598]).
 * Removes deprecated API endpoints for bulk CRUD actions on detection rules ({kibana-pull}197422[#197422], {kibana-pull}207906[#207906]).
 
 [discrete]
 [[deprecations-9.0.0-beta]]
-==== Deprecations
+== Deprecations
 * Renames the `integration-assistant` plugin to `automatic-import` to match the associated feature ({kibana-pull}207325[#207325]).
 * Removes all legacy risk engine code and features ({kibana-pull}201810[#201810]).
 * Removes deprecated API endpoints for {elastic-defend} ({kibana-pull}199598[#199598]).
@@ -30,7 +21,7 @@ coming::[9.0.0-beta1]
 
 [discrete]
 [[known-issue-9.0.0-beta]]
-==== Known issues
+== Known issues
 
 // tag::known-issue[]
 [discrete]
@@ -54,14 +45,14 @@ On November 12, 2024, it was discovered that manually running a custom query rul
 
 [discrete]
 [[features-9.0.0-beta]]
-==== New features
+== New features
 * Enables Automatic Import to accept CEL log samples ({kibana-pull}206491[#206491]).
 * Applies the latest Elastic UI framework (EUI) to {elastic-sec} features ({kibana-pull}204007[#204007], {kibana-pull}204908[#204908]).
 * Adds the option to view {es} queries that run during rule execution for threshold, custom query, and {ml} rules ({kibana-pull}203320[#203320]). 
 
 [discrete]
 [[enhancements-9.0.0-beta]]
-==== Enhancements
+== Enhancements
 * Enhances Automatic Import by including setup and troubleshooting documentation for each input type that's selected in the readme ({kibana-pull}206477[#206477]).
 * Allows users to include `closed` alerts in risk score calculations ({kibana-pull}201909[#201909]).
 * Adds the ability to continue to the Entity Analytics dashboard when there is no data ({kibana-pull}201363[#201363]).
@@ -69,5 +60,5 @@ On November 12, 2024, it was discovered that manually running a custom query rul
 
 [discrete]
 [[bug-fixes-9.0.0-beta]]
-==== Bug fixes
+== Bug fixes
 * Ensures that table actions use standard colors ({kibana-pull}207743[#207743]).


### PR DESCRIPTION
This PR removes the "coming" admonitions from the Kibana and Logstash release notes. It also removes some extra section levels from the security release notes.