### PR TITLE
Harmonize ELSER model ID

### DIFF
--- a/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
+++ b/docs/en/stack/ml/nlp/ml-nlp-elser.asciidoc
@@ -120,7 +120,7 @@ The easiest and recommended way to download and deploy ELSER is to use the {ref}
 --
 [source,console]
 ----------------------------------
-PUT _inference/sparse_embedding/my-elser-model
+PUT _inference/sparse_embedding/.elser_model_2
 {
   "service": "elser",
   "service_settings": {


### PR DESCRIPTION
This PR updates the ELSER – **Elastic Learned Sparse EncodeR** documentation to use a consistent model ID to match the [Tutorial: semantic search with ELSER](https://www.elastic.co/guide/en/elasticsearch/reference/8.17/infer-service-elser.html) page.

Related issue: https://github.com/elastic/search-docs-team/issues/258

Raised in this [Slack thread](https://elastic.slack.com/archives/C0JF80CJZ/p1739305599411689)

