### PR TITLE
Adds transforms to Upgrade guide

### DIFF
--- a/docs/en/install-upgrade/upgrading-stack.asciidoc
+++ b/docs/en/install-upgrade/upgrading-stack.asciidoc
@@ -852,7 +852,7 @@ POST _aliases
 ----
 ====
 
-.Deleting the transform
+.Deleting the {transform}
 [%collapsible]
 ====
 You can use the https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-transform-delete-transform[Transform Delete API] to delete the transform and stop it from writing to the destination index.

--- a/docs/en/install-upgrade/upgrading-stack.asciidoc
+++ b/docs/en/install-upgrade/upgrading-stack.asciidoc
@@ -510,7 +510,7 @@ POST _transform/my-transform/_reset
 .Reindexing the transform’s destination index while the Transform is paused
 [%collapsible]
 ====
-When Kibana’s Upgrade Assistant reindexes the documents, Kibana will put a write block on the old destination index, copy the results to a new index, delete the old index, and create an alias to the new index. During the time, the Transform will pause and wait for the destination to become writable again.  If you do not want the Transform to pause, continue to <<breaking_90_transform_reindex_running, reindexing while running>>.
+When Kibana’s Upgrade Assistant reindexes the documents, Kibana will put a write block on the old destination index, copy the results to a new index, delete the old index, and create an alias to the new index. During the time, the Transform will pause and wait for the destination to become writable again.  If you do not want the Transform to pause, continue to <<reindexing-transform-running>>.
 
 If an index is less than 10GB of size, we recommend using Kibana’s Upgrade Assistant to automatically migrate the index.
 

--- a/docs/en/install-upgrade/upgrading-stack.asciidoc
+++ b/docs/en/install-upgrade/upgrading-stack.asciidoc
@@ -771,7 +771,7 @@ PUT /my-destination-index/_settings
 }
 ----
 
-.. Start the reindexing process in asynchronous mode. Set the `op_type` to `create` so the reindex does not overwrite work that the Transform is doing.
+.. Start the reindexing process in asynchronous mode. Set the `op_type` to `create` so the reindex does not overwrite work that the {transform} is doing.
 
 +
 [source,console]

--- a/docs/en/install-upgrade/upgrading-stack.asciidoc
+++ b/docs/en/install-upgrade/upgrading-stack.asciidoc
@@ -855,7 +855,7 @@ POST _aliases
 .Deleting the {transform}
 [%collapsible]
 ====
-You can use the https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-transform-delete-transform[Transform Delete API] to delete the transform and stop it from writing to the destination index.
+You can use the https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-transform-delete-transform[Transform Delete API] to delete the {transform} and stop it from writing to the destination index.
 
 [source,console]
 ----

--- a/docs/en/install-upgrade/upgrading-stack.asciidoc
+++ b/docs/en/install-upgrade/upgrading-stack.asciidoc
@@ -713,7 +713,7 @@ POST _aliases
 .Reindexing the {transform}'s destination index while the {transform} is running
 [%collapsible]
 ====
-If you want the Transform and the Reindex task to write documents to the new destination index at the same time:
+If you want the {transform} and the reindex task to write documents to the new destination index at the same time:
 
 . Set the original index to read-only.
 +

--- a/docs/en/install-upgrade/upgrading-stack.asciidoc
+++ b/docs/en/install-upgrade/upgrading-stack.asciidoc
@@ -510,7 +510,7 @@ POST _transform/my-transform/_reset
 .Reindexing the transform’s destination index while the Transform is paused
 [%collapsible]
 ====
-When Kibana’s Upgrade Assistant reindexes the documents, Kibana will put a write block on the old destination index, copy the results to a new index, delete the old index, and create an alias to the new index. During the time, the Transform will pause and wait for the destination to become writable again.  If you do not want the Transform to pause, continue to <<reindexing-transform-running>>.
+When Kibana’s Upgrade Assistant reindexes the documents, Kibana will put a write block on the old destination index, copy the results to a new index, delete the old index, and create an alias to the new index. During the time, the Transform will pause and wait for the destination to become writable again.  If you do not want the Transform to pause, continue to <<reindexing-transform-running, Reindexing the transform’s destination index while the Transform is running>>.
 
 If an index is less than 10GB of size, we recommend using Kibana’s Upgrade Assistant to automatically migrate the index.
 

--- a/docs/en/install-upgrade/upgrading-stack.asciidoc
+++ b/docs/en/install-upgrade/upgrading-stack.asciidoc
@@ -469,7 +469,6 @@ The transform destination indices created in Elasticsearch 7.x must be either re
 .Which indices require attention?
 [%collapsible]
 ====
-
 To identify indices that require action, use the https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-migration-deprecations-1[Deprecation info API]:
 
 [source,console]
@@ -493,11 +492,11 @@ The response contains the list of critical deprecation warnings in the `index_se
     ]
   }
 ----
+====
 
 .Resetting the transform
 [%collapsible]
 ====
-
 If the index was created by the Transform, you can use the https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-transform-reset-transform[Transform Reset API] to delete the destination index and recreate it the next time the Transform runs.
 
 If the index was not created by the Transform, and you still want to reset it, you can manually delete and recreate the index, then call the Reset API.
@@ -506,11 +505,12 @@ If the index was not created by the Transform, and you still want to reset it, y
 ----
 POST _transform/my-transform/_reset
 ----
+====
 
 .Reindexing the transform’s destination index while the Transform is paused
 [%collapsible]
 ====
-When Kibana’s Upgrade Assistant reindexes the documents, Kibana will put a write block on the old destination index, copy the results to a new index, delete the old index, and create an alias to the new index. During the time, the Transform will pause and wait for the destination to become writable again.  If you do not want the Transform to pause, continue to [insert link to next section TODO].
+When Kibana’s Upgrade Assistant reindexes the documents, Kibana will put a write block on the old destination index, copy the results to a new index, delete the old index, and create an alias to the new index. During the time, the Transform will pause and wait for the destination to become writable again.  If you do not want the Transform to pause, continue to <<breaking_90_transform_reindex_running, reindexing while running>>.
 
 If an index is less than 10GB of size, we recommend using Kibana’s Upgrade Assistant to automatically migrate the index.
 
@@ -709,6 +709,7 @@ POST _aliases
 ----
 ====
 
+[[reindexing-transform-running]]
 .Reindexing the transform’s destination index while the Transform is running
 [%collapsible]
 ====

--- a/docs/en/install-upgrade/upgrading-stack.asciidoc
+++ b/docs/en/install-upgrade/upgrading-stack.asciidoc
@@ -499,7 +499,7 @@ The response contains the list of critical deprecation warnings in the `index_se
 ====
 If the index was created by the {transform}, you can use the https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-transform-reset-transform[Transform Reset API] to delete the destination index and recreate it the next time the {transform} runs.
 
-If the index was not created by the Transform, and you still want to reset it, you can manually delete and recreate the index, then call the Reset API.
+If the index was not created by the {transform}, and you still want to reset it, you can manually delete and recreate the index, then call the Reset API.
 
 [source,console]
 ----

--- a/docs/en/install-upgrade/upgrading-stack.asciidoc
+++ b/docs/en/install-upgrade/upgrading-stack.asciidoc
@@ -497,7 +497,7 @@ The response contains the list of critical deprecation warnings in the `index_se
 .Resetting the transform
 [%collapsible]
 ====
-If the index was created by the Transform, you can use the https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-transform-reset-transform[Transform Reset API] to delete the destination index and recreate it the next time the Transform runs.
+If the index was created by the {transform}, you can use the https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-transform-reset-transform[Transform Reset API] to delete the destination index and recreate it the next time the {transform} runs.
 
 If the index was not created by the Transform, and you still want to reset it, you can manually delete and recreate the index, then call the Reset API.
 

--- a/docs/en/install-upgrade/upgrading-stack.asciidoc
+++ b/docs/en/install-upgrade/upgrading-stack.asciidoc
@@ -510,7 +510,7 @@ POST _transform/my-transform/_reset
 .Reindexing the {transform}'s destination index while the {transform} is paused
 [%collapsible]
 ====
-When Kibana’s Upgrade Assistant reindexes the documents, Kibana will put a write block on the old destination index, copy the results to a new index, delete the old index, and create an alias to the new index. During the time, the Transform will pause and wait for the destination to become writable again.  If you do not want the Transform to pause, continue to <<reindexing-transform-running, Reindexing the transform’s destination index while the Transform is running>>.
+When {kib} Upgrade Assistant reindexes the documents, {kib} will put a write block on the old destination index, copy the results to a new index, delete the old index, and create an alias to the new index. During this time, the {transform} will pause and wait for the destination to become writable again.  If you do not want the {transform} to pause, continue to <<reindexing-transform-running, reindexing the {transform}'s destination index while the {transform} is running>>.
 
 If an index is less than 10GB of size, we recommend using Kibana’s Upgrade Assistant to automatically migrate the index.
 

--- a/docs/en/install-upgrade/upgrading-stack.asciidoc
+++ b/docs/en/install-upgrade/upgrading-stack.asciidoc
@@ -454,3 +454,418 @@ endif::[]
 // 
 // end::generic-upgrade-steps[]
 
+[discrete]
+[[breaking_90_transform_destination_index]]
+=== Transform destination indices migration
+
+The transform destination indices created in Elasticsearch 7.x must be either reset, reindexed, or deleted before upgrading to 9.x.
+
+**Resetting**: You can reset the Transform to delete all state, checkpoints, and the destination index (if it was created by the Transform). The next time you start the Transform, it will reprocess all data from the source index, creating a new destination index in Elasticsearch 8.x compatible with 9.x. However, if data had been deleted from the source index, you will lose all previously computed results that had been stored in the destination index.
+
+**Reindexing**: You can reindex the destination index and then update the Transform to write to the new destination index. This is useful if there are results that you want to retain that may not exist in the source index. In order to prevent the Transform and Reindex tasks from conflicting with one another, you can either pause the Transform while the Reindex runs, or you can write to the new destination index while the Reindex backfills old results.
+
+**Deleting**: You can delete any Transforms that are no longer being used. Once the Transform is deleted, you can either delete the destination index or move it into readonly.
+
+.Which indices require attention?
+[%collapsible]
+====
+
+To identify indices that require action, use the https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-migration-deprecations-1[Deprecation info API]:
+
+[source,console]
+----
+GET /_migration/deprecations
+----
+
+The response contains the list of critical deprecation warnings in the `index_settings` section:
+
+[source,console]
+----
+"index_settings": {
+    "my-destination-index": [
+      {
+        "level": "critical",
+        "message": "One or more Transforms write to this index with a compatibility version < 9.0",
+        "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/migrating-9.0.html#breaking_90_transform_destination_index",
+        "details": "Transforms [my-transform] write to this index with version [7.8.23].",
+        "resolve_during_rolling_upgrade": false
+      }
+    ]
+  }
+----
+
+.Resetting the transform
+[%collapsible]
+====
+
+If the index was created by the Transform, you can use the https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-transform-reset-transform[Transform Reset API] to delete the destination index and recreate it the next time the Transform runs.
+
+If the index was not created by the Transform, and you still want to reset it, you can manually delete and recreate the index, then call the Reset API.
+
+[source,console]
+----
+POST _transform/my-transform/_reset
+----
+
+.Reindexing the transform’s destination index while the Transform is paused
+[%collapsible]
+====
+When Kibana’s Upgrade Assistant reindexes the documents, Kibana will put a write block on the old destination index, copy the results to a new index, delete the old index, and create an alias to the new index. During the time, the Transform will pause and wait for the destination to become writable again.  If you do not want the Transform to pause, continue to [insert link to next section TODO].
+
+If an index is less than 10GB of size, we recommend using Kibana’s Upgrade Assistant to automatically migrate the index.
+
+If an index size is greater than 10 GB it is recommended to use the Reindex API. Reindexing consists of the following steps:
+
+You can use the https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cat-indices-1[Get index information API] to obtain the size of an index:
+
+[source,console]
+----
+GET _cat/indices/.transform-destination-example?v&h=index,store.size
+----
+
+The reindexing can be initiated in the {kib} Upgrade Assistant.
+
+If an index size is greater than 10 GB, it is recommended to use the Reindex API. Reindexing consists of the following steps:
+
+. Set the original index to read-only.
++
+[source,console]
+----
+PUT .transform-destination-example/_block/read_only
+----
+
+. Create a new index from the legacy index.
++
+[source,console]
+----
+POST _create_from/.transform-destination-example/.reindexed-v9-transform-destination-example
+----
+
+. Reindex documents. To accelerate the reindexing process, it is recommended that the number of replicas be set to `0` before the reindexing and then set back to the original number once it is completed.
+
+.. Get the number of replicas.
++
+[source,console]
+----
+GET /.reindexed-v9-transform-destination-example/_settings
+----
++
+Note the number of replicas in the response. For example:
++
+[source,console]
+----
+{
+  ".reindexed-v9-transform-destination-example": {
+    "settings": {
+      "index": {
+        "number_of_replicas": "1",
+        "number_of_shards": "1"
+      }
+    }
+  }
+}
+----
+
+.. Set the number of replicas to `0.`
++
+[source,console]
+----
+PUT /.reindexed-v9-transform-destination-example/_settings
+{
+  "index": {
+    "number_of_replicas": 0
+  }
+}
+----
+
+.. Start the reindexing process in asynchronous mode.
++
+[source,console]
+----
+POST _reindex?wait_for_completion=false
+{
+  "source": {
+    "index": ".transform-destination-example"
+  },
+  "dest": {
+    "index": ".reindexed-v9-transform-destination-example"
+  }
+}
+----
++
+The response will contain a `task_id`. You can check when the task is completed using the following command:
++
+[source,console]
+----
+GET _tasks/<task_id>
+----
+
+.. Set the number of replicas to the original number when the reindexing is finished.
++
+[source,console]
+----
+PUT /.reindexed-v9-transform-destination-example/_settings
+{
+  "index": {
+    "number_of_replicas": "<original_number_of_replicas>"
+  }
+}
+----
+
+. Get the aliases the original index is pointing to.
++
+[source,console]
+----
+GET .transform-destination-example/_alias
+----
++
+The response may contain multiple aliases if the results of multiple jobs are stored in the same index.
++
+[source,console]
+----
+{
+  ".transform-destination-example": {
+    "aliases": {
+      ".transform-destination-example1": {
+        "filter": {
+          "term": {
+            "job_id": {
+              "value": "example1"
+            }
+          }
+        },
+        "is_hidden": true
+      },
+      ".transform-destination-example2": {
+        "filter": {
+          "term": {
+            "job_id": {
+              "value": "example2"
+            }
+          }
+        },
+        "is_hidden": true
+      }
+    }
+  }
+}
+----
+
+. Now you can reassign the aliases to the new index and delete the original index in one step. Note that when adding the new index to the aliases, you must use the same `filter` and `is_hidden` parameters as for the original index.
++
+[source,console]
+----
+POST _aliases
+{
+  "actions": [
+    {
+      "add": {
+        "index": ".reindexed-v9-transform-destination-example",
+        "alias": ".transform-destination-example1",
+        "filter": {
+          "term": {
+            "job_id": {
+              "value": "example1"
+            }
+          }
+        },
+        "is_hidden": true
+      }
+    },
+    {
+      "add": {
+        "index": ".reindexed-v9-transform-destination-example",
+        "alias": ".transform-destination-example2",
+        "filter": {
+          "term": {
+            "job_id": {
+              "value": "example2"
+            }
+          }
+        },
+        "is_hidden": true
+      }
+    },
+    {
+      "remove": {
+        "index": ".transform-destination-example",
+        "aliases": ".transform-destination-*"
+      }
+    },
+    {
+      "remove_index": {
+        "index": ".transform-destination-example"
+      }
+    },
+    {
+      "add": {
+        "index": ".reindexed-v9-transform-destination-example",
+        "alias": ".transform-destination-example",
+        "is_hidden": true
+      }
+    }
+  ]
+}
+----
+====
+
+.Reindexing the transform’s destination index while the Transform is running
+[%collapsible]
+====
+If you want the Transform and the Reindex task to write documents to the new destination index at the same time:
+
+. Set the original index to read-only.
++
+[source,console]
+----
+POST _create_from/my-destination-index/my-new-destination-index
+----
+
+. Update the Transform to write to the new destination index:
++
+[source,console]
+----
+POST _transform/my-transform/_update
+{
+ "dest": {
+   "index": "my-new-destination-index"
+ }
+}
+----
+
+. Reindex documents. To accelerate the reindexing process, it is recommended that the number of replicas be set to 0 before the reindexing and then set back to the original number once it is completed.
+
+.. Get the number of replicas.
++
+[source,console]
+----
+GET /my-destination-index/_settings
+----
++
+.. Note the number of replicas in the response. For example:
++
+[source,console]
+----
+{
+  "my-destination-index": {
+    "settings": {
+      "index": {
+        "number_of_replicas": "1",
+        "number_of_shards": "1"
+      }
+    }
+  }
+}
+----
+
+.. Set the number of replicas to `0.`
++
+[source,console]
+----
+PUT /my-destination-index/_settings
+{
+  "index": {
+    "number_of_replicas": 0
+  }
+}
+----
+
+.. Start the reindexing process in asynchronous mode. Set the `op_type` to `create` so the reindex does not overwrite work that the Transform is doing.
+
++
+[source,console]
+----
+POST _reindex
+{
+ "conflicts": "proceed",
+ "source": {
+   "index": "my-destination-index"
+ },
+ "dest": {
+   "index": "my-new-destination-index",
+   "op_type": "create"
+ }
+}
+----
++
+The response will contain a `task_id`. You can check when the task is completed using the following command:
++
+[source,console]
+----
+GET _tasks/<task_id>
+----
+
+.. Set the number of replicas to the original number when the reindexing is finished.
++
+[source,console]
+----
+PUT /my-new-destination-index/_settings
+{
+  "index": {
+    "number_of_replicas": "<original_number_of_replicas>"
+  }
+}
+----
+
+.. Get the aliases the original index is pointing to.
++
+[source,console]
+----
+GET my-destination-index/_alias
+
+{
+  "my-destination-index": {
+    "aliases": {
+      "my-destination-alias": {},
+    }
+  }
+}
+----
+
+.. Now you can reassign the aliases to the new index and delete the original index in one step. Note that when adding the new index to the aliases, you must use the same `filter` and `is_hidden` parameters as for the original index.
++
+[source,console]
+----
+POST _aliases
+{
+  "actions": [
+    {
+      "add": {
+        "index": "my-new-destination-index",
+        "alias": "my-destination-alias"
+      }
+    },
+    {
+      "remove": {
+        "index": "my-destination-index",
+        "aliases": "my-destination-alias"
+      }
+    },
+    {
+      "remove_index": {
+        "index": "my-destination-index"
+      }
+    }
+  ]
+}
+----
+====
+
+.Deleting the transform
+[%collapsible]
+====
+You can use the https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-transform-delete-transform[Transform Delete API] to delete the transform and stop it from writing to the destination index.
+
+[source,console]
+----
+DELETE _transform/my-transform
+----
+
+If the destination index is no longer needed, it can be deleted alongside the transform.
+
+[source,console]
+----
+DELETE _transform/my-transform?delete_dest_index
+----
+
+====

--- a/docs/en/install-upgrade/upgrading-stack.asciidoc
+++ b/docs/en/install-upgrade/upgrading-stack.asciidoc
@@ -464,7 +464,7 @@ The {transform} destination indices created in {es} 7.x must be either reset, re
 
 **Reindexing**: You can reindex the destination index and then update the {transform} to write to the new destination index. This is useful if there are results that you want to retain that may not exist in the source index. To prevent the {transform} and reindex tasks from conflicting with one another, you can either pause the {transform} while the reindex runs, or you can write to the new destination index while the reindex backfills old results.
 
-**Deleting**: You can delete any Transforms that are no longer being used. Once the Transform is deleted, you can either delete the destination index or move it into readonly.
+**Deleting**: You can delete any {transform} that are no longer being used. Once the {transform} is deleted, you can either delete the destination index or make it read-only.
 
 .Which indices require attention?
 [%collapsible]

--- a/docs/en/install-upgrade/upgrading-stack.asciidoc
+++ b/docs/en/install-upgrade/upgrading-stack.asciidoc
@@ -460,7 +460,7 @@ endif::[]
 
 The {transform} destination indices created in {es} 7.x must be either reset, reindexed, or deleted before upgrading to 9.x.
 
-**Resetting**: You can reset the Transform to delete all state, checkpoints, and the destination index (if it was created by the Transform). The next time you start the Transform, it will reprocess all data from the source index, creating a new destination index in Elasticsearch 8.x compatible with 9.x. However, if data had been deleted from the source index, you will lose all previously computed results that had been stored in the destination index.
+**Resetting**: You can reset the {transform} to delete all state, checkpoints, and the destination index (if it was created by the {transform}). The next time you start the {transform}, it will reprocess all data from the source index, creating a new destination index in {es} 8.x compatible with 9.x. However, if data had been deleted from the source index, you will lose all previously computed results that had been stored in the destination index.
 
 **Reindexing**: You can reindex the destination index and then update the Transform to write to the new destination index. This is useful if there are results that you want to retain that may not exist in the source index. In order to prevent the Transform and Reindex tasks from conflicting with one another, you can either pause the Transform while the Reindex runs, or you can write to the new destination index while the Reindex backfills old results.
 

--- a/docs/en/install-upgrade/upgrading-stack.asciidoc
+++ b/docs/en/install-upgrade/upgrading-stack.asciidoc
@@ -512,7 +512,7 @@ POST _transform/my-transform/_reset
 ====
 When {kib} Upgrade Assistant reindexes the documents, {kib} will put a write block on the old destination index, copy the results to a new index, delete the old index, and create an alias to the new index. During this time, the {transform} will pause and wait for the destination to become writable again.  If you do not want the {transform} to pause, continue to <<reindexing-transform-running, reindexing the {transform}'s destination index while the {transform} is running>>.
 
-If an index is less than 10GB of size, we recommend using Kibana’s Upgrade Assistant to automatically migrate the index.
+If an index is less than 10GB of size, we recommend using {kib}'s Upgrade Assistant to automatically migrate the index.
 
 If an index size is greater than 10 GB it is recommended to use the Reindex API. Reindexing consists of the following steps:
 

--- a/docs/en/install-upgrade/upgrading-stack.asciidoc
+++ b/docs/en/install-upgrade/upgrading-stack.asciidoc
@@ -462,7 +462,7 @@ The {transform} destination indices created in {es} 7.x must be either reset, re
 
 **Resetting**: You can reset the {transform} to delete all state, checkpoints, and the destination index (if it was created by the {transform}). The next time you start the {transform}, it will reprocess all data from the source index, creating a new destination index in {es} 8.x compatible with 9.x. However, if data had been deleted from the source index, you will lose all previously computed results that had been stored in the destination index.
 
-**Reindexing**: You can reindex the destination index and then update the Transform to write to the new destination index. This is useful if there are results that you want to retain that may not exist in the source index. In order to prevent the Transform and Reindex tasks from conflicting with one another, you can either pause the Transform while the Reindex runs, or you can write to the new destination index while the Reindex backfills old results.
+**Reindexing**: You can reindex the destination index and then update the {transform} to write to the new destination index. This is useful if there are results that you want to retain that may not exist in the source index. To prevent the {transform} and reindex tasks from conflicting with one another, you can either pause the {transform} while the reindex runs, or you can write to the new destination index while the reindex backfills old results.
 
 **Deleting**: You can delete any Transforms that are no longer being used. Once the Transform is deleted, you can either delete the destination index or move it into readonly.
 

--- a/docs/en/install-upgrade/upgrading-stack.asciidoc
+++ b/docs/en/install-upgrade/upgrading-stack.asciidoc
@@ -458,7 +458,7 @@ endif::[]
 [[breaking_90_transform_destination_index]]
 === {transform-cap} destination indices migration
 
-The transform destination indices created in Elasticsearch 7.x must be either reset, reindexed, or deleted before upgrading to 9.x.
+The {transform} destination indices created in {es} 7.x must be either reset, reindexed, or deleted before upgrading to 9.x.
 
 **Resetting**: You can reset the Transform to delete all state, checkpoints, and the destination index (if it was created by the Transform). The next time you start the Transform, it will reprocess all data from the source index, creating a new destination index in Elasticsearch 8.x compatible with 9.x. However, if data had been deleted from the source index, you will lose all previously computed results that had been stored in the destination index.
 

--- a/docs/en/install-upgrade/upgrading-stack.asciidoc
+++ b/docs/en/install-upgrade/upgrading-stack.asciidoc
@@ -507,7 +507,7 @@ POST _transform/my-transform/_reset
 ----
 ====
 
-.Reindexing the transform’s destination index while the Transform is paused
+.Reindexing the {transform}'s destination index while the {transform} is paused
 [%collapsible]
 ====
 When Kibana’s Upgrade Assistant reindexes the documents, Kibana will put a write block on the old destination index, copy the results to a new index, delete the old index, and create an alias to the new index. During the time, the Transform will pause and wait for the destination to become writable again.  If you do not want the Transform to pause, continue to <<reindexing-transform-running, Reindexing the transform’s destination index while the Transform is running>>.

--- a/docs/en/install-upgrade/upgrading-stack.asciidoc
+++ b/docs/en/install-upgrade/upgrading-stack.asciidoc
@@ -710,7 +710,7 @@ POST _aliases
 ====
 
 [[reindexing-transform-running]]
-.Reindexing the transform’s destination index while the Transform is running
+.Reindexing the {transform}'s destination index while the {transform} is running
 [%collapsible]
 ====
 If you want the Transform and the Reindex task to write documents to the new destination index at the same time:

--- a/docs/en/install-upgrade/upgrading-stack.asciidoc
+++ b/docs/en/install-upgrade/upgrading-stack.asciidoc
@@ -456,7 +456,7 @@ endif::[]
 
 [discrete]
 [[breaking_90_transform_destination_index]]
-=== Transform destination indices migration
+=== {transform-cap} destination indices migration
 
 The transform destination indices created in Elasticsearch 7.x must be either reset, reindexed, or deleted before upgrading to 9.x.
 

--- a/docs/en/install-upgrade/upgrading-stack.asciidoc
+++ b/docs/en/install-upgrade/upgrading-stack.asciidoc
@@ -722,7 +722,7 @@ If you want the Transform and the Reindex task to write documents to the new des
 POST _create_from/my-destination-index/my-new-destination-index
 ----
 
-. Update the Transform to write to the new destination index:
+. Update the {transform} to write to the new destination index:
 +
 [source,console]
 ----

--- a/docs/en/install-upgrade/upgrading-stack.asciidoc
+++ b/docs/en/install-upgrade/upgrading-stack.asciidoc
@@ -862,7 +862,7 @@ You can use the https://www.elastic.co/docs/api/doc/elasticsearch/operation/oper
 DELETE _transform/my-transform
 ----
 
-If the destination index is no longer needed, it can be deleted alongside the transform.
+If the destination index is no longer needed, it can be deleted alongside the {transform}.
 
 [source,console]
 ----


### PR DESCRIPTION
This PR adds the 'Transform destination indices migration' section to the [Upgrade to Elastic 9.0.0-beta1](https://www.elastic.co/guide/en/elastic-stack/9.0/upgrading-elastic-stack.html) documentation.

Related issue: https://github.com/elastic/search-docs-team/issues/253