### PR TITLE
[DOCS] Beats 9.0 rc1 release notes

### DIFF
--- a/docs/en/install-upgrade/release-notes/release-notes-beats-rc1.asciidoc
+++ b/docs/en/install-upgrade/release-notes/release-notes-beats-rc1.asciidoc
@@ -2,6 +2,55 @@
 // each other on Github, so don't worry too much on using the right prefix.
 :issue: https://github.com/elastic/beats/issues/
 :pull: https://github.com/elastic/beats/pull/
-= Beats version 9.0.0-rc1
 
-coming::[9.0.0-rc1]
+[[release-notes-9.0.0-rc1]]
+=== Beats version 9.0.0-rc1
+https://github.com/elastic/beats/compare/v9.0.0-beta1\...v9.0.0-rc1[View commits]
+
+==== Breaking changes
+
+*Affecting all Beats*
+
+- The Beats logger and file output rotate files when necessary. The beat now forces a file rotation when unexpectedly writing to a file through a symbolic link.
+
+*Metricbeat*
+
+- Remove kibana.settings metricset since the API was removed in 8.0. {issue}30592[30592] {pull}42937[42937]
+- Removed support for the Enterprise Search module. {pull}42915[42915]
+
+==== Bugfixes
+
+*Filebeat*
+
+- Fixed race conditions in the global ratelimit processor that could drop events or apply rate limiting incorrectly. {pull}42966[42966]
+- Prevent computer details being returned for user queries by Activedirectory Entity Analytics provider. {issue}11818[11818] {pull}42796[42796]
+- Handle unexpectedEOF error in aws-s3 input and enforce retrying using download failed error. {pull}42420[42756]
+- Prevent azureblobstorage input from logging key details during blob fetch operations. {pull}43169[43169]
+
+*Metricbeat*
+
+- Add AWS OwningAccount support for cross account monitoring. {issue}40570[40570] {pull}40691[40691]
+- Fix logging argument number mismatch in Metricbeat(Redis). {pull}43072[43072]
+
+*Winlogbeat*
+
+- Reset EventLog if error EOF is encountered. {pull}42826[42826]
+- Implement backoff on error retrial. {pull}42826[42826]
+- Fix boolean key in security pipelines and sync pipelines with integration. {pull}43027[43027]
+
+==== Added
+
+*Affecting all Beats*
+
+- Update Go version to 1.24.0. {pull}42705[42705]
+
+*Filebeat*
+
+- Add `etw` input fallback to attach an already existing session. {pull}42847[42847]
+- Update CEL mito extensions to v1.17.0. {pull}42851[42851]
+- Winlog input now can report its status to Elastic-Agent. {pull}43089[43089]
+- Add configuration option to limit HTTP Endpoint body size. {pull}43171[43171]
+
+*Metricbeat*
+
+- Add a new `match_by_parent_instance` option to `perfmon` module. {pull}43002[43002]

--- a/docs/en/install-upgrade/release-notes/release-notes-beats.asciidoc
+++ b/docs/en/install-upgrade/release-notes/release-notes-beats.asciidoc
@@ -9,5 +9,5 @@
 <titleabbrev>Beats</titleabbrev>
 ++++
 
-include::release-notes-beats-rc1.asciidoc[leveloffset=+1]
+include::release-notes-beats-rc1.asciidoc[leveloffset=-1]
 include::release-notes-beats-beta1.asciidoc[leveloffset=+1]


### PR DESCRIPTION
This PR copies the contents of the Beats 9.0 rc1 release notes from https://github.com/elastic/beats/pull/43419 into the appropriate section of the Installation and Upgrade Guide, which is temporarily used as a stop-gap for 9.0 release notes.