### PR TITLE
[DOCS] Remove 9.0 coming tags

### DIFF
--- a/docs/en/install-upgrade/release-notes/release-notes-fleet-agent-rc1.asciidoc
+++ b/docs/en/install-upgrade/release-notes/release-notes-fleet-agent-rc1.asciidoc
@@ -14,8 +14,6 @@
 [[release-notes-fleet-agent-9.0.0-rc1]]
 == {fleet} and {agent} 9.0.0-rc1
 
-coming::[9.0.0-rc1]
-
 [discrete]
 [[security-updates-fleet-agent-9.0.0-rc1]]
 === Security updates

--- a/docs/en/install-upgrade/release-notes/release-notes-logstash-rc1.asciidoc
+++ b/docs/en/install-upgrade/release-notes/release-notes-logstash-rc1.asciidoc
@@ -1,7 +1,5 @@
 = {ls} version 9.0.0-rc1
 
-coming::[9.0.0-rc1]
-
 == Breaking changes
 
 [[pipeline-buffer-type]]

--- a/docs/en/install-upgrade/release-notes/release-notes-security-rc1.asciidoc
+++ b/docs/en/install-upgrade/release-notes/release-notes-security-rc1.asciidoc
@@ -1,7 +1,5 @@
 = {elastic-sec} version 9.0.0-rc1
 
-coming::[9.0.0-rc1]
-
 NOTE: All features introduced in 8.18.0 are also available in 9.0.0.
 
 [discrete]


### PR DESCRIPTION
This PR removes the "coming" tags from the 9.0 RC1 release notes