### PR TITLE
Doc: Logstash release notes for -rc1

### DIFF
--- a/docs/en/install-upgrade/release-notes/release-notes-logstash-rc1.asciidoc
+++ b/docs/en/install-upgrade/release-notes/release-notes-logstash-rc1.asciidoc
@@ -1,3 +1,18 @@
 = {ls} version 9.0.0-rc1
 
 coming::[9.0.0-rc1]
+
+[[logstash-900-rc1-features-enhancements]]
+== Features and enhancements 
+
+* Use UBI9 as base image https://github.com/elastic/logstash/pull/17174[#17174]
+* Improve plugins remove command to support multiple plugins https://github.com/elastic/logstash/pull/17030[#17030]
+* Allow concurrent Batch deserialization https://github.com/elastic/logstash/pull/17050[#17050]
+* Upgrade filter-xml and its nokogori dependency https://github.com/elastic/logstash/pull/17130[#17130]
+* Update rack dependency to 3.1.11 https://github.com/elastic/logstash/pull/17230[#17230]
+
+[[logstash-900-rc1-fixes]]
+== Fixes 
+
+* Fix pqcheck and pqrepair on Windows https://github.com/elastic/logstash/pull/17210[#17210]
+* Fix empty node stats pipelines https://github.com/elastic/logstash/pull/17185[#17185]

--- a/docs/en/install-upgrade/release-notes/release-notes-logstash-rc1.asciidoc
+++ b/docs/en/install-upgrade/release-notes/release-notes-logstash-rc1.asciidoc
@@ -10,6 +10,7 @@ coming::[9.0.0-rc1]
 * Allow concurrent Batch deserialization https://github.com/elastic/logstash/pull/17050[#17050]
 * Upgrade filter-xml and its nokogori dependency https://github.com/elastic/logstash/pull/17130[#17130]
 * Update rack dependency to 3.1.11 https://github.com/elastic/logstash/pull/17230[#17230]
+* Upgrade elasticsearch-ruby client to v8 https://github.com/elastic/logstash/pull/17161[#17161]
 
 [[logstash-900-rc1-fixes]]
 == Fixes 


### PR DESCRIPTION
Replaces: https://github.com/elastic/logstash/pull/17296.
Pre-9.0.0 release notes are published in ADOC. 