### PR TITLE
Fixes redundancy in the Transforms migration section

### DIFF
--- a/docs/en/install-upgrade/upgrading-stack.asciidoc
+++ b/docs/en/install-upgrade/upgrading-stack.asciidoc
@@ -526,7 +526,7 @@ You can use the https://www.elastic.co/docs/api/doc/elasticsearch/operation/oper
 GET _cat/indices/.transform-destination-example?v&h=index,store.size
 ----
 
-If an index size is greater than 10 GB, it is recommended to use the Reindex API. Reindexing consists of the following steps:
+If an index size is greater than 10 GB, we recommend using the Reindex API. Reindexing consists of the following steps:
 
 . Set the original index to read-only.
 +

--- a/docs/en/install-upgrade/upgrading-stack.asciidoc
+++ b/docs/en/install-upgrade/upgrading-stack.asciidoc
@@ -517,7 +517,7 @@ POST _transform/my-transform/_reset
 ====
 When {kib} Upgrade Assistant reindexes the documents, {kib} will put a write block on the old destination index, copy the results to a new index, delete the old index, and create an alias to the new index. During this time, the {transform} will pause and wait for the destination to become writable again.  If you do not want the {transform} to pause, continue to <<reindexing-transform-running, reindexing the {transform}'s destination index while the {transform} is running>>.
 
-If an index is less than 10GB of size, we recommend using {kib}'s Upgrade Assistant to automatically migrate the index.
+If an index size is less than 10 GB, we recommend using {kib}'s Upgrade Assistant to automatically migrate the index.
 
 You can use the https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cat-indices-1[Get index information API] to obtain the size of an index:
 

--- a/docs/en/install-upgrade/upgrading-stack.asciidoc
+++ b/docs/en/install-upgrade/upgrading-stack.asciidoc
@@ -519,16 +519,12 @@ When {kib} Upgrade Assistant reindexes the documents, {kib} will put a write blo
 
 If an index is less than 10GB of size, we recommend using {kib}'s Upgrade Assistant to automatically migrate the index.
 
-If an index size is greater than 10 GB it is recommended to use the Reindex API. Reindexing consists of the following steps:
-
 You can use the https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-cat-indices-1[Get index information API] to obtain the size of an index:
 
 [source,console]
 ----
 GET _cat/indices/.transform-destination-example?v&h=index,store.size
 ----
-
-The reindexing can be initiated in the {kib} Upgrade Assistant.
 
 If an index size is greater than 10 GB, it is recommended to use the Reindex API. Reindexing consists of the following steps:
 


### PR DESCRIPTION
This PR removes redundant sentences from the Transforms destination indices section.