### PR TITLE
[DOCS] Add Elasticsearch 9.0 rc1 release notes

### DIFF
--- a/docs/en/install-upgrade/release-notes/release-notes-elasticsearch-beta1.asciidoc
+++ b/docs/en/install-upgrade/release-notes/release-notes-elasticsearch-beta1.asciidoc
@@ -1,7 +1,7 @@
 = {es} version 9.0.0-beta1
 
 [discrete]
-[[breaking-changes-9.0]]
+[[breaking-changes-9.0-beta1]]
 == Breaking changes
 
 The following changes in {es} 9.0 might affect your applications
@@ -582,7 +582,7 @@ Watcher::
 * Removing support for types field in watcher search {es-pull}120748[#120748]
 
 [discrete]
-[[deprecated-9.0]]
+[[deprecated-9.0-beta1]]
 == Deprecations
 
 The following functionality has been deprecated in {es} 9.0

--- a/docs/en/install-upgrade/release-notes/release-notes-elasticsearch-rc1.asciidoc
+++ b/docs/en/install-upgrade/release-notes/release-notes-elasticsearch-rc1.asciidoc
@@ -1,3 +1,229 @@
 = {es} version 9.0.0-rc1
 
-coming::[9.0.0-rc1]
+[[breaking-9.0.0-rc1]]
+[float]
+=== Breaking changes
+
+The following changes in {es} 9.0 might affect your applications
+and prevent them from operating normally.
+Before upgrading to 9.0, review these changes and take the described steps
+to mitigate the impact.
+Also check out <<breaking-changes-9.0-beta1,{es} version 9.0.0-beta1 breaking changes>>.
+
+[discrete]
+[[breaking_90_cluster_and_node_setting_changes-rc1]]
+==== Cluster and node setting changes
+
+[[drop_tls_rsa_cipher_support_for_jdk_24]]
+.Drop `TLS_RSA` cipher support for JDK 24
+[%collapsible]
+====
+*Details* +
+This change removes `TLS_RSA` ciphers from the list of default supported ciphers, for Elasticsearch deployments running on JDK 24.
+
+*Impact* +
+The dropped ciphers are `TLS_RSA_WITH_AES_256_GCM_SHA384`, `TLS_RSA_WITH_AES_128_GCM_SHA256`, `TLS_RSA_WITH_AES_256_CBC_SHA256`, `TLS_RSA_WITH_AES_128_CBC_SHA256`, `TLS_RSA_WITH_AES_256_CBC_SHA`, and `TLS_RSA_WITH_AES_128_CBC_SHA`. TLS connections to Elasticsearch using these ciphers will no longer work. Please configure your clients to use one of supported cipher suites.
+====
+
+// TLS::
+// * Drop `TLS_RSA` cipher support for JDK 24 {es-pull}123600[#123600]
+
+[discrete]
+[[deprecated-9.0-rc1]]
+=== Deprecations
+
+The following functionality has been deprecated in {es} 9.0
+and will be removed in a future version.
+Also check out <<deprecated-9.0-beta1,{es} version 9.0.0-beta1 deprecations>>.
+
+While this won't have an immediate impact on your applications,
+we strongly encourage you to take the described steps to update your code
+after upgrading to 9.0.
+
+To find out if you are using any deprecated functionality,
+enable {ref}/logging.html#deprecation-logging[deprecation logging].
+
+[discrete]
+[[deprecations_90_rest_api-rc1]]
+==== REST API deprecations
+
+[[add_deprecation_warning_for_flush_api]]
+.Add deprecation warning for flush API
+[%collapsible]
+====
+*Details* +
+The anomaly detection job flush API is deprecated since it is only required for the post data API, which was deprecated since 7.11.0.
+
+*Impact* +
+This should have a minimal impact on users as the flush API is only required for the post data API, which was deprecated since 7.11.0.
+====
+
+// Machine Learning::
+// * Add deprecation warning for flush API {es-pull}121667[#121667] (issue: {es-issue}121506[#121506])
+
+[discrete]
+[[deprecations_90_search-rc1]]
+==== Search deprecations
+
+[[deprecate_behavioral_analytics_crud_apis]]
+.Deprecate Behavioral Analytics CRUD apis
+[%collapsible]
+====
+*Details* +
+Behavioral Analytics has been deprecated as of 9.0.0 and will be removed in a future release. The APIs will still work for now, but will emit warning headers that the API has been deprecated.
+
+*Impact* +
+Behavioral Analytics has been deprecated as of 9.0.0 and will be removed in a future release.
+====
+
+// Search::
+// * Deprecate Behavioral Analytics CRUD apis {es-pull}122960[#122960]
+
+[[bug-9.0.0-rc1]]
+[float]
+=== Bug fixes
+
+Analysis::
+* Adjust exception thrown when unable to load hunspell dict {es-pull}123743[#123743]
+
+Data streams::
+* Updating `TransportRolloverAction.checkBlock` so that non-write-index blocks do not prevent data stream rollover {es-pull}122905[#122905]
+
+Downsampling::
+* Improve downsample performance by avoiding to read unnecessary dimension values when downsampling. {es-pull}124451[#124451]
+
+ES|QL::
+* Add support to VALUES aggregation for spatial types {es-pull}122886[#122886] (issue: {es-issue}122413[#122413])
+* Avoid over collecting in Limit or Lucene Operator {es-pull}123296[#123296]
+* Change the order of the optimization rules {es-pull}124335[#124335]
+* ESQL: Remove estimated row size assertion {es-pull}122762[#122762] (issue: {es-issue}121535[#121535])
+* ES|QL: Fix scoring for full text functions {es-pull}124540[#124540]
+* Fix early termination in `LuceneSourceOperator` {es-pull}123197[#123197]
+* Fix function registry concurrency issues on constructor {es-pull}123492[#123492] (issue: {es-issue}123430[#123430])
+* Implicit numeric casting for CASE/GREATEST/LEAST {es-pull}122601[#122601] (issue: {es-issue}121890[#121890])
+* Lazy collection copying during node transform {es-pull}124424[#124424]
+* Reduce iteration complexity for plan traversal {es-pull}123427[#123427]
+* Revive inlinestats {es-pull}122257[#122257]
+* Revive some more of inlinestats functionality {es-pull}123589[#123589]
+* Use a must boolean statement when pushing down to Lucene when scoring is also needed {es-pull}124001[#124001] (issue: {es-issue}123967[#123967])
+
+Engine::
+* Hold store reference in `InternalEngine#performActionWithDirectoryReader(...)` {es-pull}123010[#123010] (issue: {es-issue}122974[#122974])
+
+Highlighting::
+* Restore V8 REST compatibility around highlight `force_source` parameter {es-pull}124873[#124873]
+
+Indices APIs::
+* Avoid hoarding cluster state references during rollover {es-pull}124107[#124107] (issue: {es-issue}123893[#123893])
+* Updates the deprecation info API to not warn about system indices and data streams {es-pull}122951[#122951]
+
+Infra/Core::
+* Fix system data streams to be restorable from a snapshot {es-pull}124651[#124651] (issue: {es-issue}89261[#89261])
+* Have create index return a bad request on poor formatting {es-pull}123761[#123761]
+* Include data streams when converting an existing resource to a system resource {es-pull}121392[#121392]
+* Prevent rare starvation bug when using scaling `EsThreadPoolExecutor` with empty core pool size. {es-pull}124732[#124732] (issue: {es-issue}124667[#124667])
+* System Index Migration Failure Results in a Non-Recoverable State {es-pull}122326[#122326]
+* System data streams are not being upgraded in the feature migration API {es-pull}124884[#124884] (issue: {es-issue}122949[#122949])
+
+Ingest Node::
+* Fix geoip databases index access after system feature migration (again) {es-pull}122938[#122938]
+* Fix geoip databases index access after system feature migration (take 3) {es-pull}124604[#124604]
+
+Machine Learning::
+* Add `ElasticInferenceServiceCompletionServiceSettings` {es-pull}123155[#123155]
+* Add enterprise license check to inference action for semantic text fields {es-pull}122293[#122293]
+* Avoid potentially throwing calls to Task#getDescription in model download {es-pull}124527[#124527]
+* Fix serialising the inference update request {es-pull}122278[#122278]
+* Migrate `model_version` to `model_id` when parsing persistent elser inference endpoints {es-pull}124769[#124769] (issue: {es-issue}124675[#124675])
+* Retry on streaming errors {es-pull}123076[#123076]
+* Set Connect Timeout to 5s {es-pull}123272[#123272]
+* [Inference API] Fix output stream ordering in `InferenceActionProxy` {es-pull}124225[#124225]
+
+Mapping::
+* Avoid serializing empty `_source` fields in mappings {es-pull}122606[#122606]
+* Merge template mappings properly during validation {es-pull}124784[#124784] (issue: {es-issue}123372[#123372])
+
+Ranking::
+* Fix LTR query feature with phrases (and two-phase) queries {es-pull}125103[#125103]
+
+Search::
+* Do not let `ShardBulkInferenceActionFilter` unwrap / rewrap ESExceptions {es-pull}123890[#123890]
+* Don't generate stacktrace in `TaskCancelledException` {es-pull}125002[#125002]
+* Fix concurrency issue in `ScriptSortBuilder` {es-pull}123757[#123757]
+* Handle search timeout in `SuggestPhase` {es-pull}122357[#122357] (issue: {es-issue}122186[#122186])
+* Let MLTQuery throw IAE when no analyzer is set {es-pull}124662[#124662] (issue: {es-issue}124562[#124562])
+
+Snapshot/Restore::
+* Fork post-snapshot-delete cleanup off master thread {es-pull}122731[#122731]
+* This PR fixes a bug whereby partial snapshots of system datastreams could be used to restore system features. {es-pull}124931[#124931]
+
+Suggesters::
+* Return an empty suggestion when suggest phase times out {es-pull}122575[#122575] (issue: {es-issue}122548[#122548])
+
+Transform::
+* If the Transform is configured to write to an alias as its destination index, when the delete_dest_index parameter is set to true, then the Delete API will now delete the write index backing the alias {es-pull}122074[#122074] (issue: {es-issue}121913[#121913])
+
+Vector Search::
+* Knn vector rescoring to sort score docs {es-pull}122653[#122653] (issue: {es-issue}119711[#119711])
+
+[[enhancement-9.0.0-rc1]]
+[float]
+=== Enhancements
+
+Authorization::
+* Do not fetch reserved roles from native store when Get Role API is called {es-pull}121971[#121971]
+
+Data streams::
+* Retry ILM async action after reindexing data stream {es-pull}124149[#124149]
+* Set cause on create index request in create from action {es-pull}124363[#124363]
+
+Downsampling::
+* Improve downsample performance by buffering docids and do bulk processing {es-pull}124477[#124477]
+* Improve rolling up metrics {es-pull}124739[#124739]
+
+ES|QL::
+* Allow skip shards with `_tier` and `_index` in ES|QL {es-pull}123728[#123728]
+* ES|QL - Add scoring for full text functions disjunctions {es-pull}121793[#121793]
+* Fix Driver status iterations and `cpuTime` {es-pull}123290[#123290] (issue: {es-issue}122967[#122967])
+* Push down `StartsWith` and `EndsWith` functions to Lucene {es-pull}123381[#123381] (issue: {es-issue}123067[#123067])
+* Reuse child `outputSet` inside the plan where possible {es-pull}124611[#124611]
+
+Infra/CLI::
+* Ignore _JAVA_OPTIONS {es-pull}124843[#124843]
+
+Infra/Core::
+* Improve size limiting string message {es-pull}122427[#122427]
+
+Infra/REST API::
+* Indicate when errors represent timeouts {es-pull}124936[#124936]
+
+Ingest Node::
+* Allow setting the `type` in the reroute processor {es-pull}122409[#122409] (issue: {es-issue}121553[#121553])
+
+[[feature-9.0.0-rc1]]
+[float]
+=== New features
+
+ES|QL::
+* Initial support for unmapped fields {es-pull}119886[#119886]
+
+Search::
+* Added optional parameters to QSTR ES|QL function {es-pull}121787[#121787] (issue: {es-issue}120933[#120933])
+
+[[upgrade-9.0.0-rc1]]
+[float]
+=== Upgrades
+
+Infra/Core::
+* Permanently switch from Java SecurityManager to Entitlements. The Java SecurityManager has been deprecated since Java 17, and it is now completely disabled in Java 24. In order to retain an similar level of protection, Elasticsearch implemented its own protection mechanism, Entitlements. Starting with this version, Entitlements will permanently replace the Java SecurityManager. {es-pull}124865[#124865]
+
+Packaging::
+* Update bundled JDK to Java 24 {es-pull}125159[#125159]
+
+Security::
+* Bump nimbus-jose-jwt to 10.0.2 {es-pull}124544[#124544]
+
+Snapshot/Restore::
+* Upgrade AWS SDK to v1.12.746 {es-pull}122431[#122431]
+
+


### PR DESCRIPTION
This PR copies the RC1 release notes from https://github.com/elastic/elasticsearch/pull/125444 and edits some links to make them work in the context of the Installation and Upgrade Guide.