### PR TITLE
[9.0] Amends the anomaly detection upgrade instructions

### DIFF
--- a/docs/en/install-upgrade/upgrading-stack.asciidoc
+++ b/docs/en/install-upgrade/upgrading-stack.asciidoc
@@ -227,13 +227,14 @@ Note the number of replicas in the response. For example:
 }
 ----
 
-.. Set the number of replicas to `0.`
+.. Set the number of replicas to `0`. You must also set the `auto_expand_replicas` parameter to `false` to change the number of replicas:
 +
 [source,console]
 ----
 PUT /.reindexed-v9-ml-anomalies-custom-example/_settings
 {
   "index": {
+    "auto_expand_replicas": false,
     "number_of_replicas": 0
   }
 }
@@ -261,14 +262,15 @@ The response will contain a `task_id`. You can check when the task is completed 
 GET _tasks/<task_id>
 ----
 
-.. Set the number of replicas to the original number when the reindexing is finished.
+.. Set the number of replicas to the original number when the reindexing is finished. Optionally, you can set the `auto_expand_replicas` parameter back to its default value (`0-1`) to allow the number of replicas to be automatically adjusted based on the number of data nodes in the cluster.
 +
 [source,console]
 ----
 PUT /.reindexed-v9-ml-anomalies-custom-example/_settings
 {
   "index": {
-    "number_of_replicas": "<original_number_of_replicas>"
+    "number_of_replicas": "<original_number_of_replicas>",
+    "auto_expand_replicas": "0-1"
   }
 }
 ----


### PR DESCRIPTION
## Overview

Related to https://github.com/elastic/search-docs-team/issues/268

This PR updates the PUT settings request in the AD upgrade guide to set the `auto_expand_replicas` parameter to `false`.